### PR TITLE
Regression Test to Compare 1G Stat Plan to Expected 1G Stat Plan

### DIFF
--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -230,11 +230,19 @@ namespace qpmodel.unittest
             TestTpchPlanOnly();
             TestTpch();
 
+            string[] dir_names = {
+                "tpch0001",
+                "tpch1"
+            };
+
             string sql_dir_fn =    "../../../test/regress/sql";
-            string write_dir_fn =  "../../../test/regress/output/tpch0001";
-            string expect_dir_fn = "../../../test/regress/expect/tpch0001";
+
             ExplainOption.show_tablename_ = false;
-            RunFolderAndVerify(sql_dir_fn, write_dir_fn, expect_dir_fn);
+            foreach (string name in dir_names) {
+                string write_dir_fn = $@"../../../test/regress/output/{name}";
+                string expect_dir_fn = $@"../../../test/regress/expect/{name}";
+                RunFolderAndVerify(sql_dir_fn, write_dir_fn, expect_dir_fn);
+            }
             ExplainOption.show_tablename_ = true;
         }
 

--- a/test/regress/expect/tpch1/q01.txt
+++ b/test/regress/expect/tpch1/q01.txt
@@ -1,0 +1,37 @@
+select
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) as sum_qty,
+	sum(l_extendedprice) as sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+	avg(l_quantity) as avg_qty,
+	avg(l_extendedprice) as avg_price,
+	avg(l_discount) as avg_disc,
+	count(*) as count_order
+from
+	lineitem
+where
+	l_shipdate <= date '1998-12-01' - interval '90' day
+group by
+	l_returnflag,
+	l_linestatus
+order by
+	l_returnflag,
+	l_linestatus
+Total cost: 11912.35
+PhysicOrder  (inccost=11912.35, cost=11.35, rows=6) (actual rows=4)
+    Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
+    Order by: l_returnflag[0], l_linestatus[1]
+    -> PhysicHashAgg  (inccost=11901, cost=5896, rows=6) (actual rows=4)
+        Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
+        Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*1-l_discount[7]), sum(l_extendedprice[3]*1-l_discount[7]*1+l_tax[10]), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
+        Group by: l_returnflag[0], l_linestatus[1]
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5884) (actual rows=5914)
+            Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
+            Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
+A,F,37474,37569624.64,35676192.097,37101416.222424,25.3918277382163,25457.011449644,0.050008477449983,1478
+N,F,1041,1041301.07,999060.898,1036450.80228,25.3918277382163,25457.011449644,0.050008477449983,38
+N,O,75168,75384955.3699997,71653166.3034002,74498798.1330728,25.3918277382163,25457.011449644,0.050008477449983,2941
+R,F,36511,36570841.24,34738472.8758,36169060.1121929,25.3918277382163,25457.011449644,0.050008477449983,1457
+

--- a/test/regress/expect/tpch1/q02.txt
+++ b/test/regress/expect/tpch1/q02.txt
@@ -1,0 +1,104 @@
+select
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+from
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+where
+	p_partkey = ps_partkey
+	and s_suppkey = ps_suppkey
+	and p_size = 15
+	and p_type like '%BRASS'
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'EUROPE'
+	and ps_supplycost = (
+		select
+			min(ps_supplycost)
+		from
+			partsupp,
+			supplier,
+			nation,
+			region
+		where
+			p_partkey = ps_partkey
+			and s_suppkey = ps_suppkey
+			and s_nationkey = n_nationkey
+			and n_regionkey = r_regionkey
+			and r_name = 'EUROPE'
+	)
+order by
+	s_acctbal desc,
+	n_name,
+	s_name,
+	p_partkey
+limit 100
+Total cost: 7610.58
+PhysicLimit (100) (inccost=7610.58, cost=100, rows=100) (actual rows=0)
+    Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
+    -> PhysicOrder  (inccost=7510.58, cost=1.58, rows=2) (actual rows=0)
+        Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
+        Order by: s_acctbal[0], n_name[2], s_name[1], p_partkey[3]
+        -> PhysicFilter  (inccost=7509, cost=2, rows=2) (actual rows=0)
+            Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
+            Filter: ps_supplycost[8]={min(ps_supplycost)}[9]
+            -> PhysicHashJoin Left (inccost=7507, cost=206, rows=2) (actual rows=0)
+                Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
+                Filter: p_partkey[3]=ps_partkey[10]
+                -> PhysicHashJoin  (inccost=4394, cost=448, rows=2) (actual rows=0)
+                    Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
+                    Filter: p_partkey[0]=ps_partkey[9]
+                    -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                        Output: p_partkey[0],p_mfgr[2]
+                        Filter: p_size[5]=15 and p_type[4]like'%BRASS'
+                    -> PhysicHashJoin  (inccost=3746, cost=1254, rows=444) (actual rows=0)
+                        Output: s_acctbal[2],s_name[3],n_name[0],s_address[4],s_phone[5],s_comment[6],ps_supplycost[7],ps_partkey[8]
+                        Filter: s_nationkey[9]=n_nationkey[1]
+                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5) (actual rows=0)
+                            Output: n_name[1],n_nationkey[2]
+                            Filter: n_regionkey[3]=r_regionkey[0]
+                            -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                                Output: r_regionkey[0]
+                                Filter: r_name[1]='EUROPE'
+                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                                Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                        -> PhysicHashJoin  (inccost=2430, cost=1620, rows=800) (actual rows=0)
+                            Output: s_acctbal[0],s_name[1],s_address[2],s_phone[3],s_comment[4],ps_supplycost[7],ps_partkey[8],s_nationkey[5]
+                            Filter: s_suppkey[6]=ps_suppkey[9]
+                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
+                            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                                Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
+                -> PhysicHashAgg  (inccost=2907, cost=800, rows=200) (actual rows=0)
+                    Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
+                    Aggregates: min(ps_supplycost[1])
+                    Group by: ps_partkey[0]
+                    -> PhysicHashJoin  (inccost=2107, cost=1210, rows=400) (actual rows=0)
+                        Output: ps_partkey[1],ps_supplycost[2]
+                        Filter: s_suppkey[0]=ps_suppkey[3]
+                        -> PhysicHashJoin  (inccost=97, cost=25, rows=5) (actual rows=0)
+                            Output: s_suppkey[1]
+                            Filter: s_nationkey[2]=n_nationkey[0]
+                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5) (actual rows=0)
+                                Output: n_nationkey[1]
+                                Filter: n_regionkey[2]=r_regionkey[0]
+                                -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=0)
+                                    Output: r_regionkey[0]
+                                    Filter: r_name[1]='EUROPE'
+                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                                    Output: n_nationkey[0],n_regionkey[2]
+                            -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                                Output: s_suppkey[0],s_nationkey[3]
+                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                            Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
+
+

--- a/test/regress/expect/tpch1/q03.txt
+++ b/test/regress/expect/tpch1/q03.txt
@@ -1,0 +1,57 @@
+select
+	l_orderkey,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	o_orderdate,
+	o_shippriority
+from
+	customer,
+	orders,
+	lineitem
+where
+	c_mktsegment = 'BUILDING'
+	and c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate < date '1995-03-15'
+	and l_shipdate > date '1995-03-15'
+group by
+	l_orderkey,
+	o_orderdate,
+	o_shippriority
+order by
+	revenue desc,
+	o_orderdate
+limit 10
+Total cost: 20328.13
+PhysicLimit (10) (inccost=20328.13, cost=10, rows=10) (actual rows=8)
+    Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
+    -> PhysicOrder  (inccost=20318.13, cost=2859.13, rows=459) (actual rows=8)
+        Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
+        Order by: {sum(l_extendedprice*1-l_discount)}[1], o_orderdate[2]
+        -> PhysicHashAgg  (inccost=17459, cost=1377, rows=459) (actual rows=8)
+            Output: {l_orderkey}[0],{sum(l_extendedprice*1-l_discount)}[3],{o_orderdate}[1],{o_shippriority}[2]
+            Aggregates: sum(l_extendedprice[4]*1-l_discount[7])
+            Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
+            -> PhysicHashJoin  (inccost=16082, cost=2101, rows=459) (actual rows=14)
+                Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
+                Filter: c_custkey[1]=o_custkey[9]
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=29)
+                    Output: 1,c_custkey[0]
+                    Filter: c_mktsegment[6]='BUILDING'
+                -> PhysicHashJoin  (inccost=13831, cost=6326, rows=1584) (actual rows=133)
+                    Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],l_discount[8],o_custkey[2]
+                    Filter: l_orderkey[4]=o_orderkey[3]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=720) (actual rows=726)
+                        Output: o_orderdate[4],o_shippriority[7],o_custkey[1],o_orderkey[0]
+                        Filter: o_orderdate[4]<'1995-03-15'
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3302) (actual rows=3252)
+                        Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
+                        Filter: l_shipdate[10]>'1995-03-15'
+1637,164224.9253,2/8/1995 12:00:00 AM,0
+5191,49378.3094,12/11/1994 12:00:00 AM,0
+742,43728.048,12/23/1994 12:00:00 AM,0
+3492,43716.0724,11/24/1994 12:00:00 AM,0
+2883,36666.9612,1/23/1995 12:00:00 AM,0
+998,11785.5486,11/26/1994 12:00:00 AM,0
+3430,4726.6775,12/12/1994 12:00:00 AM,0
+4423,3055.9365,2/17/1995 12:00:00 AM,0
+

--- a/test/regress/expect/tpch1/q04.txt
+++ b/test/regress/expect/tpch1/q04.txt
@@ -1,0 +1,47 @@
+select
+	o_orderpriority,
+	count(*) as order_count
+from
+	orders
+where
+	o_orderdate >= date '1993-07-01'
+	and o_orderdate < date '1993-07-01' + interval '3' month
+	and exists (
+		select
+			*
+		from
+			lineitem
+		where
+			l_orderkey = o_orderkey
+			and l_commitdate < l_receiptdate
+	)
+group by
+	o_orderpriority
+order by
+	o_orderpriority
+Total cost: 1811425.54
+PhysicOrder  (inccost=1811425.54, cost=8.54, rows=5) (actual rows=5)
+    Output: o_orderpriority[0],{count(*)(0)}[1]
+    Order by: o_orderpriority[0]
+    -> PhysicHashAgg  (inccost=1811417, cost=1211, rows=5) (actual rows=5)
+        Output: {o_orderpriority}[0],{count(*)(0)}[1]
+        Aggregates: count(*)(0)
+        Group by: o_orderpriority[0]
+        -> PhysicFilter  (inccost=1810206, cost=1201, rows=1201) (actual rows=44)
+            Output: o_orderpriority[1]
+            Filter: {#marker}[0]
+            -> PhysicMarkJoin Left (inccost=1809005, cost=1801500, rows=1201) (actual rows=48)
+                Output: #marker,o_orderpriority[0]
+                Filter: l_orderkey[2]=o_orderkey[1]
+                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=300) (actual rows=48)
+                    Output: o_orderpriority[5],o_orderkey[0]
+                    Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=3752, loops=48)
+                    Output: l_orderkey[0]
+                    Filter: l_commitdate[11]<l_receiptdate[12]
+1-URGENT,9
+2-HIGH,7
+3-MEDIUM,9
+4-NOT SPECIFIED,7
+5-LOW,12
+

--- a/test/regress/expect/tpch1/q05.txt
+++ b/test/regress/expect/tpch1/q05.txt
@@ -1,0 +1,63 @@
+select
+	n_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+	customer,
+	orders,
+	lineitem,
+	supplier,
+	nation,
+	region
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and l_suppkey = s_suppkey
+	and c_nationkey = s_nationkey
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'ASIA'
+	and o_orderdate >= date '1994-01-01'
+	and o_orderdate < date '1994-01-01' + interval '1' year
+group by
+	n_name
+order by
+	revenue desc
+Total cost: 21323.97
+PhysicOrder  (inccost=21323.97, cost=82.97, rows=25) (actual rows=0)
+    Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
+    Order by: {sum(l_extendedprice*1-l_discount)}[1]
+    -> PhysicHashAgg  (inccost=21241, cost=226, rows=25) (actual rows=0)
+        Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
+        Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
+        Group by: n_name[0]
+        -> PhysicHashJoin  (inccost=21015, cost=1534, rows=176) (actual rows=0)
+            Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
+            Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
+            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                Output: 1,c_custkey[0],c_nationkey[3]
+            -> PhysicHashJoin  (inccost=19331, cost=2867, rows=952) (actual rows=0)
+                Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[1]
+                Filter: l_suppkey[8]=s_suppkey[2]
+                -> PhysicHashJoin  (inccost=97, cost=25, rows=5) (actual rows=0)
+                    Output: n_name[0],s_nationkey[2],s_suppkey[3]
+                    Filter: s_nationkey[2]=n_nationkey[1]
+                    -> PhysicHashJoin  (inccost=62, cost=32, rows=5) (actual rows=5)
+                        Output: n_name[1],n_nationkey[2]
+                        Filter: n_regionkey[3]=r_regionkey[0]
+                        -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
+                            Output: r_regionkey[0]
+                            Filter: r_name[1]='ASIA'
+                        -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                            Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                    -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                        Output: s_nationkey[3],s_suppkey[0]
+                -> PhysicHashJoin  (inccost=16367, cost=8862, rows=1905) (actual rows=0)
+                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0],l_suppkey[6]
+                    Filter: l_orderkey[7]=o_orderkey[1]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=476) (actual rows=0)
+                        Output: o_custkey[1],o_orderkey[0]
+                        Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_suppkey[2],l_orderkey[0]
+
+

--- a/test/regress/expect/tpch1/q06.txt
+++ b/test/regress/expect/tpch1/q06.txt
@@ -1,0 +1,18 @@
+select
+	sum(l_extendedprice * l_discount) as revenue
+from
+	lineitem
+where
+	l_shipdate >= date '1994-01-01'
+	and l_shipdate < date '1994-01-01' + interval '1' year
+	and l_discount between (.06 - 0.01 , .06 + 0.01)
+	and l_quantity < 24
+Total cost: 6008
+PhysicHashAgg  (inccost=6008, cost=3, rows=1) (actual rows=1)
+    Output: {sum(l_extendedprice*l_discount)}[0]
+    Aggregates: sum(l_extendedprice[1]*l_discount[2])
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1) (actual rows=116)
+        Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
+        Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM' and l_discount[6]>=0.05 and l_discount[6]<=0.07 and l_quantity[4]<24
+77949.9186
+

--- a/test/regress/expect/tpch1/q07.txt
+++ b/test/regress/expect/tpch1/q07.txt
@@ -1,0 +1,79 @@
+select
+	supp_nation,
+	cust_nation,
+	l_year,
+	sum(volume) as revenue
+from
+	(
+		select
+			n1.n_name as supp_nation,
+			n2.n_name as cust_nation,
+			year(l_shipdate) as l_year,
+			l_extendedprice * (1 - l_discount) as volume
+		from
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2
+		where
+			s_suppkey = l_suppkey
+			and o_orderkey = l_orderkey
+			and c_custkey = o_custkey
+			and s_nationkey = n1.n_nationkey
+			and c_nationkey = n2.n_nationkey
+			and (
+				(n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+				or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+			)
+			and l_shipdate between (date '1995-01-01' , date '1996-12-31')
+	) as shipping
+group by
+	supp_nation,
+	cust_nation,
+	l_year
+order by
+	supp_nation,
+	cust_nation,
+	l_year
+Total cost: 243894.1
+PhysicOrder  (inccost=243894.1, cost=0.1, rows=1) (actual rows=0)
+    Output: supp_nation[0],cust_nation[1],l_year[2],{sum(volume)}[3]
+    Order by: supp_nation[0], cust_nation[1], l_year[2]
+    -> PhysicHashAgg  (inccost=243894, cost=10268, rows=1) (actual rows=0)
+        Output: {supp_nation}[0],{cust_nation}[1],{l_year}[2],{sum(volume)}[3]
+        Aggregates: sum(volume[3])
+        Group by: supp_nation[0], cust_nation[1], l_year[2]
+        -> PhysicFromQuery <shipping> (inccost=233626, cost=10266, rows=10266) (actual rows=0)
+            Output: supp_nation[0],cust_nation[1],l_year[2],volume[3]
+            -> PhysicHashJoin  (inccost=223360, cost=102686, rows=10266) (actual rows=0)
+                Output: n_name (as supp_nation)[2],n_name (as cust_nation)[3],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5]
+                Filter: s_suppkey[0]=l_suppkey[6] and s_nationkey[1]=n_nationkey[7]
+                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                    Output: s_suppkey[0],s_nationkey[3]
+                -> PhysicHashJoin  (inccost=120664, cost=97346, rows=92400) (actual rows=61)
+                    Output: n_name (as supp_nation)[0],n_name (as cust_nation)[1],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5],l_suppkey[6],n_nationkey[2]
+                    Filter: c_nationkey[7]=n_nationkey[3]
+                    -> PhysicNLJoin  (inccost=1275, cost=1225, rows=625) (actual rows=2)
+                        Output: n_name (as supp_nation)[2],n_name (as cust_nation)[0],n_nationkey[3],n_nationkey[1]
+                        Filter: n_name[2]='FRANCE' and n_name[0]='GERMANY' or n_name[2]='GERMANY' and n_name[0]='FRANCE'
+                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
+                            Output: n_name (as cust_nation)[1],n_nationkey[0]
+                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=25)
+                            Output: n_name (as supp_nation)[1],n_nationkey[0]
+                    -> PhysicHashJoin  (inccost=22043, cost=6460, rows=3696) (actual rows=1793)
+                        Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],c_nationkey[0]
+                        Filter: c_custkey[1]=o_custkey[5]
+                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                            Output: c_nationkey[3],c_custkey[0]
+                        -> PhysicHashJoin  (inccost=15433, cost=7928, rows=2464) (actual rows=1793)
+                            Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],o_custkey[0]
+                            Filter: o_orderkey[1]=l_orderkey[5]
+                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                                Output: o_custkey[1],o_orderkey[0]
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=2464) (actual rows=1793)
+                                Output: year(l_shipdate[10]),l_extendedprice[5]*1-l_discount[6](as volume),l_suppkey[2],l_orderkey[0]
+                                Filter: l_shipdate[10]>='1995-01-01' and l_shipdate[10]<='1996-12-31'
+
+

--- a/test/regress/expect/tpch1/q08.txt
+++ b/test/regress/expect/tpch1/q08.txt
@@ -1,0 +1,90 @@
+select
+	o_year,
+	sum(case
+		when nation = 'BRAZIL' then volume
+		else 0
+	end) / sum(volume) as mkt_share
+from
+	(
+		select
+			year(o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) as volume,
+			n2.n_name as nation
+		from
+			part,
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2,
+			region
+		where
+			p_partkey = l_partkey
+			and s_suppkey = l_suppkey
+			and l_orderkey = o_orderkey
+			and o_custkey = c_custkey
+			and c_nationkey = n1.n_nationkey
+			and n1.n_regionkey = r_regionkey
+			and r_name = 'AMERICA'
+			and s_nationkey = n2.n_nationkey
+			and o_orderdate between (date '1995-01-01' ,date '1996-12-31')
+			and p_type = 'ECONOMY ANODIZED STEEL'
+	) as all_nations
+group by
+	o_year
+order by
+	o_year
+Total cost: 57478.1
+PhysicOrder  (inccost=57478.1, cost=0.1, rows=1) (actual rows=2)
+    Output: o_year[0],{sum(case with 1)/sum(volume)(as mkt_share)}[1]
+    Order by: o_year[0]
+    -> PhysicHashAgg  (inccost=57478, cost=22, rows=1) (actual rows=2)
+        Output: {o_year}[0],{sum(case with 1)}[1]/{sum(volume)}[2](as mkt_share)
+        Aggregates: sum(case with 1), sum(volume[5])
+        Group by: o_year[0]
+        -> PhysicFromQuery <all_nations> (inccost=57456, cost=20, rows=20) (actual rows=5)
+            Output: o_year[0],case with 1,nation[2]='BRAZIL',nation[2],'BRAZIL',volume[1],0
+            -> PhysicHashJoin  (inccost=57436, cost=2075, rows=20) (actual rows=5)
+                Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3]
+                Filter: p_partkey[0]=l_partkey[4]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=2) (actual rows=1)
+                    Output: p_partkey[0]
+                    Filter: p_type[4]='ECONOMY ANODIZED STEEL'
+                -> PhysicHashJoin  (inccost=55161, cost=12311, rows=2051) (actual rows=385)
+                    Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3],l_partkey[4]
+                    Filter: n_regionkey[5]=r_regionkey[0]
+                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
+                        Output: r_regionkey[0]
+                        Filter: r_name[1]='AMERICA'
+                    -> PhysicHashJoin  (inccost=42845, cost=14001, rows=10258) (actual rows=1810)
+                        Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],n_name (as nation)[0],l_partkey[4],n_regionkey[5]
+                        Filter: s_nationkey[6]=n_nationkey[1]
+                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
+                            Output: n_name (as nation)[1],n_nationkey[0]
+                        -> PhysicHashJoin  (inccost=28819, cost=7402, rows=3691) (actual rows=1810)
+                            Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[5],s_nationkey[0]
+                            Filter: s_suppkey[1]=l_suppkey[6]
+                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                Output: s_nationkey[3],s_suppkey[0]
+                            -> PhysicHashJoin  (inccost=21407, cost=11540, rows=3691) (actual rows=1810)
+                                Output: {year(o_orderdate)}[0],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[1],l_suppkey[5]
+                                Filter: l_orderkey[6]=o_orderkey[2]
+                                -> PhysicHashJoin  (inccost=3862, cost=1837, rows=922) (actual rows=452)
+                                    Output: {year(o_orderdate)}[2],n_regionkey[0],o_orderkey[3]
+                                    Filter: o_custkey[4]=c_custkey[1]
+                                    -> PhysicHashJoin  (inccost=525, cost=350, rows=150) (actual rows=150)
+                                        Output: n_regionkey[0],c_custkey[2]
+                                        Filter: c_nationkey[3]=n_nationkey[1]
+                                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25)
+                                            Output: n_regionkey[2],n_nationkey[0]
+                                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                                            Output: c_custkey[0],c_nationkey[3]
+                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=615) (actual rows=452)
+                                        Output: year(o_orderdate[4]),o_orderkey[0],o_custkey[1]
+                                        Filter: o_orderdate[4]>='1995-01-01' and o_orderdate[4]<='1996-12-31'
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                    Output: l_extendedprice[5]*1-l_discount[6](as volume),l_partkey[1],l_suppkey[2],l_orderkey[0]
+1995,0
+1996,0
+

--- a/test/regress/expect/tpch1/q09.txt
+++ b/test/regress/expect/tpch1/q09.txt
@@ -1,0 +1,131 @@
+select
+	nation,
+	o_year,
+	sum(amount) as sum_profit
+from
+	(
+		select
+			n_name as nation,
+			year(o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+		from
+			part,
+			supplier,
+			lineitem,
+			partsupp,
+			orders,
+			nation
+		where
+			s_suppkey = l_suppkey
+			and ps_suppkey = l_suppkey
+			and ps_partkey = l_partkey
+			and p_partkey = l_partkey
+			and o_orderkey = l_orderkey
+			and s_nationkey = n_nationkey
+			and p_name like '%green%'
+	) as profit
+group by
+	nation,
+	o_year
+order by
+	nation,
+	o_year desc
+Total cost: 47074.1
+PhysicOrder  (inccost=47074.1, cost=0.1, rows=1) (actual rows=60)
+    Output: nation[0],o_year[1],{sum(amount)}[2]
+    Order by: nation[0], o_year[1]
+    -> PhysicHashAgg  (inccost=47074, cost=35, rows=1) (actual rows=60)
+        Output: {nation}[0],{o_year}[1],{sum(amount)}[2]
+        Aggregates: sum(amount[2])
+        Group by: nation[0], o_year[1]
+        -> PhysicFromQuery <profit> (inccost=47039, cost=33, rows=33) (actual rows=493)
+            Output: nation[0],o_year[1],amount[2]
+            -> PhysicHashJoin  (inccost=47006, cost=6707, rows=33) (actual rows=493)
+                Output: n_name (as nation)[1],{year(o_orderdate)}[2],{l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[3]
+                Filter: p_partkey[0]=l_partkey[4]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=9)
+                    Output: p_partkey[0]
+                    Filter: p_name[1]like'%green%'
+                -> PhysicHashJoin  (inccost=40099, cost=9124, rows=6672) (actual rows=8447)
+                    Output: n_name (as nation)[0],{year(o_orderdate)}[2],{l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[3],l_partkey[4]
+                    Filter: s_nationkey[5]=n_nationkey[1]
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                        Output: n_name (as nation)[1],n_nationkey[0]
+                    -> PhysicHashJoin  (inccost=30950, cost=7804, rows=2402) (actual rows=8447)
+                        Output: {year(o_orderdate)}[0],{l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[2],l_partkey[3],s_nationkey[4]
+                        Filter: o_orderkey[1]=l_orderkey[5]
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                            Output: year(o_orderdate[4]),o_orderkey[0]
+                        -> PhysicHashJoin  (inccost=21646, cost=4824, rows=2402) (actual rows=8447)
+                            Output: {l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[2],l_partkey[3],s_nationkey[0],l_orderkey[4]
+                            Filter: s_suppkey[1]=l_suppkey[5]
+                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                Output: s_nationkey[3],s_suppkey[0]
+                            -> PhysicHashJoin  (inccost=16812, cost=10007, rows=2402) (actual rows=8447)
+                                Output: l_extendedprice[3]*1-l_discount[4]-ps_supplycost[0]*l_quantity[5](as amount),l_partkey[6],l_orderkey[7],l_suppkey[8]
+                                Filter: ps_suppkey[1]=l_suppkey[8] and ps_partkey[2]=l_partkey[6]
+                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
+                                    Output: ps_supplycost[3],ps_suppkey[1],ps_partkey[0]
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                    Output: l_extendedprice[5],l_discount[6],l_quantity[4],l_partkey[1],l_orderkey[0],l_suppkey[2]
+ARGENTINA,1998,17779.0697
+ARGENTINA,1997,13943.9538
+ARGENTINA,1996,7641.4227
+ARGENTINA,1995,20892.7525
+ARGENTINA,1994,15088.3526
+ARGENTINA,1993,17586.3446
+ARGENTINA,1992,28732.4615
+ETHIOPIA,1998,28217.16
+ETHIOPIA,1996,33970.65
+ETHIOPIA,1995,37720.35
+ETHIOPIA,1994,37251.01
+ETHIOPIA,1993,23782.61
+IRAN,1997,23590.008
+IRAN,1996,7428.2325
+IRAN,1995,21000.9965
+IRAN,1994,29408.13
+IRAN,1993,49876.415
+IRAN,1992,52064.24
+IRAQ,1998,11619.9604
+IRAQ,1997,47910.246
+IRAQ,1996,18459.5675
+IRAQ,1995,32782.3701
+IRAQ,1994,9041.2317
+IRAQ,1993,30687.2625
+IRAQ,1992,29098.2557
+KENYA,1998,33148.3345
+KENYA,1997,54355.0165
+KENYA,1996,53607.4854
+KENYA,1995,85354.8738
+KENYA,1994,102904.2511
+KENYA,1993,109310.8084
+KENYA,1992,138534.121
+MOROCCO,1998,157058.2328
+MOROCCO,1997,88669.961
+MOROCCO,1996,236833.6672
+MOROCCO,1995,381575.8668
+MOROCCO,1994,243523.4336
+MOROCCO,1993,232196.7803
+MOROCCO,1992,347434.1452
+PERU,1998,101109.0196
+PERU,1997,58073.0866
+PERU,1996,30360.5218
+PERU,1995,138451.78
+PERU,1994,55023.0632
+PERU,1993,110409.0863
+PERU,1992,70946.1916
+UNITED KINGDOM,1998,139685.044
+UNITED KINGDOM,1997,183502.0498
+UNITED KINGDOM,1996,374085.2884
+UNITED KINGDOM,1995,548356.7984
+UNITED KINGDOM,1994,266982.768
+UNITED KINGDOM,1993,717309.464
+UNITED KINGDOM,1992,79540.6016
+UNITED STATES,1998,32847.96
+UNITED STATES,1997,30849.5
+UNITED STATES,1996,56125.46
+UNITED STATES,1995,15961.7977
+UNITED STATES,1994,31671.2
+UNITED STATES,1993,55057.469
+UNITED STATES,1992,51970.23
+

--- a/test/regress/expect/tpch1/q10.txt
+++ b/test/regress/expect/tpch1/q10.txt
@@ -1,0 +1,82 @@
+select
+	c_custkey,
+	c_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	c_acctbal,
+	n_name,
+	c_address,
+	c_phone,
+	c_comment
+from
+	customer,
+	orders,
+	lineitem,
+	nation
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate >= date '1993-10-01'
+	and o_orderdate < date '1993-10-01' + interval '3' month
+	and l_returnflag = 'R'
+	and c_nationkey = n_nationkey
+group by
+	c_custkey,
+	c_name,
+	c_acctbal,
+	c_phone,
+	n_name,
+	c_address,
+	c_comment
+order by
+	revenue desc
+limit 20
+Total cost: 16331.61
+PhysicLimit (20) (inccost=16331.61, cost=20, rows=20) (actual rows=20)
+    Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
+    -> PhysicOrder  (inccost=16311.61, cost=3164.61, rows=501) (actual rows=20)
+        Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
+        Order by: {sum(l_extendedprice*1-l_discount)}[2]
+        -> PhysicHashAgg  (inccost=13147, cost=1503, rows=501) (actual rows=43)
+            Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
+            Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
+            Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
+            -> PhysicHashJoin  (inccost=11644, cost=1135, rows=501) (actual rows=140)
+                Output: c_custkey[0],c_name[1],c_acctbal[2],n_name[3],c_address[4],c_phone[5],c_comment[6],{l_extendedprice*1-l_discount}[8],l_extendedprice[9],{1-l_discount}[10],1,l_discount[11]
+                Filter: c_custkey[0]=o_custkey[12]
+                -> PhysicHashJoin  (inccost=525, cost=350, rows=150) (actual rows=150)
+                    Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{1}[1]
+                    Filter: c_nationkey[9]=n_nationkey[2]
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                        Output: n_name[1],1,n_nationkey[0]
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                        Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
+                -> PhysicHashJoin  (inccost=9984, cost=2479, rows=334) (actual rows=140)
+                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
+                    Filter: l_orderkey[6]=o_orderkey[1]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=344) (actual rows=64)
+                        Output: o_custkey[1],o_orderkey[0]
+                        Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=1457)
+                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
+                        Filter: l_returnflag[8]='R'
+121,Customer#000000121,282635.1719,6428.32,PERU,tv nCR2YKupGN73mQudO,27-411-990-2959,uriously stealthy ideas. carefully final courts use carefully
+124,Customer#000000124,222182.5188,1842.49,CHINA,aTbyVAW5tCd,v09O,28-183-750-7809,le fluffily even dependencies. quietly s
+106,Customer#000000106,190241.3334,3288.42,ARGENTINA,xGCOEAUjUNG,11-751-989-4627,lose slyly. ironic accounts along the evenly regular theodolites wake about the special, final gifts.
+16,Customer#000000016,161422.0461,4681.03,IRAN,cYiaeMLZSMAOQ2 d0W,,20-781-609-3107,kly silent courts. thinly regular theodolites sleep fluffily after
+44,Customer#000000044,149364.5652,7315.94,MOZAMBIQUE,Oi,dOSPwDu4jo4x,,P85E0dmhZGvNtBwi,26-190-260-5375,r requests around the unusual, bold a
+71,Customer#000000071,129481.0245,-611.19,GERMANY,TlGalgdXWBmMV,6agLyWYDyIz9MKzcY8gl,w6t1B,17-710-812-5403,g courts across the regular, final pinto beans are blithely pending ac
+89,Customer#000000089,121663.1243,1530.76,KENYA,dtR, y9JQWUO6FoJExyp8whOU,24-394-451-5404,counts are slyly beyond the slyly final accounts. quickly final ideas wake. r
+112,Customer#000000112,111137.7141,2953.35,ROMANIA,RcfgG3bO7QeCnfjqJT1,29-233-262-8382,rmanently unusual multipliers. blithely ruthless deposits are furiously along the
+62,Customer#000000062,106368.0153,595.61,GERMANY,upJK2Dnw13,,17-361-978-7059,kly special dolphins. pinto beans are slyly. quickly regular accounts are furiously a
+146,Customer#000000146,103265.9888,3328.68,CANADA,GdxkdXG9u7iyI1,,y5tq4ZyrcEy,13-835-723-3223,ffily regular dinos are slyly unusual requests. slyly specia
+19,Customer#000000019,99306.0127,8914.71,CHINA,uc,3bHIx84H,wdrmLOjVsiqXCq2tr,28-396-526-5053,nag. furiously careful packages are slyly at the accounts. furiously regular in
+145,Customer#000000145,99256.9018,9748.93,JORDAN,kQjHmt2kcec cy3hfMh969u,23-562-444-8454,ests? express, express instructions use. blithely fina
+103,Customer#000000103,97311.7724,2757.45,INDONESIA,8KIsQX4LJ7QMsj6DrtFtXu0nUEdV,8a,19-216-107-2107,furiously pending notornis boost slyly around the blithely ironic ideas? final, even instructions cajole fl
+136,Customer#000000136,95855.398,-842.39,GERMANY,QoLsJ0v5C1IQbh,DS1,17-501-210-4726,ackages sleep ironic, final courts. even requests above the blithely bold requests g
+53,Customer#000000053,92568.9124,4113.64,MOROCCO,HnaxHzTfFTZs8MuCpJyTbZ47Cm4wFOOgib,25-168-852-5363,ar accounts are. even foxes are blithely. fluffily pending deposits boost
+49,Customer#000000049,90965.7262,4573.94,IRAN,cNgAeX7Fqrdf7HQN9EwjUa4nxT,68L FKAxzl,20-908-631-4424,nusual foxes! fluffily pending packages maintain to the regular
+37,Customer#000000037,88065.7458,-917.75,INDIA,7EV4Pwh,3SboctTWt,18-385-235-7162,ilent packages are carefully among the deposits. furiousl
+82,Customer#000000082,86998.9644,9468.34,CHINA,zhG3EZbap4c992Gj3bK,3Ne,Xn,28-159-442-5305,s wake. bravely regular accounts are furiously. regula
+125,Customer#000000125,84808.068,-234.12,ROMANIA,,wSZXdVR xxIIfm9s8ITyLl3kgjT6UC07GY0Y,29-261-996-3120,x-ray finally after the packages? regular requests c
+59,Customer#000000059,84655.5711,3458.6,ARGENTINA,zLOCP0wh92OtBihgspOGl4,11-355-584-3112,ously final packages haggle blithely after the express deposits. furiou
+

--- a/test/regress/expect/tpch1/q11.txt
+++ b/test/regress/expect/tpch1/q11.txt
@@ -1,0 +1,68 @@
+select
+	ps_partkey,
+	sum(ps_supplycost * ps_availqty) as value
+from
+	partsupp,
+	supplier,
+	nation
+where
+	ps_suppkey = s_suppkey
+	and s_nationkey = n_nationkey
+	and n_name = 'GERMANY'
+group by
+	ps_partkey having
+		sum(ps_supplycost * ps_availqty) > (
+			select
+				sum(ps_supplycost * ps_availqty) * 0.0001000000
+			from
+				partsupp,
+				supplier,
+				nation
+			where
+				ps_suppkey = s_suppkey
+				and s_nationkey = n_nationkey
+				and n_name = 'GERMANY'
+		)
+order by
+	value desc
+Total cost: 2328.56
+PhysicOrder  (inccost=2328.56, cost=358.56, rows=80) (actual rows=0)
+    Output: ps_partkey[0],{sum(ps_supplycost*ps_availqty)}[1]
+    Order by: {sum(ps_supplycost*ps_availqty)}[1]
+    -> PhysicHashAgg  (inccost=1970, cost=240, rows=80) (actual rows=0)
+        Output: {ps_partkey}[0],{sum(ps_supplycost*ps_availqty)}[1]
+        Aggregates: sum(ps_supplycost[2]*ps_availqty[3])
+        Group by: ps_partkey[0]
+        Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
+        <ScalarSubqueryExpr> cached 1
+            -> PhysicHashAgg  (inccost=1812, cost=82, rows=1) (actual rows=0)
+                Output: {sum(ps_supplycost*ps_availqty)}[0]*0.0001000000
+                Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
+                -> PhysicHashJoin  (inccost=1730, cost=882, rows=80) (actual rows=0)
+                    Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
+                    Filter: ps_suppkey[4]=s_suppkey[0]
+                    -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+                        Output: s_suppkey[1]
+                        Filter: s_nationkey[2]=n_nationkey[0]
+                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
+                            Output: n_nationkey[0]
+                            Filter: n_name[1]='GERMANY'
+                        -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                            Output: s_suppkey[0],s_nationkey[3]
+                    -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                        Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
+        -> PhysicHashJoin  (inccost=1730, cost=882, rows=80) (actual rows=0)
+            Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
+            Filter: ps_suppkey[5]=s_suppkey[0]
+            -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+                Output: s_suppkey[1]
+                Filter: s_nationkey[2]=n_nationkey[0]
+                -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+                    Output: n_nationkey[0]
+                    Filter: n_name[1]='GERMANY'
+                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                    Output: s_suppkey[0],s_nationkey[3]
+            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
+
+

--- a/test/regress/expect/tpch1/q12.txt
+++ b/test/regress/expect/tpch1/q12.txt
@@ -1,0 +1,47 @@
+select
+	l_shipmode,
+	sum(case
+		when o_orderpriority = '1-URGENT'
+			or o_orderpriority = '2-HIGH'
+			then 1
+		else 0
+	end) as high_line_count,
+	sum(case
+		when o_orderpriority <> '1-URGENT'
+			and o_orderpriority <> '2-HIGH'
+			then 1
+		else 0
+	end) as low_line_count
+from
+	orders,
+	lineitem
+where
+	o_orderkey = l_orderkey
+	and l_shipmode in ('MAIL', 'SHIP')
+	and l_commitdate < l_receiptdate
+	and l_shipdate < l_commitdate
+	and l_receiptdate >= date '1994-01-01'
+	and l_receiptdate < date '1994-01-01' + interval '1' year
+group by
+	l_shipmode
+order by
+	l_shipmode
+Total cost: 16056.32
+PhysicOrder  (inccost=16056.32, cost=14.32, rows=7) (actual rows=2)
+    Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
+    Order by: l_shipmode[0]
+    -> PhysicHashAgg  (inccost=16042, cost=1855, rows=7) (actual rows=2)
+        Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
+        Aggregates: sum(case with 1), sum(case with 1)
+        Group by: l_shipmode[0]
+        -> PhysicHashJoin  (inccost=14187, cost=6682, rows=1841) (actual rows=25)
+            Output: l_shipmode[14],{case with 1}[0],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[1],{o_orderpriority='1-URGENT'}[2],o_orderpriority[3],{'1-URGENT'}[4],{o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[10],{o_orderpriority<>'1-URGENT'}[11],{o_orderpriority<>'2-HIGH'}[12]
+            Filter: o_orderkey[13]=l_orderkey[15]
+            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],'1-URGENT',o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1841) (actual rows=25)
+                Output: l_shipmode[14],l_orderkey[0]
+                Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
+MAIL,5,5
+SHIP,5,10
+

--- a/test/regress/expect/tpch1/q14.txt
+++ b/test/regress/expect/tpch1/q14.txt
@@ -1,0 +1,27 @@
+select
+	100.00 * sum(case
+		when p_type like 'PROMO%'
+			then l_extendedprice * (1 - l_discount)
+		else 0
+	end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+	lineitem,
+	part
+where
+	l_partkey = p_partkey
+	and l_shipdate >= date '1995-09-01'
+	and l_shipdate < date '1995-09-01' + interval '1' month
+Total cost: 11275
+PhysicHashAgg  (inccost=11275, cost=1558, rows=1) (actual rows=1)
+    Output: 100.00*{sum(case with 1)}[0]/{sum(l_extendedprice*1-l_discount)}[1](as promo_revenue)
+    Aggregates: sum(case with 1), sum(l_extendedprice[5]*1-l_discount[8])
+    -> PhysicHashJoin  (inccost=9717, cost=3512, rows=1556) (actual rows=84)
+        Output: case with 1,{p_typelike'PROMO%'}[1],p_type[0],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[8],l_extendedprice[6],{1-l_discount}[9],{1}[3],l_discount[7],{0}[4]
+        Filter: l_partkey[10]=p_partkey[5]
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200)
+            Output: p_type[4],p_type[4]like'PROMO%','PROMO%',1,0,p_partkey[0]
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1556) (actual rows=84)
+            Output: l_extendedprice[5],l_discount[6],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],l_partkey[1]
+            Filter: l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM'
+15.2302126115973
+

--- a/test/regress/expect/tpch1/q15.txt
+++ b/test/regress/expect/tpch1/q15.txt
@@ -1,0 +1,63 @@
+with revenue0 as
+	(select
+		l_suppkey as supplier_no,
+		sum(l_extendedprice * (1 - l_discount)) as total_revenue
+	from
+		lineitem
+	where
+		l_shipdate >= date '1996-01-01'
+		and l_shipdate < date '1996-01-01' + interval '3' month
+	group by
+		l_suppkey)
+
+
+select
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+from
+	supplier,
+	revenue0
+where
+	s_suppkey = supplier_no
+	and total_revenue = (
+		select
+			max(total_revenue)
+		from
+			revenue0
+	)
+Total cost: 7670
+PhysicFilter  (inccost=7670, cost=10, rows=10) (actual rows=1)
+    Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
+    Filter: total_revenue[4]=@1
+    <ScalarSubqueryExpr> cached 1
+        -> PhysicHashAgg  (inccost=7622, cost=12, rows=1) (actual rows=1)
+            Output: {max(total_revenue)}[0]
+            Aggregates: max(total_revenue[0])
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7610, cost=10, rows=10) (actual rows=10)
+                Output: total_revenue[1]
+                -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+                    Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
+                    Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
+                    Group by: l_suppkey[0]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                        Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
+                        Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
+    -> PhysicHashJoin  (inccost=7660, cost=40, rows=10) (actual rows=10)
+        Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
+        Filter: s_suppkey[0]=supplier_no[5]
+        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+            Output: s_suppkey[0],s_name[1],s_address[2],s_phone[4]
+        -> PhysicFromQuery <revenue0> (inccost=7610, cost=10, rows=10) (actual rows=10)
+            Output: total_revenue[1],supplier_no[0]
+            -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+                Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
+                Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
+                Group by: l_suppkey[0]
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                    Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
+                    Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
+10,Supplier#000000010,Saygah3gYWMp72i PY,34-852-489-8585,772262.2438
+

--- a/test/regress/expect/tpch1/q16.txt
+++ b/test/regress/expect/tpch1/q16.txt
@@ -1,0 +1,53 @@
+select
+	p_brand,
+	p_type,
+	p_size,
+	count(distinct ps_suppkey) as supplier_cnt
+from
+	partsupp,
+	part
+where
+	p_partkey = ps_partkey
+	and p_brand <> 'Brand#45'
+	and p_type not like 'MEDIUM POLISHED%'
+	and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+	and ps_suppkey not in (
+		select
+			s_suppkey
+		from
+			supplier
+		where
+			s_comment like '%Customer%Complaints%'
+	)
+group by
+	p_brand,
+	p_type,
+	p_size
+order by
+	supplier_cnt desc,
+	p_brand,
+	p_type,
+	p_size
+Total cost: 10827.68
+PhysicOrder  (inccost=10827.68, cost=5427.68, rows=800) (actual rows=0)
+    Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
+    Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
+    -> PhysicHashAgg  (inccost=5400, cost=2400, rows=800) (actual rows=0)
+        Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
+        Aggregates: count(ps_suppkey[3])
+        Group by: p_brand[0], p_type[1], p_size[2]
+        -> PhysicHashJoin  (inccost=3000, cost=2000, rows=800) (actual rows=0)
+            Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
+            Filter: p_partkey[3]=ps_partkey[5]
+            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=34)
+                Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
+                Filter: p_brand[3]<>'Brand#45' and p_type[4]not like'MEDIUM POLISHED%' and p_size[5] in (49,14,23, ... <Total: 8> )
+            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                Output: ps_suppkey[1],ps_partkey[0]
+                Filter: ps_suppkey[1] in @1
+                <InSubqueryExpr> cached 1
+                    -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
+                        Output: s_suppkey[0]
+                        Filter: s_comment[6]like'%Customer%Complaints%'
+
+

--- a/test/regress/expect/tpch1/q17.txt
+++ b/test/regress/expect/tpch1/q17.txt
@@ -1,0 +1,43 @@
+select
+	sum(l_extendedprice) / 7.0 as avg_yearly
+from
+	lineitem,
+	part
+where
+	p_partkey = l_partkey
+	and p_brand = 'Brand#23'
+	and p_container = 'MED BOX'
+	and l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p_partkey
+	)
+Total cost: 25004
+PhysicHashAgg  (inccost=25004, cost=32, rows=1) (actual rows=1)
+    Output: {sum(l_extendedprice)}[0]/7.0(as avg_yearly)
+    Aggregates: sum(l_extendedprice[0])
+    -> PhysicFilter  (inccost=24972, cost=30, rows=30) (actual rows=0)
+        Output: l_extendedprice[0]
+        Filter: l_quantity[1]<0.2*{avg(l_quantity)}[2]
+        -> PhysicHashJoin Left (inccost=24942, cost=290, rows=30) (actual rows=0)
+            Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
+            Filter: l_partkey[4]=p_partkey[2]
+            -> PhysicHashJoin  (inccost=12242, cost=6037, rows=30) (actual rows=0)
+                Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
+                Filter: p_partkey[0]=l_partkey[3]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                    Output: p_partkey[0]
+                    Filter: p_container[6]='MED BOX' and p_brand[3]='Brand#23'
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                    Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
+            -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200) (actual rows=0)
+                Output: {avg(l_quantity)}[1],{l_partkey}[0]
+                Aggregates: avg(l_quantity[1])
+                Group by: l_partkey[0]
+                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                    Output: l_partkey[1],l_quantity[4]
+
+

--- a/test/regress/expect/tpch1/q18.txt
+++ b/test/regress/expect/tpch1/q18.txt
@@ -1,0 +1,66 @@
+select
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice,
+	sum(l_quantity)
+from
+	customer,
+	orders,
+	lineitem
+where
+	o_orderkey in (
+		select
+			l_orderkey
+		from
+			lineitem
+		group by
+			l_orderkey having
+				sum(l_quantity) > 300
+	)
+	and c_custkey = o_custkey
+	and o_orderkey = l_orderkey
+group by
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice
+order by
+	o_totalprice desc,
+	o_orderdate
+limit 100
+Total cost: 148014.25
+PhysicLimit (100) (inccost=148014.25, cost=100, rows=100) (actual rows=0)
+    Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
+    -> PhysicOrder  (inccost=147914.25, cost=82916.25, rows=9007) (actual rows=0)
+        Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
+        Order by: o_totalprice[4], o_orderdate[3]
+        -> PhysicHashAgg  (inccost=64998, cost=27021, rows=9007) (actual rows=0)
+            Output: {c_name}[0],{c_custkey}[1],{o_orderkey}[2],{o_orderdate}[3],{o_totalprice}[4],{sum(l_quantity)}[5]
+            Aggregates: sum(l_quantity[5])
+            Group by: c_name[0], c_custkey[1], o_orderkey[2], o_orderdate[3], o_totalprice[4]
+            -> PhysicHashJoin  (inccost=37977, cost=15312, rows=9007) (actual rows=0)
+                Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],l_quantity[5]
+                Filter: c_custkey[1]=o_custkey[6]
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                    Output: c_name[1],c_custkey[0]
+                -> PhysicHashJoin  (inccost=22515, cost=15010, rows=6005) (actual rows=0)
+                    Output: o_orderkey[0],o_orderdate[1],o_totalprice[2],l_quantity[4],o_custkey[3]
+                    Filter: o_orderkey[0]=l_orderkey[5]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
+                        Output: o_orderkey[0],o_orderdate[4],o_totalprice[3],o_custkey[1]
+                        Filter: o_orderkey[0] in @1
+                        <InSubqueryExpr> cached 1
+                            -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500) (actual rows=0)
+                                Output: {l_orderkey}[0]
+                                Aggregates: sum(l_quantity[1])
+                                Group by: l_orderkey[0]
+                                Filter: {sum(l_quantity)}[1]>300
+                                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                    Output: l_orderkey[0],l_quantity[4]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l_quantity[4],l_orderkey[0]
+
+

--- a/test/regress/expect/tpch1/q19.txt
+++ b/test/regress/expect/tpch1/q19.txt
@@ -1,0 +1,48 @@
+select
+	sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+	lineitem,
+	part
+where
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#12'
+		and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+		and l_quantity >= 1 and l_quantity <= 1 + 10
+		and p_size between (1 ,5)
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#23'
+		and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+		and l_quantity >= 10 and l_quantity <= 10 + 10
+		and p_size between (1, 10)
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#34'
+		and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+		and l_quantity >= 20 and l_quantity <= 20 + 10
+		and p_size between (1,15)
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+Total cost: 2470357
+PhysicHashAgg  (inccost=2470357, cost=1201002, rows=1) (actual rows=1)
+    Output: {sum(l_extendedprice*1-l_discount)}[0]
+    Aggregates: sum(l_extendedprice[1]*1-l_discount[4])
+    -> PhysicNLJoin  (inccost=1269355, cost=1263150, rows=1201000) (actual rows=0)
+        Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],{1}[3],l_discount[4]
+        Filter: p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12' and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and l_quantity[6]>=1 and l_quantity[6]<=11 and p_size[12]>=1 and p_size[12]<=5 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23' and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and l_quantity[6]>=10 and l_quantity[6]<=20 and p_size[12]>=1 and p_size[12]<=10 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34' and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and l_quantity[6]>=20 and l_quantity[6]<=30 and p_size[12]>=1 and p_size[12]<=15 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON'
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+            Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200, loops=6005)
+            Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
+
+

--- a/test/regress/expect/tpch1/q20.txt
+++ b/test/regress/expect/tpch1/q20.txt
@@ -1,0 +1,73 @@
+select
+	s_name,
+	s_address
+from
+	supplier,
+	nation
+where
+	s_suppkey in (
+		select
+			ps_suppkey
+		from
+			partsupp
+		where
+			ps_partkey in (
+				select
+					p_partkey
+				from
+					part
+				where
+					p_name like 'forest%'
+			)
+			and ps_availqty > (
+				select
+					0.5 * sum(l_quantity)
+				from
+					lineitem
+				where
+					l_partkey = ps_partkey
+					and l_suppkey = ps_suppkey
+					and l_shipdate >= date '1994-01-01'
+					and l_shipdate < date '1994-01-01' + interval '1' year
+			)
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'CANADA'
+order by
+	s_name
+Total cost: 48.1
+PhysicOrder  (inccost=48.1, cost=0.1, rows=1) (actual rows=0)
+    Output: s_name[0],s_address[1]
+    Order by: s_name[0]
+    -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+        Output: s_name[1],s_address[2]
+        Filter: s_nationkey[3]=n_nationkey[0]
+        -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+            Output: n_nationkey[0]
+            Filter: n_name[1]='CANADA'
+        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+            Output: s_name[1],s_address[2],s_nationkey[3]
+            Filter: s_suppkey[0] in @1
+            <InSubqueryExpr> cached 1
+                -> PhysicFilter  (inccost=17447, cost=753, rows=753) (actual rows=47)
+                    Output: ps_suppkey[0]
+                    Filter: ps_availqty[1]>0.5*{sum(l_quantity)}[2]
+                    -> PhysicHashJoin Left (inccost=16694, cost=4237, rows=753) (actual rows=60)
+                        Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
+                        Filter: l_partkey[4]=ps_partkey[2] and l_suppkey[5]=ps_suppkey[0]
+                        -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=60)
+                            Output: ps_suppkey[1],ps_availqty[2],ps_partkey[0]
+                            Filter: ps_partkey[0] in @2
+                            <InSubqueryExpr> cached 2
+                                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=15)
+                                    Output: p_partkey[0]
+                                    Filter: p_name[1]like'forest%'
+                        -> PhysicHashAgg  (inccost=11657, cost=5652, rows=1884) (actual rows=499)
+                            Output: {sum(l_quantity)}[2],{l_partkey}[0],{l_suppkey}[1]
+                            Aggregates: sum(l_quantity[2])
+                            Group by: l_partkey[0], l_suppkey[1]
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1884) (actual rows=922)
+                                Output: l_partkey[1],l_suppkey[2],l_quantity[4]
+                                Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM'
+
+

--- a/test/regress/expect/tpch1/q21.txt
+++ b/test/regress/expect/tpch1/q21.txt
@@ -1,0 +1,89 @@
+select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'SAUDI ARABIA'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+limit 100
+Total cost: 38044918.02
+PhysicLimit (100) (inccost=38044918.02, cost=100, rows=100) (actual rows=0)
+    Output: s_name[0],{count(*)(0)}[1]
+    -> PhysicOrder  (inccost=38044818.02, cost=24.02, rows=10) (actual rows=0)
+        Output: s_name[0],{count(*)(0)}[1]
+        Order by: {count(*)(0)}[1], s_name[0]
+        -> PhysicHashAgg  (inccost=38044794, cost=6025, rows=10) (actual rows=0)
+            Output: {s_name}[0],{count(*)(0)}[1]
+            Aggregates: count(*)(0)
+            Group by: s_name[0]
+            -> PhysicFilter  (inccost=38038769, cost=6005, rows=6005) (actual rows=0)
+                Output: s_name[1]
+                Filter: {#marker}[0]
+                -> PhysicMarkJoin Left (inccost=38032764, cost=36060025, rows=6005) (actual rows=0)
+                    Output: #marker,s_name[0]
+                    Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
+                    -> PhysicFilter  (inccost=1966734, cost=6005, rows=6005) (actual rows=0)
+                        Output: s_name[1],l_orderkey[2],l_suppkey[3]
+                        Filter: {#marker}[0]
+                        -> PhysicMarkJoin Left (inccost=1960729, cost=1933610, rows=6005) (actual rows=0)
+                            Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
+                            Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
+                            -> PhysicHashJoin  (inccost=21114, cost=3198, rows=290) (actual rows=0)
+                                Output: s_name[0],l_orderkey[2],l_suppkey[3]
+                                Filter: s_suppkey[1]=l_suppkey[3]
+                                -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+                                    Output: s_name[1],s_suppkey[2]
+                                    Filter: s_nationkey[3]=n_nationkey[0]
+                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+                                        Output: n_nationkey[0]
+                                        Filter: n_name[1]='SAUDI ARABIA'
+                                    -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                        Output: s_name[1],s_suppkey[0],s_nationkey[3]
+                                -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906) (actual rows=0)
+                                    Output: l_orderkey[1],l_suppkey[2]
+                                    Filter: o_orderkey[0]=l_orderkey[1]
+                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=0)
+                                        Output: o_orderkey[0]
+                                        Filter: o_orderstatus[2]='F'
+                                    -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                        Output: l_orderkey[0],l_suppkey[2]
+                                        Filter: l_receiptdate[12]>l_commitdate[11]
+                            -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                Output: l_orderkey[0],l_suppkey[2]
+                                Filter: l_receiptdate[12]>l_commitdate[11]
+                    -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l_orderkey[0],l_suppkey[2]
+
+

--- a/test/regress/expect/tpch1/q22.txt
+++ b/test/regress/expect/tpch1/q22.txt
@@ -1,0 +1,73 @@
+select
+	cntrycode,
+	count(*) as numcust,
+	sum(c_acctbal) as totacctbal
+from
+	(
+		select
+			substring(c_phone, 1, 2) as cntrycode,
+			c_acctbal
+		from
+			customer
+		where
+			substring(c_phone, 1, 2) in
+				('13', '31', '23', '29', '30', '18', '17')
+			and c_acctbal > (
+				select
+					avg(c_acctbal)
+				from
+					customer
+				where
+					c_acctbal > 0.00
+					and substring(c_phone, 1, 2) in
+						('13', '31', '23', '29', '30', '18', '17')
+			)
+			and not exists (
+				select
+					*
+				from
+					orders
+				where
+					o_custkey = c_custkey
+			)
+	) as custsale
+group by
+	cntrycode
+order by
+	cntrycode
+Total cost: 233402.1
+PhysicOrder  (inccost=233402.1, cost=0.1, rows=1) (actual rows=7)
+    Output: cntrycode[0],{count(*)(0)}[1],{sum(c_acctbal)}[2]
+    Order by: cntrycode[0]
+    -> PhysicHashAgg  (inccost=233402, cost=2252, rows=1) (actual rows=7)
+        Output: {cntrycode}[0],{count(*)(0)}[1],{sum(c_acctbal)}[2]
+        Aggregates: count(*)(0), sum(c_acctbal[1])
+        Group by: cntrycode[0]
+        -> PhysicFromQuery <custsale> (inccost=231150, cost=2250, rows=2250) (actual rows=9)
+            Output: cntrycode[0],c_acctbal[1]
+            -> PhysicFilter  (inccost=228900, cost=2250, rows=2250) (actual rows=9)
+                Output: {substring(c_phone,1,2)}[1],c_acctbal[2]
+                Filter: {#marker}[0]
+                -> PhysicMarkJoin Left (inccost=226650, cost=225000, rows=2250) (actual rows=17)
+                    Output: #marker,{substring(c_phone,1,2)}[0],c_acctbal[1]
+                    Filter: o_custkey[3]=c_custkey[2]
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=17)
+                        Output: substring(c_phone[4],1,2),c_acctbal[5],c_custkey[0]
+                        Filter: substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and c_acctbal[5]>@1
+                        <ScalarSubqueryExpr> cached 1
+                            -> PhysicHashAgg  (inccost=284, cost=134, rows=1) (actual rows=1)
+                                Output: {avg(c_acctbal)}[0]
+                                Aggregates: avg(c_acctbal[0])
+                                -> PhysicScanTable customer as customer__1 (inccost=150, cost=150, rows=132) (actual rows=35)
+                                    Output: c_acctbal[5]
+                                    Filter: c_acctbal[5]>0.00 and substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=17)
+                        Output: o_custkey[1]
+13,1,5679.84
+17,1,9127.27
+18,2,14647.99
+23,1,9255.67
+29,2,17195.08
+30,1,7638.57
+31,1,9331.13
+


### PR DESCRIPTION
Qingqing, 

This chaneset contains  a regression test for TPC-H 1G statistical. 

----------------------------------
This changeset contains a regression test to compare the generated
query execution plans, based on 1G statistical data, against the
expected plans for 1G statistical data.