### PR TITLE
Changes to qpmodel statistics that allow serialization and deserialization

### DIFF
--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -40,6 +40,7 @@ using qpmodel.optimizer;
 using qpmodel.test;
 using qpmodel.expr;
 using qpmodel.dml;
+using qpmodel;
 
 using psql;
 
@@ -239,9 +240,14 @@ namespace test
 
         void TestTpcds_LoadData()
         {
+            //string curdir = Directory.GetCurrentDirectory();
+            //string file = $@"{curdir}\..\..\..\tpcds\data\stats\dump";
             Tpcds.CreateTables();
             Tpcds.LoadTables("tiny");
             Tpcds.AnalyzeTables();
+            //seriaize_and_write(file);
+            //Catalog.sysstat_.read_serialized_stats(file);
+
         }
 
         void TestTpcds()


### PR DESCRIPTION
This MR may not be quite ready to merge. It contains code for  serialization and deserialization of  statistics data. I hard-coded  read_stats and write_stats calls in the tpcds unit test to make sure that the changes to the stats code works. So, it is now possible to run Tpcds.AnalyzeTables() every time, or serialize and write the  stats data and read it back in instead of calling the analyze  function. 

I left commented out function calls for the methods in test_tpcds because I was not sure what form you might  want the UnitTests to take. 

+++++++++++++++++++++++++++++++++

This changeset implements:

    1. wrapper fucntions to allow access of stats information through
       "table name" and "column name" while using a "tabcol" value
       internally that is a concatination of table name + column name.

   2.  methods that serialize and deserialize the sysstats_ table in
       class Catalog.