### PR TITLE
Initial Primitive Tests, Same Column Filter and "IN" Expression Estimation

### DIFF
--- a/qpmodel/Statis.cs
+++ b/qpmodel/Statis.cs
@@ -322,9 +322,14 @@ namespace qpmodel.stat
             if (selList.Count() == 1)
                 return selList[0];
             double selectOut = 0.0;
+            double backupSel = 1.0;
             foreach (var selectivity in selList)
+            {
                 selectOut += 1.0 - selectivity;
-            return Math.Max(0, 1.0 - selectOut);
+                backupSel *= selectivity;
+            }
+            if (selectOut >= 0.0 && selectOut <1.0) return 1 - selectOut;
+            return backupSel;
         }
 
         // problems:

--- a/qpmodel/Statis.cs
+++ b/qpmodel/Statis.cs
@@ -325,7 +325,7 @@ namespace qpmodel.stat
                         if (inPred.children_[i] is LiteralExpr pr)
                             selectivity += stat.EstSelectivity("=", pr.val_);
                     }
-                    return selectivity;
+                    return Math.Min(1.0, selectivity);
                 }
             }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -1970,7 +1970,7 @@ namespace qpmodel.unittest
                 string fn = Path.GetFileNameWithoutExtension(v);
                 var results = SQLStatement.ExecSQL(File.ReadAllText(v), out physicplan, out string error_, option);
                 //File.WriteAllText(expect_dir_fn + $"{fn}.txt", physicplan);
-                string expected = File.ReadAllText(expect_dir_fn + $"{fn}.txt");
+                string expected = File.ReadAllText(expect_dir_fn + $"{fn}.txt").Replace("\r", string.Empty);
                 bool is_equal = expected.Equals(physicplan);
                 if (!is_equal) CheckEstimation(physicplan, expected);
                 Assert.IsTrue(is_equal);
@@ -1988,7 +1988,7 @@ namespace qpmodel.unittest
             for (int i=0; i<sqls.Length; ++i)
             {
                 var results = SQLStatement.ExecSQL(sqls[i], out physicplan, out string error_, option);
-                string expected = File.ReadAllText(expect_dir_fn + test_name + $"_{i}.txt");
+                string expected = File.ReadAllText(expect_dir_fn + test_name + $"_{i}.txt").Replace("\r", string.Empty);
                 bool is_equal = expected.Equals(physicplan);
                 if (!is_equal) CheckEstimation(physicplan, expected);
                 Console.WriteLine(physicplan);

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -1898,6 +1898,18 @@ namespace qpmodel.unittest
     [TestClass]
     public class CEPrimitive
     {
+        void CheckTableLoad()
+        {
+            string sql = "select * from lineitem";
+            var results = SQLStatement.ExecSQL(sql, out string physicplan, out string error_);
+            if (results == null)
+            {
+                Tpch.CreateTables();
+                Tpch.LoadTables("0001");
+            }
+            else
+                Debug.Assert(results.Count == 6005);
+        }
         int ExtractNum(string str)
         {
             string numstr = str.Split(')')[0];
@@ -1938,13 +1950,13 @@ namespace qpmodel.unittest
             }
         }
 
+        string expect_dir_fn = "../../../test/primitive/expect/";
+
         [TestMethod]
         public void TpchUnit()
         {
             // initialize tpch database
-            Tpch.CreateTables();
-            Tpch.LoadTables("0001");
-            Tpch.AnalyzeTables();
+            CheckTableLoad();
 
             // load query and set option
             var files = Directory.GetFiles(@"../../../tpch", "*.sql");
@@ -1956,22 +1968,18 @@ namespace qpmodel.unittest
             {
                 string fn = Path.GetFileNameWithoutExtension(v);
                 var results = SQLStatement.ExecSQL(File.ReadAllText(v), out physicplan, out string error_, option);
-                //File.WriteAllText("../../../test/primitive/expect/" + $"{fn}.txt", physicplan);
-                string expected = File.ReadAllText("../../../test/primitive/expect/" + $"{fn}.txt");
+                //File.WriteAllText(expect_dir_fn + $"{fn}.txt", physicplan);
+                string expected = File.ReadAllText(expect_dir_fn + $"{fn}.txt");
                 bool is_equal = expected.Equals(physicplan);
                 if (!is_equal) CheckEstimation(physicplan, expected);
                 Assert.IsTrue(is_equal);
             }
-            Assert.IsTrue(true);
         }
-
-        string expect_dir_fn = "../../../test/primitive/expect/";
 
         void CheckSql(string[] sqls, string test_name)
         {
             // initialize tpch database
-            Tpch.CreateTables();
-            Tpch.LoadTables("001");
+            CheckTableLoad();
             var option = new QueryOption();
             option.explain_.show_cost_ = true;
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -1906,6 +1906,7 @@ namespace qpmodel.unittest
             {
                 Tpch.CreateTables();
                 Tpch.LoadTables("0001");
+                Tpch.AnalyzeTables();
             }
             else
                 Debug.Assert(results.Count == 6005);
@@ -2016,7 +2017,7 @@ namespace qpmodel.unittest
                 // filter on one column, q04
                 "select * from orders where o_orderdate >= date '1993-07-01' and o_orderdate<date '1993-07-01' + interval '3' month",
                 // filter on one column, q06, between
-                "select * from lineitem, partsupp where ps_suppkey = l_suppkey and ps_partkey = l_partkey"
+                "select * from lineitem where l_discount between (.06 - 0.01 , .06 + 0.01)"
             };
             CheckSql(sqls, "filtersamecol");
         }

--- a/test/primitive/expect/aggregate_0.txt
+++ b/test/primitive/expect/aggregate_0.txt
@@ -1,7 +1,7 @@
 Total cost: 2
-PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=2000)
+PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=200)
     Output: {count(*)(0)}[1]
     Aggregates: count(*)(0)
     Group by: lineitem.l_partkey[0]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_partkey[1]

--- a/test/primitive/expect/aggregate_0.txt
+++ b/test/primitive/expect/aggregate_0.txt
@@ -1,7 +1,7 @@
-Total cost: 2
-PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=200)
+Total cost: 12410
+PhysicHashAgg  (inccost=12410, cost=6405, rows=200) (actual rows=200)
     Output: {count(*)(0)}[1]
     Aggregates: count(*)(0)
     Group by: lineitem.l_partkey[0]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
         Output: lineitem.l_partkey[1]

--- a/test/primitive/expect/aggregate_0.txt
+++ b/test/primitive/expect/aggregate_0.txt
@@ -1,0 +1,7 @@
+Total cost: 2
+PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=2000)
+    Output: {count(*)(0)}[1]
+    Aggregates: count(*)(0)
+    Group by: lineitem.l_partkey[0]
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_partkey[1]

--- a/test/primitive/expect/aggregate_1.txt
+++ b/test/primitive/expect/aggregate_1.txt
@@ -1,0 +1,7 @@
+Total cost: 2
+PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=7996)
+    Output: {count(*)(0)}[2]
+    Aggregates: count(*)(0)
+    Group by: lineitem.l_partkey[0], lineitem.l_suppkey[1]
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_partkey[1],lineitem.l_suppkey[2]

--- a/test/primitive/expect/aggregate_1.txt
+++ b/test/primitive/expect/aggregate_1.txt
@@ -1,7 +1,7 @@
-Total cost: 2
-PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=700)
+Total cost: 16010
+PhysicHashAgg  (inccost=16010, cost=10005, rows=2000) (actual rows=700)
     Output: {count(*)(0)}[2]
     Aggregates: count(*)(0)
     Group by: lineitem.l_partkey[0], lineitem.l_suppkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
         Output: lineitem.l_partkey[1],lineitem.l_suppkey[2]

--- a/test/primitive/expect/aggregate_1.txt
+++ b/test/primitive/expect/aggregate_1.txt
@@ -1,7 +1,7 @@
 Total cost: 2
-PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=7996)
+PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=700)
     Output: {count(*)(0)}[2]
     Aggregates: count(*)(0)
     Group by: lineitem.l_partkey[0], lineitem.l_suppkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_partkey[1],lineitem.l_suppkey[2]

--- a/test/primitive/expect/aggregate_2.txt
+++ b/test/primitive/expect/aggregate_2.txt
@@ -1,7 +1,7 @@
-Total cost: 4
-PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=450)
+Total cost: 12012
+PhysicHashAgg  (inccost=12012, cost=6007, rows=1) (actual rows=450)
     Output: {count(*)(0)}[1]
     Aggregates: count(*)(0)
     Group by: lineitem.l_orderkey[0]/5
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
         Output: lineitem.l_orderkey[0]

--- a/test/primitive/expect/aggregate_2.txt
+++ b/test/primitive/expect/aggregate_2.txt
@@ -1,0 +1,7 @@
+Total cost: 4
+PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=4501)
+    Output: {count(*)(0)}[1]
+    Aggregates: count(*)(0)
+    Group by: lineitem.l_orderkey[0]/5
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_orderkey[0]

--- a/test/primitive/expect/aggregate_2.txt
+++ b/test/primitive/expect/aggregate_2.txt
@@ -1,7 +1,7 @@
 Total cost: 4
-PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=4501)
+PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=450)
     Output: {count(*)(0)}[1]
     Aggregates: count(*)(0)
     Group by: lineitem.l_orderkey[0]/5
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_orderkey[0]

--- a/test/primitive/expect/aggregate_3.txt
+++ b/test/primitive/expect/aggregate_3.txt
@@ -1,7 +1,7 @@
 Total cost: 4
-PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=38259)
+PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=3827)
     Output: {count(*)(0)}[1]
     Aggregates: count(*)(0)
     Group by: lineitem.l_orderkey[0]+lineitem.l_partkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1]

--- a/test/primitive/expect/aggregate_3.txt
+++ b/test/primitive/expect/aggregate_3.txt
@@ -1,7 +1,7 @@
-Total cost: 4
-PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=3827)
+Total cost: 12012
+PhysicHashAgg  (inccost=12012, cost=6007, rows=1) (actual rows=3827)
     Output: {count(*)(0)}[1]
     Aggregates: count(*)(0)
     Group by: lineitem.l_orderkey[0]+lineitem.l_partkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1]

--- a/test/primitive/expect/aggregate_3.txt
+++ b/test/primitive/expect/aggregate_3.txt
@@ -1,0 +1,7 @@
+Total cost: 4
+PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=38259)
+    Output: {count(*)(0)}[1]
+    Aggregates: count(*)(0)
+    Group by: lineitem.l_orderkey[0]+lineitem.l_partkey[1]
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_orderkey[0],lineitem.l_partkey[1]

--- a/test/primitive/expect/filterin_0.txt
+++ b/test/primitive/expect/filterin_0.txt
@@ -1,4 +1,4 @@
 Total cost: 1
-PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=34302)
+PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=1652)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
     Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP')

--- a/test/primitive/expect/filterin_0.txt
+++ b/test/primitive/expect/filterin_0.txt
@@ -1,4 +1,4 @@
 Total cost: 6005
-PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=1652)
+PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1651) (actual rows=1652)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
     Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP')

--- a/test/primitive/expect/filterin_0.txt
+++ b/test/primitive/expect/filterin_0.txt
@@ -1,4 +1,4 @@
-Total cost: 1
-PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=1652)
+Total cost: 6005
+PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=1652)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
     Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP')

--- a/test/primitive/expect/filterin_0.txt
+++ b/test/primitive/expect/filterin_0.txt
@@ -1,0 +1,4 @@
+Total cost: 1
+PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=34302)
+    Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
+    Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP')

--- a/test/primitive/expect/filterin_1.txt
+++ b/test/primitive/expect/filterin_1.txt
@@ -1,0 +1,4 @@
+Total cost: 1
+PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=429)
+    Output: customer.c_custkey[0],customer.c_name[1],customer.c_address[2],customer.c_nationkey[3],customer.c_phone[4],customer.c_acctbal[5],customer.c_mktsegment[6],customer.c_comment[7]
+    Filter: substring(customer.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )

--- a/test/primitive/expect/filterin_1.txt
+++ b/test/primitive/expect/filterin_1.txt
@@ -1,4 +1,4 @@
 Total cost: 1
-PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=429)
+PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=40)
     Output: customer.c_custkey[0],customer.c_name[1],customer.c_address[2],customer.c_nationkey[3],customer.c_phone[4],customer.c_acctbal[5],customer.c_mktsegment[6],customer.c_comment[7]
     Filter: substring(customer.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )

--- a/test/primitive/expect/filterin_1.txt
+++ b/test/primitive/expect/filterin_1.txt
@@ -1,4 +1,4 @@
-Total cost: 1
-PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=40)
+Total cost: 150
+PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=40)
     Output: customer.c_custkey[0],customer.c_name[1],customer.c_address[2],customer.c_nationkey[3],customer.c_phone[4],customer.c_acctbal[5],customer.c_mktsegment[6],customer.c_comment[7]
     Filter: substring(customer.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )

--- a/test/primitive/expect/filterlike_0.txt
+++ b/test/primitive/expect/filterlike_0.txt
@@ -1,0 +1,4 @@
+Total cost: 1
+PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=5814)
+    Output: part.p_partkey[0],part.p_name[1],part.p_mfgr[2],part.p_brand[3],part.p_type[4],part.p_size[5],part.p_container[6],part.p_retailprice[7],part.p_comment[8]
+    Filter: part.p_type[4]not like'MEDIUM POLISHED%'

--- a/test/primitive/expect/filterlike_0.txt
+++ b/test/primitive/expect/filterlike_0.txt
@@ -1,4 +1,4 @@
-Total cost: 1
-PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=193)
+Total cost: 200
+PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=193)
     Output: part.p_partkey[0],part.p_name[1],part.p_mfgr[2],part.p_brand[3],part.p_type[4],part.p_size[5],part.p_container[6],part.p_retailprice[7],part.p_comment[8]
     Filter: part.p_type[4]not like'MEDIUM POLISHED%'

--- a/test/primitive/expect/filterlike_0.txt
+++ b/test/primitive/expect/filterlike_0.txt
@@ -1,4 +1,4 @@
 Total cost: 1
-PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=5814)
+PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=193)
     Output: part.p_partkey[0],part.p_name[1],part.p_mfgr[2],part.p_brand[3],part.p_type[4],part.p_size[5],part.p_container[6],part.p_retailprice[7],part.p_comment[8]
     Filter: part.p_type[4]not like'MEDIUM POLISHED%'

--- a/test/primitive/expect/filterlike_1.txt
+++ b/test/primitive/expect/filterlike_1.txt
@@ -1,4 +1,4 @@
 Total cost: 1
-PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=1488)
+PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=57)
     Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]
     Filter: partsupp.ps_comment[4]like'%carefully regular%'

--- a/test/primitive/expect/filterlike_1.txt
+++ b/test/primitive/expect/filterlike_1.txt
@@ -1,4 +1,4 @@
-Total cost: 1
-PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=57)
+Total cost: 800
+PhysicScanTable partsupp (inccost=800, cost=800, rows=1) (actual rows=57)
     Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]
     Filter: partsupp.ps_comment[4]like'%carefully regular%'

--- a/test/primitive/expect/filterlike_1.txt
+++ b/test/primitive/expect/filterlike_1.txt
@@ -1,0 +1,4 @@
+Total cost: 1
+PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=1488)
+    Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]
+    Filter: partsupp.ps_comment[4]like'%carefully regular%'

--- a/test/primitive/expect/filtersamecol_0.txt
+++ b/test/primitive/expect/filtersamecol_0.txt
@@ -1,0 +1,4 @@
+Total cost: 1
+PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=570)
+    Output: orders.o_orderkey[0],orders.o_custkey[1],orders.o_orderstatus[2],orders.o_totalprice[3],orders.o_orderdate[4],orders.o_orderpriority[5],orders.o_clerk[6],orders.o_shippriority[7],orders.o_comment[8]
+    Filter: orders.o_orderdate[4]>='1993-07-01' and orders.o_orderdate[4]<'9/29/1993 12:00:00 AM'

--- a/test/primitive/expect/filtersamecol_0.txt
+++ b/test/primitive/expect/filtersamecol_0.txt
@@ -1,4 +1,4 @@
-Total cost: 1
-PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=48)
+Total cost: 1500
+PhysicScanTable orders (inccost=1500, cost=1500, rows=45) (actual rows=48)
     Output: orders.o_orderkey[0],orders.o_custkey[1],orders.o_orderstatus[2],orders.o_totalprice[3],orders.o_orderdate[4],orders.o_orderpriority[5],orders.o_clerk[6],orders.o_shippriority[7],orders.o_comment[8]
     Filter: orders.o_orderdate[4]>='1993-07-01' and orders.o_orderdate[4]<'9/29/1993 12:00:00 AM'

--- a/test/primitive/expect/filtersamecol_0.txt
+++ b/test/primitive/expect/filtersamecol_0.txt
@@ -1,4 +1,4 @@
 Total cost: 1
-PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=570)
+PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=48)
     Output: orders.o_orderkey[0],orders.o_custkey[1],orders.o_orderstatus[2],orders.o_totalprice[3],orders.o_orderdate[4],orders.o_orderpriority[5],orders.o_clerk[6],orders.o_shippriority[7],orders.o_comment[8]
     Filter: orders.o_orderdate[4]>='1993-07-01' and orders.o_orderdate[4]<'9/29/1993 12:00:00 AM'

--- a/test/primitive/expect/filtersamecol_1.txt
+++ b/test/primitive/expect/filtersamecol_1.txt
@@ -1,8 +1,4 @@
-Total cost: 6
-PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=8447)
-    Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],partsupp.ps_partkey[16],partsupp.ps_suppkey[17],partsupp.ps_availqty[18],partsupp.ps_supplycost[19],partsupp.ps_comment[20]
-    Filter: partsupp.ps_suppkey[17]=lineitem.l_suppkey[2] and partsupp.ps_partkey[16]=lineitem.l_partkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
-        Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
-    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
-        Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]
+Total cost: 6005
+PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1666) (actual rows=1666)
+    Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
+    Filter: lineitem.l_discount[6]>=0.05 and lineitem.l_discount[6]<=0.07

--- a/test/primitive/expect/filtersamecol_1.txt
+++ b/test/primitive/expect/filtersamecol_1.txt
@@ -1,0 +1,8 @@
+Total cost: 6
+PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=60175)
+    Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],partsupp.ps_partkey[16],partsupp.ps_suppkey[17],partsupp.ps_availqty[18],partsupp.ps_supplycost[19],partsupp.ps_comment[20]
+    Filter: partsupp.ps_suppkey[17]=lineitem.l_suppkey[2] and partsupp.ps_partkey[16]=lineitem.l_partkey[1]
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
+    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=8000)
+        Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]

--- a/test/primitive/expect/filtersamecol_1.txt
+++ b/test/primitive/expect/filtersamecol_1.txt
@@ -1,8 +1,8 @@
 Total cost: 6
-PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=60175)
+PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=8447)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],partsupp.ps_partkey[16],partsupp.ps_suppkey[17],partsupp.ps_availqty[18],partsupp.ps_supplycost[19],partsupp.ps_comment[20]
     Filter: partsupp.ps_suppkey[17]=lineitem.l_suppkey[2] and partsupp.ps_partkey[16]=lineitem.l_partkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
-    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=8000)
+    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
         Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]

--- a/test/primitive/expect/hashjoin_0.txt
+++ b/test/primitive/expect/hashjoin_0.txt
@@ -1,8 +1,8 @@
 Total cost: 6
-PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=60175)
+PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=6005)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],orders.o_orderkey[16],orders.o_custkey[17],orders.o_orderstatus[18],orders.o_totalprice[19],orders.o_orderdate[20],orders.o_orderpriority[21],orders.o_clerk[22],orders.o_shippriority[23],orders.o_comment[24]
     Filter: lineitem.l_orderkey[0]=orders.o_orderkey[16]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
-    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=15000)
+    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500)
         Output: orders.o_orderkey[0],orders.o_custkey[1],orders.o_orderstatus[2],orders.o_totalprice[3],orders.o_orderdate[4],orders.o_orderpriority[5],orders.o_clerk[6],orders.o_shippriority[7],orders.o_comment[8]

--- a/test/primitive/expect/hashjoin_0.txt
+++ b/test/primitive/expect/hashjoin_0.txt
@@ -1,0 +1,8 @@
+Total cost: 6
+PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=60175)
+    Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],orders.o_orderkey[16],orders.o_custkey[17],orders.o_orderstatus[18],orders.o_totalprice[19],orders.o_orderdate[20],orders.o_orderpriority[21],orders.o_clerk[22],orders.o_shippriority[23],orders.o_comment[24]
+    Filter: lineitem.l_orderkey[0]=orders.o_orderkey[16]
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
+    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=15000)
+        Output: orders.o_orderkey[0],orders.o_custkey[1],orders.o_orderstatus[2],orders.o_totalprice[3],orders.o_orderdate[4],orders.o_orderpriority[5],orders.o_clerk[6],orders.o_shippriority[7],orders.o_comment[8]

--- a/test/primitive/expect/hashjoin_0.txt
+++ b/test/primitive/expect/hashjoin_0.txt
@@ -1,8 +1,8 @@
-Total cost: 6
-PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=6005)
+Total cost: 27020
+PhysicHashJoin  (inccost=27020, cost=19515, rows=6005) (actual rows=6005)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],orders.o_orderkey[16],orders.o_custkey[17],orders.o_orderstatus[18],orders.o_totalprice[19],orders.o_orderdate[20],orders.o_orderpriority[21],orders.o_clerk[22],orders.o_shippriority[23],orders.o_comment[24]
     Filter: lineitem.l_orderkey[0]=orders.o_orderkey[16]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
-    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500)
+    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
         Output: orders.o_orderkey[0],orders.o_custkey[1],orders.o_orderstatus[2],orders.o_totalprice[3],orders.o_orderdate[4],orders.o_orderpriority[5],orders.o_clerk[6],orders.o_shippriority[7],orders.o_comment[8]

--- a/test/primitive/expect/hashjoin_1.txt
+++ b/test/primitive/expect/hashjoin_1.txt
@@ -1,0 +1,8 @@
+Total cost: 6
+PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=60175)
+    Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],partsupp.ps_partkey[16],partsupp.ps_suppkey[17],partsupp.ps_availqty[18],partsupp.ps_supplycost[19],partsupp.ps_comment[20]
+    Filter: partsupp.ps_suppkey[17]=lineitem.l_suppkey[2] and partsupp.ps_partkey[16]=lineitem.l_partkey[1]
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+        Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
+    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=8000)
+        Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]

--- a/test/primitive/expect/hashjoin_1.txt
+++ b/test/primitive/expect/hashjoin_1.txt
@@ -1,8 +1,8 @@
-Total cost: 6
-PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=8447)
+Total cost: 22017
+PhysicHashJoin  (inccost=22017, cost=15212, rows=2402) (actual rows=8447)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],partsupp.ps_partkey[16],partsupp.ps_suppkey[17],partsupp.ps_availqty[18],partsupp.ps_supplycost[19],partsupp.ps_comment[20]
     Filter: partsupp.ps_suppkey[17]=lineitem.l_suppkey[2] and partsupp.ps_partkey[16]=lineitem.l_partkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
-    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
+    -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
         Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]

--- a/test/primitive/expect/hashjoin_1.txt
+++ b/test/primitive/expect/hashjoin_1.txt
@@ -1,8 +1,8 @@
 Total cost: 6
-PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=60175)
+PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=8447)
     Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15],partsupp.ps_partkey[16],partsupp.ps_suppkey[17],partsupp.ps_availqty[18],partsupp.ps_supplycost[19],partsupp.ps_comment[20]
     Filter: partsupp.ps_suppkey[17]=lineitem.l_suppkey[2] and partsupp.ps_partkey[16]=lineitem.l_partkey[1]
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=60175)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
         Output: lineitem.l_orderkey[0],lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_linenumber[3],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_tax[7],lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_shipdate[10],lineitem.l_commitdate[11],lineitem.l_receiptdate[12],lineitem.l_shipinstruct[13],lineitem.l_shipmode[14],lineitem.l_comment[15]
-    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=8000)
+    -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
         Output: partsupp.ps_partkey[0],partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_comment[4]

--- a/test/primitive/expect/q01.txt
+++ b/test/primitive/expect/q01.txt
@@ -1,0 +1,11 @@
+Total cost: 11912.35
+PhysicOrder  (inccost=11912.35, cost=11.35, rows=6) (actual rows=4)
+    Output: lineitem.l_returnflag[0],lineitem.l_linestatus[1],{sum(lineitem.l_quantity)}[2],{sum(lineitem.l_extendedprice)}[3],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[4],{sum(lineitem.l_extendedprice*1-lineitem.l_discount*1+lineitem.l_tax)}[5],{avg(lineitem.l_quantity)}[6],{avg(lineitem.l_extendedprice)}[7],{avg(lineitem.l_discount)}[8],{count(*)(0)}[9]
+    Order by: lineitem.l_returnflag[0], lineitem.l_linestatus[1]
+    -> PhysicHashAgg  (inccost=11901, cost=5896, rows=6) (actual rows=4)
+        Output: {lineitem.l_returnflag}[0],{lineitem.l_linestatus}[1],{sum(lineitem.l_quantity)}[2],{sum(lineitem.l_extendedprice)}[3],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[4],{sum(lineitem.l_extendedprice*1-lineitem.l_discount*1+lineitem.l_tax)}[5],{avg(lineitem.l_quantity)}[6],{avg(lineitem.l_extendedprice)}[7],{avg(lineitem.l_discount)}[8],{count(*)(0)}[9]
+        Aggregates: sum(lineitem.l_quantity[2]), sum(lineitem.l_extendedprice[3]), sum(lineitem.l_extendedprice[3]*1-lineitem.l_discount[7]), sum(lineitem.l_extendedprice[3]*1-lineitem.l_discount[7]*1+lineitem.l_tax[10]), avg(lineitem.l_quantity[2]), avg(lineitem.l_extendedprice[3]), avg(lineitem.l_discount[7]), count(*)(0)
+        Group by: lineitem.l_returnflag[0], lineitem.l_linestatus[1]
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5884) (actual rows=5914)
+            Output: lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],1-lineitem.l_discount[6],1,lineitem.l_discount[6],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6]*1+lineitem.l_tax[7],1+lineitem.l_tax[7],lineitem.l_tax[7]
+            Filter: lineitem.l_shipdate[10]<='9/2/1998 12:00:00 AM'

--- a/test/primitive/expect/q01.txt
+++ b/test/primitive/expect/q01.txt
@@ -1,11 +1,11 @@
-Total cost: NaN
-PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=4)
+Total cost: 11912.35
+PhysicOrder  (inccost=11912.35, cost=11.35, rows=6) (actual rows=4)
     Output: lineitem.l_returnflag[0],lineitem.l_linestatus[1],{sum(lineitem.l_quantity)}[2],{sum(lineitem.l_extendedprice)}[3],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[4],{sum(lineitem.l_extendedprice*1-lineitem.l_discount*1+lineitem.l_tax)}[5],{avg(lineitem.l_quantity)}[6],{avg(lineitem.l_extendedprice)}[7],{avg(lineitem.l_discount)}[8],{count(*)(0)}[9]
     Order by: lineitem.l_returnflag[0], lineitem.l_linestatus[1]
-    -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=4)
+    -> PhysicHashAgg  (inccost=11901, cost=5896, rows=6) (actual rows=4)
         Output: {lineitem.l_returnflag}[0],{lineitem.l_linestatus}[1],{sum(lineitem.l_quantity)}[2],{sum(lineitem.l_extendedprice)}[3],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[4],{sum(lineitem.l_extendedprice*1-lineitem.l_discount*1+lineitem.l_tax)}[5],{avg(lineitem.l_quantity)}[6],{avg(lineitem.l_extendedprice)}[7],{avg(lineitem.l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(lineitem.l_quantity[2]), sum(lineitem.l_extendedprice[3]), sum(lineitem.l_extendedprice[3]*1-lineitem.l_discount[7]), sum(lineitem.l_extendedprice[3]*1-lineitem.l_discount[7]*1+lineitem.l_tax[10]), avg(lineitem.l_quantity[2]), avg(lineitem.l_extendedprice[3]), avg(lineitem.l_discount[7]), count(*)(0)
         Group by: lineitem.l_returnflag[0], lineitem.l_linestatus[1]
-        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=5914)
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5884) (actual rows=5914)
             Output: lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],1-lineitem.l_discount[6],1,lineitem.l_discount[6],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6]*1+lineitem.l_tax[7],1+lineitem.l_tax[7],lineitem.l_tax[7]
             Filter: lineitem.l_shipdate[10]<='9/2/1998 12:00:00 AM'

--- a/test/primitive/expect/q01.txt
+++ b/test/primitive/expect/q01.txt
@@ -1,11 +1,11 @@
-Total cost: 11912.35
-PhysicOrder  (inccost=11912.35, cost=11.35, rows=6) (actual rows=4)
+Total cost: NaN
+PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=4)
     Output: lineitem.l_returnflag[0],lineitem.l_linestatus[1],{sum(lineitem.l_quantity)}[2],{sum(lineitem.l_extendedprice)}[3],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[4],{sum(lineitem.l_extendedprice*1-lineitem.l_discount*1+lineitem.l_tax)}[5],{avg(lineitem.l_quantity)}[6],{avg(lineitem.l_extendedprice)}[7],{avg(lineitem.l_discount)}[8],{count(*)(0)}[9]
     Order by: lineitem.l_returnflag[0], lineitem.l_linestatus[1]
-    -> PhysicHashAgg  (inccost=11901, cost=5896, rows=6) (actual rows=4)
+    -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=4)
         Output: {lineitem.l_returnflag}[0],{lineitem.l_linestatus}[1],{sum(lineitem.l_quantity)}[2],{sum(lineitem.l_extendedprice)}[3],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[4],{sum(lineitem.l_extendedprice*1-lineitem.l_discount*1+lineitem.l_tax)}[5],{avg(lineitem.l_quantity)}[6],{avg(lineitem.l_extendedprice)}[7],{avg(lineitem.l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(lineitem.l_quantity[2]), sum(lineitem.l_extendedprice[3]), sum(lineitem.l_extendedprice[3]*1-lineitem.l_discount[7]), sum(lineitem.l_extendedprice[3]*1-lineitem.l_discount[7]*1+lineitem.l_tax[10]), avg(lineitem.l_quantity[2]), avg(lineitem.l_extendedprice[3]), avg(lineitem.l_discount[7]), count(*)(0)
         Group by: lineitem.l_returnflag[0], lineitem.l_linestatus[1]
-        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5884) (actual rows=5914)
+        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=5914)
             Output: lineitem.l_returnflag[8],lineitem.l_linestatus[9],lineitem.l_quantity[4],lineitem.l_extendedprice[5],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],1-lineitem.l_discount[6],1,lineitem.l_discount[6],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6]*1+lineitem.l_tax[7],1+lineitem.l_tax[7],lineitem.l_tax[7]
             Filter: lineitem.l_shipdate[10]<='9/2/1998 12:00:00 AM'

--- a/test/primitive/expect/q02.txt
+++ b/test/primitive/expect/q02.txt
@@ -1,0 +1,58 @@
+Total cost: 20573.58
+PhysicLimit (100) (inccost=20573.58, cost=100, rows=100) (actual rows=0)
+    Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
+    -> PhysicOrder  (inccost=20473.58, cost=1.58, rows=2) (actual rows=0)
+        Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
+        Order by: supplier.s_acctbal[0], nation.n_name[2], supplier.s_name[1], part.p_partkey[3]
+        -> PhysicFilter  (inccost=20472, cost=2, rows=2) (actual rows=0)
+            Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
+            Filter: partsupp.ps_supplycost[8]={min(partsupp__1.ps_supplycost)}[9]
+            -> PhysicNLJoin Left (inccost=20470, cost=2520, rows=2) (actual rows=0)
+                Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8],{min(partsupp__1.ps_supplycost)}[9]
+                Filter: part.p_partkey[3]=partsupp__1.ps_partkey[10]
+                -> PhysicNLJoin  (inccost=14184, cost=4994, rows=2) (actual rows=0)
+                    Output: supplier.s_acctbal[2],supplier.s_name[3],nation.n_name[4],part.p_partkey[0],part.p_mfgr[1],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8]
+                    Filter: part.p_partkey[0]=partsupp.ps_partkey[9]
+                    -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                        Output: part.p_partkey[0],part.p_mfgr[2]
+                        Filter: part.p_size[5]=15 and part.p_type[4]like'%BRASS'
+                    -> PhysicHashJoin  (inccost=8990, cost=2668, rows=444) (actual rows=0)
+                        Output: supplier.s_acctbal[1],supplier.s_name[2],nation.n_name[3],supplier.s_address[4],supplier.s_phone[5],supplier.s_comment[6],partsupp.ps_supplycost[7],partsupp.ps_partkey[8]
+                        Filter: nation.n_regionkey[9]=region.r_regionkey[0]
+                        -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                            Output: region.r_regionkey[0]
+                            Filter: region.r_name[1]='EUROPE'
+                        -> PhysicHashJoin  (inccost=6317, cost=3072, rows=2222) (actual rows=0)
+                            Output: supplier.s_acctbal[3],supplier.s_name[4],nation.n_name[0],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8],partsupp.ps_partkey[9],nation.n_regionkey[1]
+                            Filter: supplier.s_nationkey[10]=nation.n_nationkey[2]
+                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                                Output: nation.n_name[1],nation.n_regionkey[2],nation.n_nationkey[0]
+                            -> PhysicHashJoin  (inccost=3220, cost=2410, rows=800) (actual rows=0)
+                                Output: supplier.s_acctbal[3],supplier.s_name[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[0],partsupp.ps_partkey[1],supplier.s_nationkey[8]
+                                Filter: supplier.s_suppkey[9]=partsupp.ps_suppkey[2]
+                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                                    Output: partsupp.ps_supplycost[3],partsupp.ps_partkey[0],partsupp.ps_suppkey[1]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                    Output: supplier.s_acctbal[5],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[4],supplier.s_comment[6],supplier.s_nationkey[3],supplier.s_suppkey[0]
+                -> PhysicHashAgg  (inccost=3766, cost=800, rows=200) (actual rows=0)
+                    Output: {min(partsupp__1.ps_supplycost)}[1],{partsupp__1.ps_partkey}[0]
+                    Aggregates: min(partsupp__1.ps_supplycost[1])
+                    Group by: partsupp__1.ps_partkey[0]
+                    -> PhysicHashJoin  (inccost=2966, cost=2005, rows=400) (actual rows=0)
+                        Output: partsupp__1.ps_partkey[0],partsupp__1.ps_supplycost[1]
+                        Filter: supplier__1.s_suppkey[3]=partsupp__1.ps_suppkey[2]
+                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                            Output: partsupp__1.ps_partkey[0],partsupp__1.ps_supplycost[3],partsupp__1.ps_suppkey[1]
+                        -> PhysicHashJoin  (inccost=161, cost=34, rows=5) (actual rows=0)
+                            Output: supplier__1.s_suppkey[1]
+                            Filter: nation__1.n_regionkey[2]=region__1.r_regionkey[0]
+                            -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=0)
+                                Output: region__1.r_regionkey[0]
+                                Filter: region__1.r_name[1]='EUROPE'
+                            -> PhysicHashJoin  (inccost=122, cost=87, rows=27) (actual rows=0)
+                                Output: supplier__1.s_suppkey[2],nation__1.n_regionkey[0]
+                                Filter: supplier__1.s_nationkey[3]=nation__1.n_nationkey[1]
+                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                                    Output: nation__1.n_regionkey[2],nation__1.n_nationkey[0]
+                                -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                                    Output: supplier__1.s_suppkey[0],supplier__1.s_nationkey[3]

--- a/test/primitive/expect/q02.txt
+++ b/test/primitive/expect/q02.txt
@@ -1,58 +1,58 @@
-Total cost: 366.1
-PhysicLimit (100) (inccost=366.1, cost=100, rows=100) (actual rows=0)
+Total cost: 20573.58
+PhysicLimit (100) (inccost=20573.58, cost=100, rows=100) (actual rows=0)
     Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
-    -> PhysicOrder  (inccost=266.1, cost=0.1, rows=1) (actual rows=0)
+    -> PhysicOrder  (inccost=20473.58, cost=1.58, rows=2) (actual rows=0)
         Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
         Order by: supplier.s_acctbal[0], nation.n_name[2], supplier.s_name[1], part.p_partkey[3]
-        -> PhysicFilter  (inccost=266, cost=1, rows=1) (actual rows=0)
+        -> PhysicFilter  (inccost=20472, cost=2, rows=2) (actual rows=0)
             Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
             Filter: partsupp.ps_supplycost[8]={min(partsupp__1.ps_supplycost)}[9]
-            -> PhysicNLJoin Left (inccost=265, cost=110, rows=1) (actual rows=0)
+            -> PhysicNLJoin Left (inccost=20470, cost=2520, rows=2) (actual rows=0)
                 Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8],{min(partsupp__1.ps_supplycost)}[9]
                 Filter: part.p_partkey[3]=partsupp__1.ps_partkey[10]
-                -> PhysicNLJoin  (inccost=138, cost=121, rows=1) (actual rows=0)
+                -> PhysicNLJoin  (inccost=14184, cost=4994, rows=2) (actual rows=0)
                     Output: supplier.s_acctbal[2],supplier.s_name[3],nation.n_name[4],part.p_partkey[0],part.p_mfgr[1],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8]
                     Filter: part.p_partkey[0]=partsupp.ps_partkey[9]
-                    -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=0)
+                    -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
                         Output: part.p_partkey[0],part.p_mfgr[2]
                         Filter: part.p_size[5]=15 and part.p_type[4]like'%BRASS'
-                    -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=8990, cost=2668, rows=444) (actual rows=0)
                         Output: supplier.s_acctbal[1],supplier.s_name[2],nation.n_name[3],supplier.s_address[4],supplier.s_phone[5],supplier.s_comment[6],partsupp.ps_supplycost[7],partsupp.ps_partkey[8]
                         Filter: nation.n_regionkey[9]=region.r_regionkey[0]
-                        -> PhysicScanTable region (inccost=1, cost=1, rows=1) (actual rows=0)
+                        -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
                             Output: region.r_regionkey[0]
                             Filter: region.r_name[1]='EUROPE'
-                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=6317, cost=3072, rows=2222) (actual rows=0)
                             Output: supplier.s_acctbal[3],supplier.s_name[4],nation.n_name[0],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8],partsupp.ps_partkey[9],nation.n_regionkey[1]
                             Filter: supplier.s_nationkey[10]=nation.n_nationkey[2]
-                            -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=0)
+                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
                                 Output: nation.n_name[1],nation.n_regionkey[2],nation.n_nationkey[0]
-                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=3220, cost=2410, rows=800) (actual rows=0)
                                 Output: supplier.s_acctbal[3],supplier.s_name[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[0],partsupp.ps_partkey[1],supplier.s_nationkey[8]
                                 Filter: supplier.s_suppkey[9]=partsupp.ps_suppkey[2]
-                                -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=0)
+                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                                     Output: partsupp.ps_supplycost[3],partsupp.ps_partkey[0],partsupp.ps_suppkey[1]
-                                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=0)
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
                                     Output: supplier.s_acctbal[5],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[4],supplier.s_comment[6],supplier.s_nationkey[3],supplier.s_suppkey[0]
-                -> PhysicHashAgg  (inccost=17, cost=1, rows=0) (actual rows=0)
+                -> PhysicHashAgg  (inccost=3766, cost=800, rows=200) (actual rows=0)
                     Output: {min(partsupp__1.ps_supplycost)}[1],{partsupp__1.ps_partkey}[0]
                     Aggregates: min(partsupp__1.ps_supplycost[1])
                     Group by: partsupp__1.ps_partkey[0]
-                    -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=2966, cost=2005, rows=400) (actual rows=0)
                         Output: partsupp__1.ps_partkey[0],partsupp__1.ps_supplycost[1]
                         Filter: supplier__1.s_suppkey[3]=partsupp__1.ps_suppkey[2]
-                        -> PhysicScanTable partsupp as partsupp__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
                             Output: partsupp__1.ps_partkey[0],partsupp__1.ps_supplycost[3],partsupp__1.ps_suppkey[1]
-                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=161, cost=34, rows=5) (actual rows=0)
                             Output: supplier__1.s_suppkey[1]
                             Filter: nation__1.n_regionkey[2]=region__1.r_regionkey[0]
-                            -> PhysicScanTable region as region__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                            -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=0)
                                 Output: region__1.r_regionkey[0]
                                 Filter: region__1.r_name[1]='EUROPE'
-                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=122, cost=87, rows=27) (actual rows=0)
                                 Output: supplier__1.s_suppkey[2],nation__1.n_regionkey[0]
                                 Filter: supplier__1.s_nationkey[3]=nation__1.n_nationkey[1]
-                                -> PhysicScanTable nation as nation__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=0)
                                     Output: nation__1.n_regionkey[2],nation__1.n_nationkey[0]
-                                -> PhysicScanTable supplier as supplier__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                                -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
                                     Output: supplier__1.s_suppkey[0],supplier__1.s_nationkey[3]

--- a/test/primitive/expect/q02.txt
+++ b/test/primitive/expect/q02.txt
@@ -1,58 +1,58 @@
-Total cost: 20573.58
-PhysicLimit (100) (inccost=20573.58, cost=100, rows=100) (actual rows=0)
+Total cost: 366.1
+PhysicLimit (100) (inccost=366.1, cost=100, rows=100) (actual rows=0)
     Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
-    -> PhysicOrder  (inccost=20473.58, cost=1.58, rows=2) (actual rows=0)
+    -> PhysicOrder  (inccost=266.1, cost=0.1, rows=1) (actual rows=0)
         Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
         Order by: supplier.s_acctbal[0], nation.n_name[2], supplier.s_name[1], part.p_partkey[3]
-        -> PhysicFilter  (inccost=20472, cost=2, rows=2) (actual rows=0)
+        -> PhysicFilter  (inccost=266, cost=1, rows=1) (actual rows=0)
             Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7]
             Filter: partsupp.ps_supplycost[8]={min(partsupp__1.ps_supplycost)}[9]
-            -> PhysicNLJoin Left (inccost=20470, cost=2520, rows=2) (actual rows=0)
+            -> PhysicNLJoin Left (inccost=265, cost=110, rows=1) (actual rows=0)
                 Output: supplier.s_acctbal[0],supplier.s_name[1],nation.n_name[2],part.p_partkey[3],part.p_mfgr[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8],{min(partsupp__1.ps_supplycost)}[9]
                 Filter: part.p_partkey[3]=partsupp__1.ps_partkey[10]
-                -> PhysicNLJoin  (inccost=14184, cost=4994, rows=2) (actual rows=0)
+                -> PhysicNLJoin  (inccost=138, cost=121, rows=1) (actual rows=0)
                     Output: supplier.s_acctbal[2],supplier.s_name[3],nation.n_name[4],part.p_partkey[0],part.p_mfgr[1],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8]
                     Filter: part.p_partkey[0]=partsupp.ps_partkey[9]
-                    -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                    -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=0)
                         Output: part.p_partkey[0],part.p_mfgr[2]
                         Filter: part.p_size[5]=15 and part.p_type[4]like'%BRASS'
-                    -> PhysicHashJoin  (inccost=8990, cost=2668, rows=444) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=0)
                         Output: supplier.s_acctbal[1],supplier.s_name[2],nation.n_name[3],supplier.s_address[4],supplier.s_phone[5],supplier.s_comment[6],partsupp.ps_supplycost[7],partsupp.ps_partkey[8]
                         Filter: nation.n_regionkey[9]=region.r_regionkey[0]
-                        -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                        -> PhysicScanTable region (inccost=1, cost=1, rows=1) (actual rows=0)
                             Output: region.r_regionkey[0]
                             Filter: region.r_name[1]='EUROPE'
-                        -> PhysicHashJoin  (inccost=6317, cost=3072, rows=2222) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
                             Output: supplier.s_acctbal[3],supplier.s_name[4],nation.n_name[0],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[8],partsupp.ps_partkey[9],nation.n_regionkey[1]
                             Filter: supplier.s_nationkey[10]=nation.n_nationkey[2]
-                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                            -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=0)
                                 Output: nation.n_name[1],nation.n_regionkey[2],nation.n_nationkey[0]
-                            -> PhysicHashJoin  (inccost=3220, cost=2410, rows=800) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
                                 Output: supplier.s_acctbal[3],supplier.s_name[4],supplier.s_address[5],supplier.s_phone[6],supplier.s_comment[7],partsupp.ps_supplycost[0],partsupp.ps_partkey[1],supplier.s_nationkey[8]
                                 Filter: supplier.s_suppkey[9]=partsupp.ps_suppkey[2]
-                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                                -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=0)
                                     Output: partsupp.ps_supplycost[3],partsupp.ps_partkey[0],partsupp.ps_suppkey[1]
-                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=0)
                                     Output: supplier.s_acctbal[5],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[4],supplier.s_comment[6],supplier.s_nationkey[3],supplier.s_suppkey[0]
-                -> PhysicHashAgg  (inccost=3766, cost=800, rows=200) (actual rows=0)
+                -> PhysicHashAgg  (inccost=17, cost=1, rows=0) (actual rows=0)
                     Output: {min(partsupp__1.ps_supplycost)}[1],{partsupp__1.ps_partkey}[0]
                     Aggregates: min(partsupp__1.ps_supplycost[1])
                     Group by: partsupp__1.ps_partkey[0]
-                    -> PhysicHashJoin  (inccost=2966, cost=2005, rows=400) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=0)
                         Output: partsupp__1.ps_partkey[0],partsupp__1.ps_supplycost[1]
                         Filter: supplier__1.s_suppkey[3]=partsupp__1.ps_suppkey[2]
-                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                        -> PhysicScanTable partsupp as partsupp__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                             Output: partsupp__1.ps_partkey[0],partsupp__1.ps_supplycost[3],partsupp__1.ps_suppkey[1]
-                        -> PhysicHashJoin  (inccost=161, cost=34, rows=5) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
                             Output: supplier__1.s_suppkey[1]
                             Filter: nation__1.n_regionkey[2]=region__1.r_regionkey[0]
-                            -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=0)
+                            -> PhysicScanTable region as region__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                                 Output: region__1.r_regionkey[0]
                                 Filter: region__1.r_name[1]='EUROPE'
-                            -> PhysicHashJoin  (inccost=122, cost=87, rows=27) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
                                 Output: supplier__1.s_suppkey[2],nation__1.n_regionkey[0]
                                 Filter: supplier__1.s_nationkey[3]=nation__1.n_nationkey[1]
-                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                                -> PhysicScanTable nation as nation__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                                     Output: nation__1.n_regionkey[2],nation__1.n_nationkey[0]
-                                -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                                -> PhysicScanTable supplier as supplier__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                                     Output: supplier__1.s_suppkey[0],supplier__1.s_nationkey[3]

--- a/test/primitive/expect/q03.txt
+++ b/test/primitive/expect/q03.txt
@@ -1,25 +1,25 @@
-Total cost: 22910.13
-PhysicLimit (10) (inccost=22910.13, cost=10, rows=10) (actual rows=8)
+Total cost: NaN
+PhysicLimit (10) (inccost=NaN, cost=10, rows=10) (actual rows=8)
     Output: lineitem.l_orderkey[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1],orders.o_orderdate[2],orders.o_shippriority[3]
-    -> PhysicOrder  (inccost=22900.13, cost=2859.13, rows=459) (actual rows=8)
+    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=8)
         Output: lineitem.l_orderkey[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1],orders.o_orderdate[2],orders.o_shippriority[3]
         Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1], orders.o_orderdate[2]
-        -> PhysicHashAgg  (inccost=20041, cost=1377, rows=459) (actual rows=8)
+        -> PhysicHashAgg  (inccost=12, cost=1, rows=0) (actual rows=8)
             Output: {lineitem.l_orderkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[3],{orders.o_orderdate}[1],{orders.o_shippriority}[2]
             Aggregates: sum(lineitem.l_extendedprice[4]*1-lineitem.l_discount[7])
             Group by: lineitem.l_orderkey[0], orders.o_orderdate[1], orders.o_shippriority[2]
-            -> PhysicHashJoin  (inccost=18664, cost=2101, rows=459) (actual rows=14)
+            -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=14)
                 Output: lineitem.l_orderkey[2],orders.o_orderdate[3],orders.o_shippriority[4],{lineitem.l_extendedprice*1-lineitem.l_discount}[5],lineitem.l_extendedprice[6],{1-lineitem.l_discount}[7],{1}[0],lineitem.l_discount[8]
                 Filter: customer.c_custkey[1]=orders.o_custkey[9]
-                -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=29)
+                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=29)
                     Output: 1,customer.c_custkey[0]
                     Filter: customer.c_mktsegment[6]='BUILDING'
-                -> PhysicHashJoin  (inccost=16413, cost=8908, rows=1584) (actual rows=133)
+                -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=133)
                     Output: lineitem.l_orderkey[0],orders.o_orderdate[5],orders.o_shippriority[6],{lineitem.l_extendedprice*1-lineitem.l_discount}[1],lineitem.l_extendedprice[2],{1-lineitem.l_discount}[3],lineitem.l_discount[4],orders.o_custkey[7]
                     Filter: lineitem.l_orderkey[0]=orders.o_orderkey[8]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3302) (actual rows=3252)
+                    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=3252)
                         Output: lineitem.l_orderkey[0],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6]
                         Filter: lineitem.l_shipdate[10]>'1995-03-15'
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=720) (actual rows=726)
+                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=726)
                         Output: orders.o_orderdate[4],orders.o_shippriority[7],orders.o_custkey[1],orders.o_orderkey[0]
                         Filter: orders.o_orderdate[4]<'1995-03-15'

--- a/test/primitive/expect/q03.txt
+++ b/test/primitive/expect/q03.txt
@@ -1,25 +1,25 @@
-Total cost: NaN
-PhysicLimit (10) (inccost=NaN, cost=10, rows=10) (actual rows=8)
+Total cost: 22910.13
+PhysicLimit (10) (inccost=22910.13, cost=10, rows=10) (actual rows=8)
     Output: lineitem.l_orderkey[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1],orders.o_orderdate[2],orders.o_shippriority[3]
-    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=8)
+    -> PhysicOrder  (inccost=22900.13, cost=2859.13, rows=459) (actual rows=8)
         Output: lineitem.l_orderkey[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1],orders.o_orderdate[2],orders.o_shippriority[3]
         Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1], orders.o_orderdate[2]
-        -> PhysicHashAgg  (inccost=12, cost=1, rows=0) (actual rows=8)
+        -> PhysicHashAgg  (inccost=20041, cost=1377, rows=459) (actual rows=8)
             Output: {lineitem.l_orderkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[3],{orders.o_orderdate}[1],{orders.o_shippriority}[2]
             Aggregates: sum(lineitem.l_extendedprice[4]*1-lineitem.l_discount[7])
             Group by: lineitem.l_orderkey[0], orders.o_orderdate[1], orders.o_shippriority[2]
-            -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=14)
+            -> PhysicHashJoin  (inccost=18664, cost=2101, rows=459) (actual rows=14)
                 Output: lineitem.l_orderkey[2],orders.o_orderdate[3],orders.o_shippriority[4],{lineitem.l_extendedprice*1-lineitem.l_discount}[5],lineitem.l_extendedprice[6],{1-lineitem.l_discount}[7],{1}[0],lineitem.l_discount[8]
                 Filter: customer.c_custkey[1]=orders.o_custkey[9]
-                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=29)
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=29)
                     Output: 1,customer.c_custkey[0]
                     Filter: customer.c_mktsegment[6]='BUILDING'
-                -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=133)
+                -> PhysicHashJoin  (inccost=16413, cost=8908, rows=1584) (actual rows=133)
                     Output: lineitem.l_orderkey[0],orders.o_orderdate[5],orders.o_shippriority[6],{lineitem.l_extendedprice*1-lineitem.l_discount}[1],lineitem.l_extendedprice[2],{1-lineitem.l_discount}[3],lineitem.l_discount[4],orders.o_custkey[7]
                     Filter: lineitem.l_orderkey[0]=orders.o_orderkey[8]
-                    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=3252)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3302) (actual rows=3252)
                         Output: lineitem.l_orderkey[0],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6]
                         Filter: lineitem.l_shipdate[10]>'1995-03-15'
-                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=726)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=720) (actual rows=726)
                         Output: orders.o_orderdate[4],orders.o_shippriority[7],orders.o_custkey[1],orders.o_orderkey[0]
                         Filter: orders.o_orderdate[4]<'1995-03-15'

--- a/test/primitive/expect/q03.txt
+++ b/test/primitive/expect/q03.txt
@@ -1,0 +1,25 @@
+Total cost: 22910.13
+PhysicLimit (10) (inccost=22910.13, cost=10, rows=10) (actual rows=8)
+    Output: lineitem.l_orderkey[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1],orders.o_orderdate[2],orders.o_shippriority[3]
+    -> PhysicOrder  (inccost=22900.13, cost=2859.13, rows=459) (actual rows=8)
+        Output: lineitem.l_orderkey[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1],orders.o_orderdate[2],orders.o_shippriority[3]
+        Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1], orders.o_orderdate[2]
+        -> PhysicHashAgg  (inccost=20041, cost=1377, rows=459) (actual rows=8)
+            Output: {lineitem.l_orderkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[3],{orders.o_orderdate}[1],{orders.o_shippriority}[2]
+            Aggregates: sum(lineitem.l_extendedprice[4]*1-lineitem.l_discount[7])
+            Group by: lineitem.l_orderkey[0], orders.o_orderdate[1], orders.o_shippriority[2]
+            -> PhysicHashJoin  (inccost=18664, cost=2101, rows=459) (actual rows=14)
+                Output: lineitem.l_orderkey[2],orders.o_orderdate[3],orders.o_shippriority[4],{lineitem.l_extendedprice*1-lineitem.l_discount}[5],lineitem.l_extendedprice[6],{1-lineitem.l_discount}[7],{1}[0],lineitem.l_discount[8]
+                Filter: customer.c_custkey[1]=orders.o_custkey[9]
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=29)
+                    Output: 1,customer.c_custkey[0]
+                    Filter: customer.c_mktsegment[6]='BUILDING'
+                -> PhysicHashJoin  (inccost=16413, cost=8908, rows=1584) (actual rows=133)
+                    Output: lineitem.l_orderkey[0],orders.o_orderdate[5],orders.o_shippriority[6],{lineitem.l_extendedprice*1-lineitem.l_discount}[1],lineitem.l_extendedprice[2],{1-lineitem.l_discount}[3],lineitem.l_discount[4],orders.o_custkey[7]
+                    Filter: lineitem.l_orderkey[0]=orders.o_orderkey[8]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3302) (actual rows=3252)
+                        Output: lineitem.l_orderkey[0],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6]
+                        Filter: lineitem.l_shipdate[10]>'1995-03-15'
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=720) (actual rows=726)
+                        Output: orders.o_orderdate[4],orders.o_shippriority[7],orders.o_custkey[1],orders.o_orderkey[0]
+                        Filter: orders.o_orderdate[4]<'1995-03-15'

--- a/test/primitive/expect/q04.txt
+++ b/test/primitive/expect/q04.txt
@@ -1,20 +1,20 @@
-Total cost: NaN
-PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=5)
+Total cost: 278108.54
+PhysicOrder  (inccost=278108.54, cost=8.54, rows=5) (actual rows=5)
     Output: orders.o_orderpriority[0],{count(*)(0)}[1]
     Order by: orders.o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=5, cost=1, rows=0) (actual rows=5)
+    -> PhysicHashAgg  (inccost=278100, cost=190, rows=5) (actual rows=5)
         Output: {orders.o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: orders.o_orderpriority[0]
-        -> PhysicFilter  (inccost=4, cost=1, rows=1) (actual rows=44)
+        -> PhysicFilter  (inccost=277910, cost=180, rows=180) (actual rows=44)
             Output: orders.o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=3, cost=1, rows=1) (actual rows=48)
+            -> PhysicMarkJoin Left (inccost=277730, cost=270225, rows=180) (actual rows=48)
                 Output: #marker,orders.o_orderpriority[0]
                 Filter: lineitem.l_orderkey[2]=orders.o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=48)
+                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=45) (actual rows=48)
                     Output: orders.o_orderpriority[5],orders.o_orderkey[0]
                     Filter: orders.o_orderdate[4]>='1993-07-01' and orders.o_orderdate[4]<'9/29/1993 12:00:00 AM'
-                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=3752, loops=48)
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=3752, loops=48)
                     Output: lineitem.l_orderkey[0]
                     Filter: lineitem.l_commitdate[11]<lineitem.l_receiptdate[12]

--- a/test/primitive/expect/q04.txt
+++ b/test/primitive/expect/q04.txt
@@ -1,20 +1,20 @@
-Total cost: 1811425.54
-PhysicOrder  (inccost=1811425.54, cost=8.54, rows=5) (actual rows=5)
+Total cost: NaN
+PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=5)
     Output: orders.o_orderpriority[0],{count(*)(0)}[1]
     Order by: orders.o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=1811417, cost=1211, rows=5) (actual rows=5)
+    -> PhysicHashAgg  (inccost=5, cost=1, rows=0) (actual rows=5)
         Output: {orders.o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: orders.o_orderpriority[0]
-        -> PhysicFilter  (inccost=1810206, cost=1201, rows=1201) (actual rows=44)
+        -> PhysicFilter  (inccost=4, cost=1, rows=1) (actual rows=44)
             Output: orders.o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=1809005, cost=1801500, rows=1201) (actual rows=48)
+            -> PhysicMarkJoin Left (inccost=3, cost=1, rows=1) (actual rows=48)
                 Output: #marker,orders.o_orderpriority[0]
                 Filter: lineitem.l_orderkey[2]=orders.o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=300) (actual rows=48)
+                -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=48)
                     Output: orders.o_orderpriority[5],orders.o_orderkey[0]
                     Filter: orders.o_orderdate[4]>='1993-07-01' and orders.o_orderdate[4]<'9/29/1993 12:00:00 AM'
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=3752, loops=48)
+                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=3752, loops=48)
                     Output: lineitem.l_orderkey[0]
                     Filter: lineitem.l_commitdate[11]<lineitem.l_receiptdate[12]

--- a/test/primitive/expect/q04.txt
+++ b/test/primitive/expect/q04.txt
@@ -1,0 +1,20 @@
+Total cost: 1811425.54
+PhysicOrder  (inccost=1811425.54, cost=8.54, rows=5) (actual rows=5)
+    Output: orders.o_orderpriority[0],{count(*)(0)}[1]
+    Order by: orders.o_orderpriority[0]
+    -> PhysicHashAgg  (inccost=1811417, cost=1211, rows=5) (actual rows=5)
+        Output: {orders.o_orderpriority}[0],{count(*)(0)}[1]
+        Aggregates: count(*)(0)
+        Group by: orders.o_orderpriority[0]
+        -> PhysicFilter  (inccost=1810206, cost=1201, rows=1201) (actual rows=44)
+            Output: orders.o_orderpriority[1]
+            Filter: {#marker}[0]
+            -> PhysicMarkJoin Left (inccost=1809005, cost=1801500, rows=1201) (actual rows=48)
+                Output: #marker,orders.o_orderpriority[0]
+                Filter: lineitem.l_orderkey[2]=orders.o_orderkey[1]
+                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=300) (actual rows=48)
+                    Output: orders.o_orderpriority[5],orders.o_orderkey[0]
+                    Filter: orders.o_orderdate[4]>='1993-07-01' and orders.o_orderdate[4]<'9/29/1993 12:00:00 AM'
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=3752, loops=48)
+                    Output: lineitem.l_orderkey[0]
+                    Filter: lineitem.l_commitdate[11]<lineitem.l_receiptdate[12]

--- a/test/primitive/expect/q05.txt
+++ b/test/primitive/expect/q05.txt
@@ -1,37 +1,37 @@
-Total cost: 41355.97
-PhysicOrder  (inccost=41355.97, cost=82.97, rows=25) (actual rows=0)
+Total cost: NaN
+PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
     Output: nation.n_name[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
     Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
-    -> PhysicHashAgg  (inccost=41273, cost=226, rows=25) (actual rows=0)
+    -> PhysicHashAgg  (inccost=27, cost=1, rows=0) (actual rows=0)
         Output: {nation.n_name}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
         Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
         Group by: nation.n_name[0]
-        -> PhysicHashJoin  (inccost=41047, cost=1534, rows=176) (actual rows=0)
+        -> PhysicHashJoin  (inccost=26, cost=4, rows=1) (actual rows=0)
             Output: nation.n_name[3],{lineitem.l_extendedprice*1-lineitem.l_discount}[4],lineitem.l_extendedprice[5],{1-lineitem.l_discount}[6],{1}[0],lineitem.l_discount[7]
             Filter: customer.c_custkey[1]=orders.o_custkey[8] and customer.c_nationkey[2]=supplier.s_nationkey[9]
-            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+            -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
                 Output: 1,customer.c_custkey[0],customer.c_nationkey[3]
-            -> PhysicHashJoin  (inccost=39363, cost=6351, rows=1058) (actual rows=0)
+            -> PhysicHashJoin  (inccost=21, cost=4, rows=1) (actual rows=0)
                 Output: nation.n_name[1],{lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],supplier.s_nationkey[7]
                 Filter: nation.n_regionkey[8]=region.r_regionkey[0]
-                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
+                -> PhysicScanTable region (inccost=1, cost=1, rows=1) (actual rows=1)
                     Output: region.r_regionkey[0]
                     Filter: region.r_name[1]='ASIA'
-                -> PhysicHashJoin  (inccost=33007, cost=7246, rows=5291) (actual rows=871)
+                -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=871)
                     Output: nation.n_name[0],{lineitem.l_extendedprice*1-lineitem.l_discount}[3],lineitem.l_extendedprice[4],{1-lineitem.l_discount}[5],lineitem.l_discount[6],orders.o_custkey[7],supplier.s_nationkey[8],nation.n_regionkey[1]
                     Filter: supplier.s_nationkey[8]=nation.n_nationkey[2]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=25)
                         Output: nation.n_name[1],nation.n_regionkey[2],nation.n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=25736, cost=3830, rows=1905) (actual rows=871)
+                    -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=871)
                         Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],supplier.s_nationkey[0]
                         Filter: lineitem.l_suppkey[7]=supplier.s_suppkey[1]
-                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
                             Output: supplier.s_nationkey[3],supplier.s_suppkey[0]
-                        -> PhysicHashJoin  (inccost=21896, cost=14391, rows=1905) (actual rows=871)
+                        -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=871)
                             Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],lineitem.l_discount[3],orders.o_custkey[6],lineitem.l_suppkey[4]
                             Filter: lineitem.l_orderkey[5]=orders.o_orderkey[7]
-                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                            -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
                                 Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6],lineitem.l_suppkey[2],lineitem.l_orderkey[0]
-                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=476) (actual rows=222)
+                            -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=222)
                                 Output: orders.o_custkey[1],orders.o_orderkey[0]
                                 Filter: orders.o_orderdate[4]>='1994-01-01' and orders.o_orderdate[4]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q05.txt
+++ b/test/primitive/expect/q05.txt
@@ -1,37 +1,37 @@
-Total cost: NaN
-PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
+Total cost: 30151.97
+PhysicOrder  (inccost=30151.97, cost=82.97, rows=25) (actual rows=0)
     Output: nation.n_name[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
     Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
-    -> PhysicHashAgg  (inccost=27, cost=1, rows=0) (actual rows=0)
+    -> PhysicHashAgg  (inccost=30069, cost=132, rows=25) (actual rows=0)
         Output: {nation.n_name}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
         Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
         Group by: nation.n_name[0]
-        -> PhysicHashJoin  (inccost=26, cost=4, rows=1) (actual rows=0)
+        -> PhysicHashJoin  (inccost=29937, cost=879, rows=82) (actual rows=0)
             Output: nation.n_name[3],{lineitem.l_extendedprice*1-lineitem.l_discount}[4],lineitem.l_extendedprice[5],{1-lineitem.l_discount}[6],{1}[0],lineitem.l_discount[7]
             Filter: customer.c_custkey[1]=orders.o_custkey[8] and customer.c_nationkey[2]=supplier.s_nationkey[9]
-            -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
+            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                 Output: 1,customer.c_custkey[0],customer.c_nationkey[3]
-            -> PhysicHashJoin  (inccost=21, cost=4, rows=1) (actual rows=0)
+            -> PhysicHashJoin  (inccost=28908, cost=2987, rows=497) (actual rows=0)
                 Output: nation.n_name[1],{lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],supplier.s_nationkey[7]
                 Filter: nation.n_regionkey[8]=region.r_regionkey[0]
-                -> PhysicScanTable region (inccost=1, cost=1, rows=1) (actual rows=1)
+                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
                     Output: region.r_regionkey[0]
                     Filter: region.r_name[1]='ASIA'
-                -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=871)
+                -> PhysicHashJoin  (inccost=25916, cost=3434, rows=2488) (actual rows=871)
                     Output: nation.n_name[0],{lineitem.l_extendedprice*1-lineitem.l_discount}[3],lineitem.l_extendedprice[4],{1-lineitem.l_discount}[5],lineitem.l_discount[6],orders.o_custkey[7],supplier.s_nationkey[8],nation.n_regionkey[1]
                     Filter: supplier.s_nationkey[8]=nation.n_nationkey[2]
-                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=25)
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
                         Output: nation.n_name[1],nation.n_regionkey[2],nation.n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=871)
+                    -> PhysicHashJoin  (inccost=22457, cost=1812, rows=896) (actual rows=871)
                         Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],supplier.s_nationkey[0]
                         Filter: lineitem.l_suppkey[7]=supplier.s_suppkey[1]
-                        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                             Output: supplier.s_nationkey[3],supplier.s_suppkey[0]
-                        -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=871)
+                        -> PhysicHashJoin  (inccost=20635, cost=13130, rows=896) (actual rows=871)
                             Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],lineitem.l_discount[3],orders.o_custkey[6],lineitem.l_suppkey[4]
                             Filter: lineitem.l_orderkey[5]=orders.o_orderkey[7]
-                            -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
                                 Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6],lineitem.l_suppkey[2],lineitem.l_orderkey[0]
-                            -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=222)
+                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=224) (actual rows=222)
                                 Output: orders.o_custkey[1],orders.o_orderkey[0]
                                 Filter: orders.o_orderdate[4]>='1994-01-01' and orders.o_orderdate[4]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q05.txt
+++ b/test/primitive/expect/q05.txt
@@ -1,0 +1,37 @@
+Total cost: 41355.97
+PhysicOrder  (inccost=41355.97, cost=82.97, rows=25) (actual rows=0)
+    Output: nation.n_name[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
+    Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
+    -> PhysicHashAgg  (inccost=41273, cost=226, rows=25) (actual rows=0)
+        Output: {nation.n_name}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
+        Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
+        Group by: nation.n_name[0]
+        -> PhysicHashJoin  (inccost=41047, cost=1534, rows=176) (actual rows=0)
+            Output: nation.n_name[3],{lineitem.l_extendedprice*1-lineitem.l_discount}[4],lineitem.l_extendedprice[5],{1-lineitem.l_discount}[6],{1}[0],lineitem.l_discount[7]
+            Filter: customer.c_custkey[1]=orders.o_custkey[8] and customer.c_nationkey[2]=supplier.s_nationkey[9]
+            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                Output: 1,customer.c_custkey[0],customer.c_nationkey[3]
+            -> PhysicHashJoin  (inccost=39363, cost=6351, rows=1058) (actual rows=0)
+                Output: nation.n_name[1],{lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],supplier.s_nationkey[7]
+                Filter: nation.n_regionkey[8]=region.r_regionkey[0]
+                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
+                    Output: region.r_regionkey[0]
+                    Filter: region.r_name[1]='ASIA'
+                -> PhysicHashJoin  (inccost=33007, cost=7246, rows=5291) (actual rows=871)
+                    Output: nation.n_name[0],{lineitem.l_extendedprice*1-lineitem.l_discount}[3],lineitem.l_extendedprice[4],{1-lineitem.l_discount}[5],lineitem.l_discount[6],orders.o_custkey[7],supplier.s_nationkey[8],nation.n_regionkey[1]
+                    Filter: supplier.s_nationkey[8]=nation.n_nationkey[2]
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                        Output: nation.n_name[1],nation.n_regionkey[2],nation.n_nationkey[0]
+                    -> PhysicHashJoin  (inccost=25736, cost=3830, rows=1905) (actual rows=871)
+                        Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],supplier.s_nationkey[0]
+                        Filter: lineitem.l_suppkey[7]=supplier.s_suppkey[1]
+                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                            Output: supplier.s_nationkey[3],supplier.s_suppkey[0]
+                        -> PhysicHashJoin  (inccost=21896, cost=14391, rows=1905) (actual rows=871)
+                            Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],lineitem.l_discount[3],orders.o_custkey[6],lineitem.l_suppkey[4]
+                            Filter: lineitem.l_orderkey[5]=orders.o_orderkey[7]
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6],lineitem.l_suppkey[2],lineitem.l_orderkey[0]
+                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=476) (actual rows=222)
+                                Output: orders.o_custkey[1],orders.o_orderkey[0]
+                                Filter: orders.o_orderdate[4]>='1994-01-01' and orders.o_orderdate[4]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q06.txt
+++ b/test/primitive/expect/q06.txt
@@ -1,7 +1,7 @@
-Total cost: 4
-PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=1)
+Total cost: 6008
+PhysicHashAgg  (inccost=6008, cost=3, rows=1) (actual rows=1)
     Output: {sum(lineitem.l_extendedprice*lineitem.l_discount)}[0]
     Aggregates: sum(lineitem.l_extendedprice[1]*lineitem.l_discount[2])
-    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=116)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1) (actual rows=116)
         Output: lineitem.l_extendedprice[5]*lineitem.l_discount[6],lineitem.l_extendedprice[5],lineitem.l_discount[6]
         Filter: lineitem.l_shipdate[10]>='1994-01-01' and lineitem.l_shipdate[10]<'1/1/1995 12:00:00 AM' and lineitem.l_discount[6]>=0.05 and lineitem.l_discount[6]<=0.07 and lineitem.l_quantity[4]<24

--- a/test/primitive/expect/q06.txt
+++ b/test/primitive/expect/q06.txt
@@ -1,0 +1,7 @@
+Total cost: 6008
+PhysicHashAgg  (inccost=6008, cost=3, rows=1) (actual rows=1)
+    Output: {sum(lineitem.l_extendedprice*lineitem.l_discount)}[0]
+    Aggregates: sum(lineitem.l_extendedprice[1]*lineitem.l_discount[2])
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1) (actual rows=116)
+        Output: lineitem.l_extendedprice[5]*lineitem.l_discount[6],lineitem.l_extendedprice[5],lineitem.l_discount[6]
+        Filter: lineitem.l_shipdate[10]>='1994-01-01' and lineitem.l_shipdate[10]<'1/1/1995 12:00:00 AM' and lineitem.l_discount[6]>=0.05 and lineitem.l_discount[6]<=0.07 and lineitem.l_quantity[4]<24

--- a/test/primitive/expect/q06.txt
+++ b/test/primitive/expect/q06.txt
@@ -1,7 +1,7 @@
-Total cost: 6008
-PhysicHashAgg  (inccost=6008, cost=3, rows=1) (actual rows=1)
+Total cost: 4
+PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=1)
     Output: {sum(lineitem.l_extendedprice*lineitem.l_discount)}[0]
     Aggregates: sum(lineitem.l_extendedprice[1]*lineitem.l_discount[2])
-    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1) (actual rows=116)
+    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=116)
         Output: lineitem.l_extendedprice[5]*lineitem.l_discount[6],lineitem.l_extendedprice[5],lineitem.l_discount[6]
         Filter: lineitem.l_shipdate[10]>='1994-01-01' and lineitem.l_shipdate[10]<'1/1/1995 12:00:00 AM' and lineitem.l_discount[6]>=0.05 and lineitem.l_discount[6]<=0.07 and lineitem.l_quantity[4]<24

--- a/test/primitive/expect/q07.txt
+++ b/test/primitive/expect/q07.txt
@@ -1,37 +1,37 @@
-Total cost: 3509383.1
-PhysicOrder  (inccost=3509383.1, cost=0.1, rows=1) (actual rows=0)
+Total cost: 264.1
+PhysicOrder  (inccost=264.1, cost=0.1, rows=1) (actual rows=0)
     Output: shipping.supp_nation[0],shipping.cust_nation[1],shipping.l_year[2],{sum(shipping.volume)}[3]
     Order by: shipping.supp_nation[0], shipping.cust_nation[1], shipping.l_year[2]
-    -> PhysicHashAgg  (inccost=3509383, cost=10268, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=264, cost=3, rows=1) (actual rows=0)
         Output: {shipping.supp_nation}[0],{shipping.cust_nation}[1],{shipping.l_year}[2],{sum(shipping.volume)}[3]
         Aggregates: sum(shipping.volume[3])
         Group by: shipping.supp_nation[0], shipping.cust_nation[1], shipping.l_year[2]
-        -> PhysicFromQuery <shipping> (inccost=3499115, cost=10266, rows=10266) (actual rows=0)
+        -> PhysicFromQuery <shipping> (inccost=261, cost=1, rows=1) (actual rows=0)
             Output: shipping.supp_nation[0],shipping.cust_nation[1],shipping.l_year[2],shipping.volume[3]
-            -> PhysicHashJoin  (inccost=3488849, cost=102686, rows=10266) (actual rows=0)
+            -> PhysicHashJoin  (inccost=260, cost=4, rows=1) (actual rows=0)
                 Output: n1.n_name (as supp_nation)[2],n2.n_name (as cust_nation)[3],{year(lineitem.l_shipdate)}[4],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[5]
                 Filter: supplier.s_suppkey[0]=lineitem.l_suppkey[6] and supplier.s_nationkey[1]=n1.n_nationkey[7]
-                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
                     Output: supplier.s_suppkey[0],supplier.s_nationkey[3]
-                -> PhysicNLJoin  (inccost=3386153, cost=3234350, rows=92400) (actual rows=61)
+                -> PhysicNLJoin  (inccost=255, cost=121, rows=1) (actual rows=61)
                     Output: n1.n_name (as supp_nation)[2],n2.n_name (as cust_nation)[0],{year(lineitem.l_shipdate)}[3],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[4],lineitem.l_suppkey[5],n1.n_nationkey[6]
                     Filter: customer.c_nationkey[7]=n2.n_nationkey[1] and n1.n_name[2]='FRANCE' and n2.n_name[0]='GERMANY' or n1.n_name[2]='GERMANY' and n2.n_name[0]='FRANCE'
-                    -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
+                    -> PhysicScanTable nation as n2 (inccost=1, cost=1, rows=1) (actual rows=25)
                         Output: n2.n_name (as cust_nation)[1],n2.n_nationkey[0]
-                    -> PhysicNLJoin  (inccost=151778, cost=129710, rows=92400) (actual rows=44825, loops=25)
+                    -> PhysicNLJoin  (inccost=133, cost=121, rows=1) (actual rows=44825, loops=25)
                         Output: n1.n_name (as supp_nation)[0],{year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],n1.n_nationkey[1],customer.c_nationkey[5]
-                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=25)
+                        -> PhysicScanTable nation as n1 (inccost=1, cost=1, rows=1) (actual rows=25, loops=25)
                             Output: n1.n_name (as supp_nation)[1],n1.n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=22043, cost=6460, rows=3696) (actual rows=1793, loops=625)
+                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=1793, loops=625)
                             Output: {year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],customer.c_nationkey[0]
                             Filter: customer.c_custkey[1]=orders.o_custkey[5]
-                            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150, loops=625)
+                            -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150, loops=625)
                                 Output: customer.c_nationkey[3],customer.c_custkey[0]
-                            -> PhysicHashJoin  (inccost=15433, cost=7928, rows=2464) (actual rows=1793, loops=625)
+                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=1793, loops=625)
                                 Output: {year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],orders.o_custkey[0]
                                 Filter: orders.o_orderkey[1]=lineitem.l_orderkey[5]
-                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=625)
+                                -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500, loops=625)
                                     Output: orders.o_custkey[1],orders.o_orderkey[0]
-                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=2464) (actual rows=1793, loops=625)
+                                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=1793, loops=625)
                                     Output: year(lineitem.l_shipdate[10]),lineitem.l_extendedprice[5]*1-lineitem.l_discount[6](as volume),lineitem.l_suppkey[2],lineitem.l_orderkey[0]
                                     Filter: lineitem.l_shipdate[10]>='1995-01-01' and lineitem.l_shipdate[10]<='1996-12-31'

--- a/test/primitive/expect/q07.txt
+++ b/test/primitive/expect/q07.txt
@@ -1,37 +1,37 @@
-Total cost: 264.1
-PhysicOrder  (inccost=264.1, cost=0.1, rows=1) (actual rows=0)
+Total cost: 2482612.1
+PhysicOrder  (inccost=2482612.1, cost=0.1, rows=1) (actual rows=0)
     Output: shipping.supp_nation[0],shipping.cust_nation[1],shipping.l_year[2],{sum(shipping.volume)}[3]
     Order by: shipping.supp_nation[0], shipping.cust_nation[1], shipping.l_year[2]
-    -> PhysicHashAgg  (inccost=264, cost=3, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2482612, cost=7254, rows=1) (actual rows=0)
         Output: {shipping.supp_nation}[0],{shipping.cust_nation}[1],{shipping.l_year}[2],{sum(shipping.volume)}[3]
         Aggregates: sum(shipping.volume[3])
         Group by: shipping.supp_nation[0], shipping.cust_nation[1], shipping.l_year[2]
-        -> PhysicFromQuery <shipping> (inccost=261, cost=1, rows=1) (actual rows=0)
+        -> PhysicFromQuery <shipping> (inccost=2475358, cost=7252, rows=7252) (actual rows=0)
             Output: shipping.supp_nation[0],shipping.cust_nation[1],shipping.l_year[2],shipping.volume[3]
-            -> PhysicHashJoin  (inccost=260, cost=4, rows=1) (actual rows=0)
+            -> PhysicHashJoin  (inccost=2468106, cost=72547, rows=7252) (actual rows=0)
                 Output: n1.n_name (as supp_nation)[2],n2.n_name (as cust_nation)[3],{year(lineitem.l_shipdate)}[4],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[5]
                 Filter: supplier.s_suppkey[0]=lineitem.l_suppkey[6] and supplier.s_nationkey[1]=n1.n_nationkey[7]
-                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                     Output: supplier.s_suppkey[0],supplier.s_nationkey[3]
-                -> PhysicNLJoin  (inccost=255, cost=121, rows=1) (actual rows=61)
+                -> PhysicNLJoin  (inccost=2395549, cost=2284975, rows=65275) (actual rows=61)
                     Output: n1.n_name (as supp_nation)[2],n2.n_name (as cust_nation)[0],{year(lineitem.l_shipdate)}[3],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[4],lineitem.l_suppkey[5],n1.n_nationkey[6]
                     Filter: customer.c_nationkey[7]=n2.n_nationkey[1] and n1.n_name[2]='FRANCE' and n2.n_name[0]='GERMANY' or n1.n_name[2]='GERMANY' and n2.n_name[0]='FRANCE'
-                    -> PhysicScanTable nation as n2 (inccost=1, cost=1, rows=1) (actual rows=25)
+                    -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
                         Output: n2.n_name (as cust_nation)[1],n2.n_nationkey[0]
-                    -> PhysicNLJoin  (inccost=133, cost=121, rows=1) (actual rows=44825, loops=25)
+                    -> PhysicNLJoin  (inccost=110549, cost=91735, rows=65275) (actual rows=44825, loops=25)
                         Output: n1.n_name (as supp_nation)[0],{year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],n1.n_nationkey[1],customer.c_nationkey[5]
-                        -> PhysicScanTable nation as n1 (inccost=1, cost=1, rows=1) (actual rows=25, loops=25)
+                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=25)
                             Output: n1.n_name (as supp_nation)[1],n1.n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=1793, loops=625)
+                        -> PhysicHashJoin  (inccost=18789, cost=4652, rows=2611) (actual rows=1793, loops=625)
                             Output: {year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],customer.c_nationkey[0]
                             Filter: customer.c_custkey[1]=orders.o_custkey[5]
-                            -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150, loops=625)
+                            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150, loops=625)
                                 Output: customer.c_nationkey[3],customer.c_custkey[0]
-                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=1793, loops=625)
+                            -> PhysicHashJoin  (inccost=13987, cost=6482, rows=1741) (actual rows=1793, loops=625)
                                 Output: {year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],orders.o_custkey[0]
                                 Filter: orders.o_orderkey[1]=lineitem.l_orderkey[5]
-                                -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500, loops=625)
+                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=625)
                                     Output: orders.o_custkey[1],orders.o_orderkey[0]
-                                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=1793, loops=625)
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1741) (actual rows=1793, loops=625)
                                     Output: year(lineitem.l_shipdate[10]),lineitem.l_extendedprice[5]*1-lineitem.l_discount[6](as volume),lineitem.l_suppkey[2],lineitem.l_orderkey[0]
                                     Filter: lineitem.l_shipdate[10]>='1995-01-01' and lineitem.l_shipdate[10]<='1996-12-31'

--- a/test/primitive/expect/q07.txt
+++ b/test/primitive/expect/q07.txt
@@ -1,0 +1,37 @@
+Total cost: 3509383.1
+PhysicOrder  (inccost=3509383.1, cost=0.1, rows=1) (actual rows=0)
+    Output: shipping.supp_nation[0],shipping.cust_nation[1],shipping.l_year[2],{sum(shipping.volume)}[3]
+    Order by: shipping.supp_nation[0], shipping.cust_nation[1], shipping.l_year[2]
+    -> PhysicHashAgg  (inccost=3509383, cost=10268, rows=1) (actual rows=0)
+        Output: {shipping.supp_nation}[0],{shipping.cust_nation}[1],{shipping.l_year}[2],{sum(shipping.volume)}[3]
+        Aggregates: sum(shipping.volume[3])
+        Group by: shipping.supp_nation[0], shipping.cust_nation[1], shipping.l_year[2]
+        -> PhysicFromQuery <shipping> (inccost=3499115, cost=10266, rows=10266) (actual rows=0)
+            Output: shipping.supp_nation[0],shipping.cust_nation[1],shipping.l_year[2],shipping.volume[3]
+            -> PhysicHashJoin  (inccost=3488849, cost=102686, rows=10266) (actual rows=0)
+                Output: n1.n_name (as supp_nation)[2],n2.n_name (as cust_nation)[3],{year(lineitem.l_shipdate)}[4],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[5]
+                Filter: supplier.s_suppkey[0]=lineitem.l_suppkey[6] and supplier.s_nationkey[1]=n1.n_nationkey[7]
+                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                    Output: supplier.s_suppkey[0],supplier.s_nationkey[3]
+                -> PhysicNLJoin  (inccost=3386153, cost=3234350, rows=92400) (actual rows=61)
+                    Output: n1.n_name (as supp_nation)[2],n2.n_name (as cust_nation)[0],{year(lineitem.l_shipdate)}[3],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[4],lineitem.l_suppkey[5],n1.n_nationkey[6]
+                    Filter: customer.c_nationkey[7]=n2.n_nationkey[1] and n1.n_name[2]='FRANCE' and n2.n_name[0]='GERMANY' or n1.n_name[2]='GERMANY' and n2.n_name[0]='FRANCE'
+                    -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
+                        Output: n2.n_name (as cust_nation)[1],n2.n_nationkey[0]
+                    -> PhysicNLJoin  (inccost=151778, cost=129710, rows=92400) (actual rows=44825, loops=25)
+                        Output: n1.n_name (as supp_nation)[0],{year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],n1.n_nationkey[1],customer.c_nationkey[5]
+                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=25)
+                            Output: n1.n_name (as supp_nation)[1],n1.n_nationkey[0]
+                        -> PhysicHashJoin  (inccost=22043, cost=6460, rows=3696) (actual rows=1793, loops=625)
+                            Output: {year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],customer.c_nationkey[0]
+                            Filter: customer.c_custkey[1]=orders.o_custkey[5]
+                            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150, loops=625)
+                                Output: customer.c_nationkey[3],customer.c_custkey[0]
+                            -> PhysicHashJoin  (inccost=15433, cost=7928, rows=2464) (actual rows=1793, loops=625)
+                                Output: {year(lineitem.l_shipdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_suppkey[4],orders.o_custkey[0]
+                                Filter: orders.o_orderkey[1]=lineitem.l_orderkey[5]
+                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=625)
+                                    Output: orders.o_custkey[1],orders.o_orderkey[0]
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=2464) (actual rows=1793, loops=625)
+                                    Output: year(lineitem.l_shipdate[10]),lineitem.l_extendedprice[5]*1-lineitem.l_discount[6](as volume),lineitem.l_suppkey[2],lineitem.l_orderkey[0]
+                                    Filter: lineitem.l_shipdate[10]>='1995-01-01' and lineitem.l_shipdate[10]<='1996-12-31'

--- a/test/primitive/expect/q08.txt
+++ b/test/primitive/expect/q08.txt
@@ -1,0 +1,50 @@
+Total cost: 77962.1
+PhysicOrder  (inccost=77962.1, cost=0.1, rows=1) (actual rows=2)
+    Output: all_nations.o_year[0],{sum(case with 1)/sum(all_nations.volume)(as mkt_share)}[1]
+    Order by: all_nations.o_year[0]
+    -> PhysicHashAgg  (inccost=77962, cost=22, rows=1) (actual rows=2)
+        Output: {all_nations.o_year}[0],{sum(case with 1)}[1]/{sum(all_nations.volume)}[2](as mkt_share)
+        Aggregates: sum(case with 1), sum(all_nations.volume[5])
+        Group by: all_nations.o_year[0]
+        -> PhysicFromQuery <all_nations> (inccost=77940, cost=20, rows=20) (actual rows=5)
+            Output: all_nations.o_year[0],case with 1,all_nations.nation[2]='BRAZIL',all_nations.nation[2],'BRAZIL',all_nations.volume[1],0
+            -> PhysicHashJoin  (inccost=77920, cost=2075, rows=20) (actual rows=5)
+                Output: {year(orders.o_orderdate)}[1],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[2],n2.n_name (as nation)[3]
+                Filter: part.p_partkey[0]=lineitem.l_partkey[4]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=2) (actual rows=1)
+                    Output: part.p_partkey[0]
+                    Filter: part.p_type[4]='ECONOMY ANODIZED STEEL'
+                -> PhysicHashJoin  (inccost=75645, cost=12311, rows=2051) (actual rows=385)
+                    Output: {year(orders.o_orderdate)}[1],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[2],n2.n_name (as nation)[3],lineitem.l_partkey[4]
+                    Filter: n1.n_regionkey[5]=region.r_regionkey[0]
+                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
+                        Output: region.r_regionkey[0]
+                        Filter: region.r_name[1]='AMERICA'
+                    -> PhysicHashJoin  (inccost=63329, cost=14001, rows=10258) (actual rows=1810)
+                        Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],n2.n_name (as nation)[0],lineitem.l_partkey[4],n1.n_regionkey[5]
+                        Filter: supplier.s_nationkey[6]=n2.n_nationkey[1]
+                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
+                            Output: n2.n_name (as nation)[1],n2.n_nationkey[0]
+                        -> PhysicHashJoin  (inccost=49303, cost=7436, rows=3693) (actual rows=1810)
+                            Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],n1.n_regionkey[0],supplier.s_nationkey[5]
+                            Filter: customer.c_nationkey[6]=n1.n_nationkey[1]
+                            -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25)
+                                Output: n1.n_regionkey[2],n1.n_nationkey[0]
+                            -> PhysicHashJoin  (inccost=41842, cost=6455, rows=3693) (actual rows=1810)
+                                Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],supplier.s_nationkey[5],customer.c_nationkey[0]
+                                Filter: orders.o_custkey[6]=customer.c_custkey[1]
+                                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                                    Output: customer.c_nationkey[3],customer.c_custkey[0]
+                                -> PhysicHashJoin  (inccost=35237, cost=9697, rows=2462) (actual rows=1810)
+                                    Output: {year(orders.o_orderdate)}[0],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],supplier.s_nationkey[5],orders.o_custkey[1]
+                                    Filter: lineitem.l_orderkey[6]=orders.o_orderkey[2]
+                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=615) (actual rows=452)
+                                        Output: year(orders.o_orderdate[4]),orders.o_custkey[1],orders.o_orderkey[0]
+                                        Filter: orders.o_orderdate[4]>='1995-01-01' and orders.o_orderdate[4]<='1996-12-31'
+                                    -> PhysicHashJoin  (inccost=24040, cost=18025, rows=6005) (actual rows=6005)
+                                        Output: {lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[0],lineitem.l_partkey[1],supplier.s_nationkey[4],lineitem.l_orderkey[2]
+                                        Filter: supplier.s_suppkey[5]=lineitem.l_suppkey[3]
+                                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                            Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6](as volume),lineitem.l_partkey[1],lineitem.l_orderkey[0],lineitem.l_suppkey[2]
+                                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                            Output: supplier.s_nationkey[3],supplier.s_suppkey[0]

--- a/test/primitive/expect/q08.txt
+++ b/test/primitive/expect/q08.txt
@@ -1,50 +1,50 @@
-Total cost: 77962.1
-PhysicOrder  (inccost=77962.1, cost=0.1, rows=1) (actual rows=2)
+Total cost: 40.1
+PhysicOrder  (inccost=40.1, cost=0.1, rows=1) (actual rows=2)
     Output: all_nations.o_year[0],{sum(case with 1)/sum(all_nations.volume)(as mkt_share)}[1]
     Order by: all_nations.o_year[0]
-    -> PhysicHashAgg  (inccost=77962, cost=22, rows=1) (actual rows=2)
+    -> PhysicHashAgg  (inccost=40, cost=3, rows=1) (actual rows=2)
         Output: {all_nations.o_year}[0],{sum(case with 1)}[1]/{sum(all_nations.volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(all_nations.volume[5])
         Group by: all_nations.o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=77940, cost=20, rows=20) (actual rows=5)
+        -> PhysicFromQuery <all_nations> (inccost=37, cost=1, rows=1) (actual rows=5)
             Output: all_nations.o_year[0],case with 1,all_nations.nation[2]='BRAZIL',all_nations.nation[2],'BRAZIL',all_nations.volume[1],0
-            -> PhysicHashJoin  (inccost=77920, cost=2075, rows=20) (actual rows=5)
+            -> PhysicHashJoin  (inccost=36, cost=4, rows=1) (actual rows=5)
                 Output: {year(orders.o_orderdate)}[1],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[2],n2.n_name (as nation)[3]
                 Filter: part.p_partkey[0]=lineitem.l_partkey[4]
-                -> PhysicScanTable part (inccost=200, cost=200, rows=2) (actual rows=1)
+                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=1)
                     Output: part.p_partkey[0]
                     Filter: part.p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=75645, cost=12311, rows=2051) (actual rows=385)
+                -> PhysicHashJoin  (inccost=31, cost=4, rows=1) (actual rows=385)
                     Output: {year(orders.o_orderdate)}[1],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[2],n2.n_name (as nation)[3],lineitem.l_partkey[4]
                     Filter: n1.n_regionkey[5]=region.r_regionkey[0]
-                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
+                    -> PhysicScanTable region (inccost=1, cost=1, rows=1) (actual rows=1)
                         Output: region.r_regionkey[0]
                         Filter: region.r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=63329, cost=14001, rows=10258) (actual rows=1810)
+                    -> PhysicHashJoin  (inccost=26, cost=4, rows=1) (actual rows=1810)
                         Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],n2.n_name (as nation)[0],lineitem.l_partkey[4],n1.n_regionkey[5]
                         Filter: supplier.s_nationkey[6]=n2.n_nationkey[1]
-                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
+                        -> PhysicScanTable nation as n2 (inccost=1, cost=1, rows=1) (actual rows=25)
                             Output: n2.n_name (as nation)[1],n2.n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=49303, cost=7436, rows=3693) (actual rows=1810)
+                        -> PhysicHashJoin  (inccost=21, cost=4, rows=1) (actual rows=1810)
                             Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],n1.n_regionkey[0],supplier.s_nationkey[5]
                             Filter: customer.c_nationkey[6]=n1.n_nationkey[1]
-                            -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25)
+                            -> PhysicScanTable nation as n1 (inccost=1, cost=1, rows=1) (actual rows=25)
                                 Output: n1.n_regionkey[2],n1.n_nationkey[0]
-                            -> PhysicHashJoin  (inccost=41842, cost=6455, rows=3693) (actual rows=1810)
+                            -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=1810)
                                 Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],supplier.s_nationkey[5],customer.c_nationkey[0]
                                 Filter: orders.o_custkey[6]=customer.c_custkey[1]
-                                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
                                     Output: customer.c_nationkey[3],customer.c_custkey[0]
-                                -> PhysicHashJoin  (inccost=35237, cost=9697, rows=2462) (actual rows=1810)
+                                -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=1810)
                                     Output: {year(orders.o_orderdate)}[0],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],supplier.s_nationkey[5],orders.o_custkey[1]
                                     Filter: lineitem.l_orderkey[6]=orders.o_orderkey[2]
-                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=615) (actual rows=452)
+                                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=452)
                                         Output: year(orders.o_orderdate[4]),orders.o_custkey[1],orders.o_orderkey[0]
                                         Filter: orders.o_orderdate[4]>='1995-01-01' and orders.o_orderdate[4]<='1996-12-31'
-                                    -> PhysicHashJoin  (inccost=24040, cost=18025, rows=6005) (actual rows=6005)
+                                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=6005)
                                         Output: {lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[0],lineitem.l_partkey[1],supplier.s_nationkey[4],lineitem.l_orderkey[2]
                                         Filter: supplier.s_suppkey[5]=lineitem.l_suppkey[3]
-                                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
                                             Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6](as volume),lineitem.l_partkey[1],lineitem.l_orderkey[0],lineitem.l_suppkey[2]
-                                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
                                             Output: supplier.s_nationkey[3],supplier.s_suppkey[0]

--- a/test/primitive/expect/q08.txt
+++ b/test/primitive/expect/q08.txt
@@ -1,50 +1,50 @@
-Total cost: 40.1
-PhysicOrder  (inccost=40.1, cost=0.1, rows=1) (actual rows=2)
+Total cost: 65713.1
+PhysicOrder  (inccost=65713.1, cost=0.1, rows=1) (actual rows=2)
     Output: all_nations.o_year[0],{sum(case with 1)/sum(all_nations.volume)(as mkt_share)}[1]
     Order by: all_nations.o_year[0]
-    -> PhysicHashAgg  (inccost=40, cost=3, rows=1) (actual rows=2)
+    -> PhysicHashAgg  (inccost=65713, cost=17, rows=1) (actual rows=2)
         Output: {all_nations.o_year}[0],{sum(case with 1)}[1]/{sum(all_nations.volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(all_nations.volume[5])
         Group by: all_nations.o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=37, cost=1, rows=1) (actual rows=5)
+        -> PhysicFromQuery <all_nations> (inccost=65696, cost=15, rows=15) (actual rows=5)
             Output: all_nations.o_year[0],case with 1,all_nations.nation[2]='BRAZIL',all_nations.nation[2],'BRAZIL',all_nations.volume[1],0
-            -> PhysicHashJoin  (inccost=36, cost=4, rows=1) (actual rows=5)
+            -> PhysicHashJoin  (inccost=65681, cost=1519, rows=15) (actual rows=5)
                 Output: {year(orders.o_orderdate)}[1],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[2],n2.n_name (as nation)[3]
                 Filter: part.p_partkey[0]=lineitem.l_partkey[4]
-                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=1)
+                -> PhysicScanTable part (inccost=200, cost=200, rows=2) (actual rows=1)
                     Output: part.p_partkey[0]
                     Filter: part.p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=31, cost=4, rows=1) (actual rows=385)
+                -> PhysicHashJoin  (inccost=63962, cost=9004, rows=1500) (actual rows=385)
                     Output: {year(orders.o_orderdate)}[1],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[2],n2.n_name (as nation)[3],lineitem.l_partkey[4]
                     Filter: n1.n_regionkey[5]=region.r_regionkey[0]
-                    -> PhysicScanTable region (inccost=1, cost=1, rows=1) (actual rows=1)
+                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
                         Output: region.r_regionkey[0]
                         Filter: region.r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=26, cost=4, rows=1) (actual rows=1810)
+                    -> PhysicHashJoin  (inccost=54953, cost=10253, rows=7502) (actual rows=1810)
                         Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],n2.n_name (as nation)[0],lineitem.l_partkey[4],n1.n_regionkey[5]
                         Filter: supplier.s_nationkey[6]=n2.n_nationkey[1]
-                        -> PhysicScanTable nation as n2 (inccost=1, cost=1, rows=1) (actual rows=25)
+                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
                             Output: n2.n_name (as nation)[1],n2.n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=21, cost=4, rows=1) (actual rows=1810)
+                        -> PhysicHashJoin  (inccost=44675, cost=5452, rows=2701) (actual rows=1810)
                             Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],n1.n_regionkey[0],supplier.s_nationkey[5]
                             Filter: customer.c_nationkey[6]=n1.n_nationkey[1]
-                            -> PhysicScanTable nation as n1 (inccost=1, cost=1, rows=1) (actual rows=25)
+                            -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25)
                                 Output: n1.n_regionkey[2],n1.n_nationkey[0]
-                            -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=1810)
+                            -> PhysicHashJoin  (inccost=39198, cost=4802, rows=2701) (actual rows=1810)
                                 Output: {year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],supplier.s_nationkey[5],customer.c_nationkey[0]
                                 Filter: orders.o_custkey[6]=customer.c_custkey[1]
-                                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
+                                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                                     Output: customer.c_nationkey[3],customer.c_custkey[0]
-                                -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=1810)
+                                -> PhysicHashJoin  (inccost=34246, cost=8706, rows=1801) (actual rows=1810)
                                     Output: {year(orders.o_orderdate)}[0],{lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[3],lineitem.l_partkey[4],supplier.s_nationkey[5],orders.o_custkey[1]
                                     Filter: lineitem.l_orderkey[6]=orders.o_orderkey[2]
-                                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=452)
+                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=450) (actual rows=452)
                                         Output: year(orders.o_orderdate[4]),orders.o_custkey[1],orders.o_orderkey[0]
                                         Filter: orders.o_orderdate[4]>='1995-01-01' and orders.o_orderdate[4]<='1996-12-31'
-                                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=6005)
+                                    -> PhysicHashJoin  (inccost=24040, cost=18025, rows=6005) (actual rows=6005)
                                         Output: {lineitem.l_extendedprice*1-lineitem.l_discount(as volume)}[0],lineitem.l_partkey[1],supplier.s_nationkey[4],lineitem.l_orderkey[2]
                                         Filter: supplier.s_suppkey[5]=lineitem.l_suppkey[3]
-                                        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+                                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
                                             Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6](as volume),lineitem.l_partkey[1],lineitem.l_orderkey[0],lineitem.l_suppkey[2]
-                                        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+                                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                                             Output: supplier.s_nationkey[3],supplier.s_suppkey[0]

--- a/test/primitive/expect/q09.txt
+++ b/test/primitive/expect/q09.txt
@@ -1,0 +1,38 @@
+Total cost: 60275.1
+PhysicOrder  (inccost=60275.1, cost=0.1, rows=1) (actual rows=60)
+    Output: profit.nation[0],profit.o_year[1],{sum(profit.amount)}[2]
+    Order by: profit.nation[0], profit.o_year[1]
+    -> PhysicHashAgg  (inccost=60275, cost=35, rows=1) (actual rows=60)
+        Output: {profit.nation}[0],{profit.o_year}[1],{sum(profit.amount)}[2]
+        Aggregates: sum(profit.amount[2])
+        Group by: profit.nation[0], profit.o_year[1]
+        -> PhysicFromQuery <profit> (inccost=60240, cost=33, rows=33) (actual rows=493)
+            Output: profit.nation[0],profit.o_year[1],profit.amount[2]
+            -> PhysicHashJoin  (inccost=60207, cost=6707, rows=33) (actual rows=493)
+                Output: nation.n_name (as nation)[1],{year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[3]
+                Filter: part.p_partkey[0]=lineitem.l_partkey[4]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=9)
+                    Output: part.p_partkey[0]
+                    Filter: part.p_name[1]like'%green%'
+                -> PhysicHashJoin  (inccost=53300, cost=9124, rows=6672) (actual rows=8447)
+                    Output: nation.n_name (as nation)[0],{year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[3],lineitem.l_partkey[4]
+                    Filter: supplier.s_nationkey[5]=nation.n_nationkey[1]
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                        Output: nation.n_name (as nation)[1],nation.n_nationkey[0]
+                    -> PhysicHashJoin  (inccost=44151, cost=7804, rows=2402) (actual rows=8447)
+                        Output: {year(orders.o_orderdate)}[0],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[2],lineitem.l_partkey[3],supplier.s_nationkey[4]
+                        Filter: orders.o_orderkey[1]=lineitem.l_orderkey[5]
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                            Output: year(orders.o_orderdate[4]),orders.o_orderkey[0]
+                        -> PhysicHashJoin  (inccost=34847, cost=10007, rows=2402) (actual rows=8447)
+                            Output: lineitem.l_extendedprice[3]*1-lineitem.l_discount[4]-partsupp.ps_supplycost[0]*lineitem.l_quantity[5](as amount),lineitem.l_partkey[6],supplier.s_nationkey[7],lineitem.l_orderkey[8]
+                            Filter: partsupp.ps_suppkey[1]=lineitem.l_suppkey[9] and partsupp.ps_partkey[2]=lineitem.l_partkey[6]
+                            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
+                                Output: partsupp.ps_supplycost[3],partsupp.ps_suppkey[1],partsupp.ps_partkey[0]
+                            -> PhysicHashJoin  (inccost=24040, cost=18025, rows=6005) (actual rows=6005)
+                                Output: lineitem.l_extendedprice[0],lineitem.l_discount[1],lineitem.l_quantity[2],lineitem.l_partkey[3],supplier.s_nationkey[6],lineitem.l_orderkey[4],lineitem.l_suppkey[5]
+                                Filter: supplier.s_suppkey[7]=lineitem.l_suppkey[5]
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                    Output: lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_quantity[4],lineitem.l_partkey[1],lineitem.l_orderkey[0],lineitem.l_suppkey[2]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                    Output: supplier.s_nationkey[3],supplier.s_suppkey[0]

--- a/test/primitive/expect/q09.txt
+++ b/test/primitive/expect/q09.txt
@@ -1,38 +1,38 @@
-Total cost: 30.1
-PhysicOrder  (inccost=30.1, cost=0.1, rows=1) (actual rows=60)
+Total cost: 60275.1
+PhysicOrder  (inccost=60275.1, cost=0.1, rows=1) (actual rows=60)
     Output: profit.nation[0],profit.o_year[1],{sum(profit.amount)}[2]
     Order by: profit.nation[0], profit.o_year[1]
-    -> PhysicHashAgg  (inccost=30, cost=3, rows=1) (actual rows=60)
+    -> PhysicHashAgg  (inccost=60275, cost=35, rows=1) (actual rows=60)
         Output: {profit.nation}[0],{profit.o_year}[1],{sum(profit.amount)}[2]
         Aggregates: sum(profit.amount[2])
         Group by: profit.nation[0], profit.o_year[1]
-        -> PhysicFromQuery <profit> (inccost=27, cost=1, rows=1) (actual rows=493)
+        -> PhysicFromQuery <profit> (inccost=60240, cost=33, rows=33) (actual rows=493)
             Output: profit.nation[0],profit.o_year[1],profit.amount[2]
-            -> PhysicHashJoin  (inccost=26, cost=4, rows=1) (actual rows=493)
+            -> PhysicHashJoin  (inccost=60207, cost=6707, rows=33) (actual rows=493)
                 Output: nation.n_name (as nation)[1],{year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[3]
                 Filter: part.p_partkey[0]=lineitem.l_partkey[4]
-                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=9)
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=9)
                     Output: part.p_partkey[0]
                     Filter: part.p_name[1]like'%green%'
-                -> PhysicHashJoin  (inccost=21, cost=4, rows=1) (actual rows=8447)
+                -> PhysicHashJoin  (inccost=53300, cost=9124, rows=6672) (actual rows=8447)
                     Output: nation.n_name (as nation)[0],{year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[3],lineitem.l_partkey[4]
                     Filter: supplier.s_nationkey[5]=nation.n_nationkey[1]
-                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=25)
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
                         Output: nation.n_name (as nation)[1],nation.n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=8447)
+                    -> PhysicHashJoin  (inccost=44151, cost=7804, rows=2402) (actual rows=8447)
                         Output: {year(orders.o_orderdate)}[0],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[2],lineitem.l_partkey[3],supplier.s_nationkey[4]
                         Filter: orders.o_orderkey[1]=lineitem.l_orderkey[5]
-                        -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500)
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
                             Output: year(orders.o_orderdate[4]),orders.o_orderkey[0]
-                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=8447)
+                        -> PhysicHashJoin  (inccost=34847, cost=10007, rows=2402) (actual rows=8447)
                             Output: lineitem.l_extendedprice[3]*1-lineitem.l_discount[4]-partsupp.ps_supplycost[0]*lineitem.l_quantity[5](as amount),lineitem.l_partkey[6],supplier.s_nationkey[7],lineitem.l_orderkey[8]
                             Filter: partsupp.ps_suppkey[1]=lineitem.l_suppkey[9] and partsupp.ps_partkey[2]=lineitem.l_partkey[6]
-                            -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
+                            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
                                 Output: partsupp.ps_supplycost[3],partsupp.ps_suppkey[1],partsupp.ps_partkey[0]
-                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=6005)
+                            -> PhysicHashJoin  (inccost=24040, cost=18025, rows=6005) (actual rows=6005)
                                 Output: lineitem.l_extendedprice[0],lineitem.l_discount[1],lineitem.l_quantity[2],lineitem.l_partkey[3],supplier.s_nationkey[6],lineitem.l_orderkey[4],lineitem.l_suppkey[5]
                                 Filter: supplier.s_suppkey[7]=lineitem.l_suppkey[5]
-                                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
                                     Output: lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_quantity[4],lineitem.l_partkey[1],lineitem.l_orderkey[0],lineitem.l_suppkey[2]
-                                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                                     Output: supplier.s_nationkey[3],supplier.s_suppkey[0]

--- a/test/primitive/expect/q09.txt
+++ b/test/primitive/expect/q09.txt
@@ -1,38 +1,38 @@
-Total cost: 60275.1
-PhysicOrder  (inccost=60275.1, cost=0.1, rows=1) (actual rows=60)
+Total cost: 30.1
+PhysicOrder  (inccost=30.1, cost=0.1, rows=1) (actual rows=60)
     Output: profit.nation[0],profit.o_year[1],{sum(profit.amount)}[2]
     Order by: profit.nation[0], profit.o_year[1]
-    -> PhysicHashAgg  (inccost=60275, cost=35, rows=1) (actual rows=60)
+    -> PhysicHashAgg  (inccost=30, cost=3, rows=1) (actual rows=60)
         Output: {profit.nation}[0],{profit.o_year}[1],{sum(profit.amount)}[2]
         Aggregates: sum(profit.amount[2])
         Group by: profit.nation[0], profit.o_year[1]
-        -> PhysicFromQuery <profit> (inccost=60240, cost=33, rows=33) (actual rows=493)
+        -> PhysicFromQuery <profit> (inccost=27, cost=1, rows=1) (actual rows=493)
             Output: profit.nation[0],profit.o_year[1],profit.amount[2]
-            -> PhysicHashJoin  (inccost=60207, cost=6707, rows=33) (actual rows=493)
+            -> PhysicHashJoin  (inccost=26, cost=4, rows=1) (actual rows=493)
                 Output: nation.n_name (as nation)[1],{year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[3]
                 Filter: part.p_partkey[0]=lineitem.l_partkey[4]
-                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=9)
+                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=9)
                     Output: part.p_partkey[0]
                     Filter: part.p_name[1]like'%green%'
-                -> PhysicHashJoin  (inccost=53300, cost=9124, rows=6672) (actual rows=8447)
+                -> PhysicHashJoin  (inccost=21, cost=4, rows=1) (actual rows=8447)
                     Output: nation.n_name (as nation)[0],{year(orders.o_orderdate)}[2],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[3],lineitem.l_partkey[4]
                     Filter: supplier.s_nationkey[5]=nation.n_nationkey[1]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=25)
                         Output: nation.n_name (as nation)[1],nation.n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=44151, cost=7804, rows=2402) (actual rows=8447)
+                    -> PhysicHashJoin  (inccost=16, cost=4, rows=1) (actual rows=8447)
                         Output: {year(orders.o_orderdate)}[0],{lineitem.l_extendedprice*1-lineitem.l_discount-partsupp.ps_supplycost*lineitem.l_quantity(as amount)}[2],lineitem.l_partkey[3],supplier.s_nationkey[4]
                         Filter: orders.o_orderkey[1]=lineitem.l_orderkey[5]
-                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                        -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500)
                             Output: year(orders.o_orderdate[4]),orders.o_orderkey[0]
-                        -> PhysicHashJoin  (inccost=34847, cost=10007, rows=2402) (actual rows=8447)
+                        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=8447)
                             Output: lineitem.l_extendedprice[3]*1-lineitem.l_discount[4]-partsupp.ps_supplycost[0]*lineitem.l_quantity[5](as amount),lineitem.l_partkey[6],supplier.s_nationkey[7],lineitem.l_orderkey[8]
                             Filter: partsupp.ps_suppkey[1]=lineitem.l_suppkey[9] and partsupp.ps_partkey[2]=lineitem.l_partkey[6]
-                            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
+                            -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
                                 Output: partsupp.ps_supplycost[3],partsupp.ps_suppkey[1],partsupp.ps_partkey[0]
-                            -> PhysicHashJoin  (inccost=24040, cost=18025, rows=6005) (actual rows=6005)
+                            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=6005)
                                 Output: lineitem.l_extendedprice[0],lineitem.l_discount[1],lineitem.l_quantity[2],lineitem.l_partkey[3],supplier.s_nationkey[6],lineitem.l_orderkey[4],lineitem.l_suppkey[5]
                                 Filter: supplier.s_suppkey[7]=lineitem.l_suppkey[5]
-                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
                                     Output: lineitem.l_extendedprice[5],lineitem.l_discount[6],lineitem.l_quantity[4],lineitem.l_partkey[1],lineitem.l_orderkey[0],lineitem.l_suppkey[2]
-                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
                                     Output: supplier.s_nationkey[3],supplier.s_suppkey[0]

--- a/test/primitive/expect/q10.txt
+++ b/test/primitive/expect/q10.txt
@@ -1,0 +1,28 @@
+Total cost: 37150.61
+PhysicLimit (20) (inccost=37150.61, cost=20, rows=20) (actual rows=20)
+    Output: customer.c_custkey[0],customer.c_name[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2],customer.c_acctbal[3],nation.n_name[4],customer.c_address[5],customer.c_phone[6],customer.c_comment[7]
+    -> PhysicOrder  (inccost=37130.61, cost=3164.61, rows=501) (actual rows=20)
+        Output: customer.c_custkey[0],customer.c_name[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2],customer.c_acctbal[3],nation.n_name[4],customer.c_address[5],customer.c_phone[6],customer.c_comment[7]
+        Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2]
+        -> PhysicHashAgg  (inccost=33966, cost=1503, rows=501) (actual rows=43)
+            Output: {customer.c_custkey}[0],{customer.c_name}[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[7],{customer.c_acctbal}[2],{nation.n_name}[4],{customer.c_address}[5],{customer.c_phone}[3],{customer.c_comment}[6]
+            Aggregates: sum(lineitem.l_extendedprice[8]*1-lineitem.l_discount[11])
+            Group by: customer.c_custkey[0], customer.c_name[1], customer.c_acctbal[2], customer.c_phone[5], nation.n_name[3], customer.c_address[4], customer.c_comment[6]
+            -> PhysicHashJoin  (inccost=32463, cost=9151, rows=501) (actual rows=140)
+                Output: customer.c_custkey[0],customer.c_name[1],customer.c_acctbal[2],nation.n_name[8],customer.c_address[3],customer.c_phone[4],customer.c_comment[5],{lineitem.l_extendedprice*1-lineitem.l_discount}[9],lineitem.l_extendedprice[10],{1-lineitem.l_discount}[11],{1}[6],lineitem.l_discount[12]
+                Filter: customer.c_custkey[0]=orders.o_custkey[13] and customer.c_nationkey[7]=nation.n_nationkey[14]
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                    Output: customer.c_custkey[0],customer.c_name[1],customer.c_acctbal[5],customer.c_address[2],customer.c_phone[4],customer.c_comment[7],1,customer.c_nationkey[3]
+                -> PhysicNLJoin  (inccost=23162, cost=12040, rows=8350) (actual rows=3500)
+                    Output: nation.n_name[0],{lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],nation.n_nationkey[1]
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                        Output: nation.n_name[1],nation.n_nationkey[0]
+                    -> PhysicHashJoin  (inccost=11097, cost=3592, rows=334) (actual rows=140, loops=25)
+                        Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],lineitem.l_discount[3],orders.o_custkey[5]
+                        Filter: lineitem.l_orderkey[4]=orders.o_orderkey[6]
+                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=1457, loops=25)
+                            Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6],lineitem.l_orderkey[0]
+                            Filter: lineitem.l_returnflag[8]='R'
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=344) (actual rows=64, loops=25)
+                            Output: orders.o_custkey[1],orders.o_orderkey[0]
+                            Filter: orders.o_orderdate[4]>='1993-10-01' and orders.o_orderdate[4]<'12/30/1993 12:00:00 AM'

--- a/test/primitive/expect/q10.txt
+++ b/test/primitive/expect/q10.txt
@@ -1,28 +1,28 @@
-Total cost: NaN
-PhysicLimit (20) (inccost=NaN, cost=20, rows=20) (actual rows=20)
+Total cost: 16679.47
+PhysicLimit (20) (inccost=16679.47, cost=20, rows=20) (actual rows=20)
     Output: customer.c_custkey[0],customer.c_name[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2],customer.c_acctbal[3],nation.n_name[4],customer.c_address[5],customer.c_phone[6],customer.c_comment[7]
-    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=20)
+    -> PhysicOrder  (inccost=16659.47, cost=516.47, rows=108) (actual rows=20)
         Output: customer.c_custkey[0],customer.c_name[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2],customer.c_acctbal[3],nation.n_name[4],customer.c_address[5],customer.c_phone[6],customer.c_comment[7]
         Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2]
-        -> PhysicHashAgg  (inccost=134, cost=1, rows=0) (actual rows=43)
+        -> PhysicHashAgg  (inccost=16143, cost=324, rows=108) (actual rows=43)
             Output: {customer.c_custkey}[0],{customer.c_name}[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[7],{customer.c_acctbal}[2],{nation.n_name}[4],{customer.c_address}[5],{customer.c_phone}[3],{customer.c_comment}[6]
             Aggregates: sum(lineitem.l_extendedprice[8]*1-lineitem.l_discount[11])
             Group by: customer.c_custkey[0], customer.c_name[1], customer.c_acctbal[2], customer.c_phone[5], nation.n_name[3], customer.c_address[4], customer.c_comment[6]
-            -> PhysicHashJoin  (inccost=133, cost=4, rows=1) (actual rows=140)
+            -> PhysicHashJoin  (inccost=15819, cost=2208, rows=108) (actual rows=140)
                 Output: customer.c_custkey[0],customer.c_name[1],customer.c_acctbal[2],nation.n_name[8],customer.c_address[3],customer.c_phone[4],customer.c_comment[5],{lineitem.l_extendedprice*1-lineitem.l_discount}[9],lineitem.l_extendedprice[10],{1-lineitem.l_discount}[11],{1}[6],lineitem.l_discount[12]
                 Filter: customer.c_custkey[0]=orders.o_custkey[13] and customer.c_nationkey[7]=nation.n_nationkey[14]
-                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                     Output: customer.c_custkey[0],customer.c_name[1],customer.c_acctbal[5],customer.c_address[2],customer.c_phone[4],customer.c_comment[7],1,customer.c_nationkey[3]
-                -> PhysicNLJoin  (inccost=128, cost=121, rows=1) (actual rows=3500)
+                -> PhysicNLJoin  (inccost=13461, cost=2870, rows=1800) (actual rows=3500)
                     Output: nation.n_name[0],{lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],nation.n_nationkey[1]
-                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=25)
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
                         Output: nation.n_name[1],nation.n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=140, loops=25)
+                    -> PhysicHashJoin  (inccost=10566, cost=3061, rows=72) (actual rows=140, loops=25)
                         Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],lineitem.l_discount[3],orders.o_custkey[5]
                         Filter: lineitem.l_orderkey[4]=orders.o_orderkey[6]
-                        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=1457, loops=25)
+                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=1457, loops=25)
                             Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6],lineitem.l_orderkey[0]
                             Filter: lineitem.l_returnflag[8]='R'
-                        -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=64, loops=25)
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=75) (actual rows=64, loops=25)
                             Output: orders.o_custkey[1],orders.o_orderkey[0]
                             Filter: orders.o_orderdate[4]>='1993-10-01' and orders.o_orderdate[4]<'12/30/1993 12:00:00 AM'

--- a/test/primitive/expect/q10.txt
+++ b/test/primitive/expect/q10.txt
@@ -1,28 +1,28 @@
-Total cost: 37150.61
-PhysicLimit (20) (inccost=37150.61, cost=20, rows=20) (actual rows=20)
+Total cost: NaN
+PhysicLimit (20) (inccost=NaN, cost=20, rows=20) (actual rows=20)
     Output: customer.c_custkey[0],customer.c_name[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2],customer.c_acctbal[3],nation.n_name[4],customer.c_address[5],customer.c_phone[6],customer.c_comment[7]
-    -> PhysicOrder  (inccost=37130.61, cost=3164.61, rows=501) (actual rows=20)
+    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=20)
         Output: customer.c_custkey[0],customer.c_name[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2],customer.c_acctbal[3],nation.n_name[4],customer.c_address[5],customer.c_phone[6],customer.c_comment[7]
         Order by: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[2]
-        -> PhysicHashAgg  (inccost=33966, cost=1503, rows=501) (actual rows=43)
+        -> PhysicHashAgg  (inccost=134, cost=1, rows=0) (actual rows=43)
             Output: {customer.c_custkey}[0],{customer.c_name}[1],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[7],{customer.c_acctbal}[2],{nation.n_name}[4],{customer.c_address}[5],{customer.c_phone}[3],{customer.c_comment}[6]
             Aggregates: sum(lineitem.l_extendedprice[8]*1-lineitem.l_discount[11])
             Group by: customer.c_custkey[0], customer.c_name[1], customer.c_acctbal[2], customer.c_phone[5], nation.n_name[3], customer.c_address[4], customer.c_comment[6]
-            -> PhysicHashJoin  (inccost=32463, cost=9151, rows=501) (actual rows=140)
+            -> PhysicHashJoin  (inccost=133, cost=4, rows=1) (actual rows=140)
                 Output: customer.c_custkey[0],customer.c_name[1],customer.c_acctbal[2],nation.n_name[8],customer.c_address[3],customer.c_phone[4],customer.c_comment[5],{lineitem.l_extendedprice*1-lineitem.l_discount}[9],lineitem.l_extendedprice[10],{1-lineitem.l_discount}[11],{1}[6],lineitem.l_discount[12]
                 Filter: customer.c_custkey[0]=orders.o_custkey[13] and customer.c_nationkey[7]=nation.n_nationkey[14]
-                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
                     Output: customer.c_custkey[0],customer.c_name[1],customer.c_acctbal[5],customer.c_address[2],customer.c_phone[4],customer.c_comment[7],1,customer.c_nationkey[3]
-                -> PhysicNLJoin  (inccost=23162, cost=12040, rows=8350) (actual rows=3500)
+                -> PhysicNLJoin  (inccost=128, cost=121, rows=1) (actual rows=3500)
                     Output: nation.n_name[0],{lineitem.l_extendedprice*1-lineitem.l_discount}[2],lineitem.l_extendedprice[3],{1-lineitem.l_discount}[4],lineitem.l_discount[5],orders.o_custkey[6],nation.n_nationkey[1]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=25)
                         Output: nation.n_name[1],nation.n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=11097, cost=3592, rows=334) (actual rows=140, loops=25)
+                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=140, loops=25)
                         Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],lineitem.l_discount[3],orders.o_custkey[5]
                         Filter: lineitem.l_orderkey[4]=orders.o_orderkey[6]
-                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=1457, loops=25)
+                        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=1457, loops=25)
                             Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],lineitem.l_discount[6],lineitem.l_orderkey[0]
                             Filter: lineitem.l_returnflag[8]='R'
-                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=344) (actual rows=64, loops=25)
+                        -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=64, loops=25)
                             Output: orders.o_custkey[1],orders.o_orderkey[0]
                             Filter: orders.o_orderdate[4]>='1993-10-01' and orders.o_orderdate[4]<'12/30/1993 12:00:00 AM'

--- a/test/primitive/expect/q11.txt
+++ b/test/primitive/expect/q11.txt
@@ -1,39 +1,39 @@
-Total cost: NaN
-PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
+Total cost: 3127.56
+PhysicOrder  (inccost=3127.56, cost=358.56, rows=80) (actual rows=0)
     Output: partsupp.ps_partkey[0],{sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
     Order by: {sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=12, cost=1, rows=0) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2769, cost=240, rows=80) (actual rows=0)
         Output: {partsupp.ps_partkey}[0],{sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
         Aggregates: sum(partsupp.ps_supplycost[2]*partsupp.ps_availqty[3])
         Group by: partsupp.ps_partkey[0]
         Filter: {sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=14, cost=3, rows=1) (actual rows=0)
+            -> PhysicHashAgg  (inccost=2611, cost=82, rows=1) (actual rows=0)
                 Output: {sum(partsupp__1.ps_supplycost*partsupp__1.ps_availqty)}[0]*0.0001000000
                 Aggregates: sum(partsupp__1.ps_supplycost[1]*partsupp__1.ps_availqty[2])
-                -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
+                -> PhysicHashJoin  (inccost=2529, cost=1681, rows=80) (actual rows=0)
                     Output: {partsupp__1.ps_supplycost*partsupp__1.ps_availqty}[0],partsupp__1.ps_supplycost[1],partsupp__1.ps_availqty[2]
                     Filter: partsupp__1.ps_suppkey[3]=supplier__1.s_suppkey[4]
-                    -> PhysicScanTable partsupp as partsupp__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                    -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
                         Output: partsupp__1.ps_supplycost[3]*partsupp__1.ps_availqty[2],partsupp__1.ps_supplycost[3],partsupp__1.ps_availqty[2],partsupp__1.ps_suppkey[1]
-                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
                         Output: supplier__1.s_suppkey[1]
                         Filter: supplier__1.s_nationkey[2]=nation__1.n_nationkey[0]
-                        -> PhysicScanTable nation as nation__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
                             Output: nation__1.n_nationkey[0]
                             Filter: nation__1.n_name[1]='GERMANY'
-                        -> PhysicScanTable supplier as supplier__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                        -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
                             Output: supplier__1.s_suppkey[0],supplier__1.s_nationkey[3]
-        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
+        -> PhysicHashJoin  (inccost=2529, cost=1681, rows=80) (actual rows=0)
             Output: partsupp.ps_partkey[0],{partsupp.ps_supplycost*partsupp.ps_availqty}[1],partsupp.ps_supplycost[2],partsupp.ps_availqty[3]
             Filter: partsupp.ps_suppkey[4]=supplier.s_suppkey[5]
-            -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
+            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
                 Output: partsupp.ps_partkey[0],partsupp.ps_supplycost[3]*partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_availqty[2],partsupp.ps_suppkey[1]
-            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+            -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
                 Output: supplier.s_suppkey[1]
                 Filter: supplier.s_nationkey[2]=nation.n_nationkey[0]
-                -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=1)
+                -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
                     Output: nation.n_nationkey[0]
                     Filter: nation.n_name[1]='GERMANY'
-                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                     Output: supplier.s_suppkey[0],supplier.s_nationkey[3]

--- a/test/primitive/expect/q11.txt
+++ b/test/primitive/expect/q11.txt
@@ -1,0 +1,39 @@
+Total cost: 3127.56
+PhysicOrder  (inccost=3127.56, cost=358.56, rows=80) (actual rows=0)
+    Output: partsupp.ps_partkey[0],{sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
+    Order by: {sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
+    -> PhysicHashAgg  (inccost=2769, cost=240, rows=80) (actual rows=0)
+        Output: {partsupp.ps_partkey}[0],{sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
+        Aggregates: sum(partsupp.ps_supplycost[2]*partsupp.ps_availqty[3])
+        Group by: partsupp.ps_partkey[0]
+        Filter: {sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]>@1
+        <ScalarSubqueryExpr> cached 1
+            -> PhysicHashAgg  (inccost=2611, cost=82, rows=1) (actual rows=0)
+                Output: {sum(partsupp__1.ps_supplycost*partsupp__1.ps_availqty)}[0]*0.0001000000
+                Aggregates: sum(partsupp__1.ps_supplycost[1]*partsupp__1.ps_availqty[2])
+                -> PhysicHashJoin  (inccost=2529, cost=1681, rows=80) (actual rows=0)
+                    Output: {partsupp__1.ps_supplycost*partsupp__1.ps_availqty}[0],partsupp__1.ps_supplycost[1],partsupp__1.ps_availqty[2]
+                    Filter: partsupp__1.ps_suppkey[3]=supplier__1.s_suppkey[4]
+                    -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                        Output: partsupp__1.ps_supplycost[3]*partsupp__1.ps_availqty[2],partsupp__1.ps_supplycost[3],partsupp__1.ps_availqty[2],partsupp__1.ps_suppkey[1]
+                    -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+                        Output: supplier__1.s_suppkey[1]
+                        Filter: supplier__1.s_nationkey[2]=nation__1.n_nationkey[0]
+                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
+                            Output: nation__1.n_nationkey[0]
+                            Filter: nation__1.n_name[1]='GERMANY'
+                        -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                            Output: supplier__1.s_suppkey[0],supplier__1.s_nationkey[3]
+        -> PhysicHashJoin  (inccost=2529, cost=1681, rows=80) (actual rows=0)
+            Output: partsupp.ps_partkey[0],{partsupp.ps_supplycost*partsupp.ps_availqty}[1],partsupp.ps_supplycost[2],partsupp.ps_availqty[3]
+            Filter: partsupp.ps_suppkey[4]=supplier.s_suppkey[5]
+            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
+                Output: partsupp.ps_partkey[0],partsupp.ps_supplycost[3]*partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_availqty[2],partsupp.ps_suppkey[1]
+            -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+                Output: supplier.s_suppkey[1]
+                Filter: supplier.s_nationkey[2]=nation.n_nationkey[0]
+                -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+                    Output: nation.n_nationkey[0]
+                    Filter: nation.n_name[1]='GERMANY'
+                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                    Output: supplier.s_suppkey[0],supplier.s_nationkey[3]

--- a/test/primitive/expect/q11.txt
+++ b/test/primitive/expect/q11.txt
@@ -1,39 +1,39 @@
-Total cost: 3127.56
-PhysicOrder  (inccost=3127.56, cost=358.56, rows=80) (actual rows=0)
+Total cost: NaN
+PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
     Output: partsupp.ps_partkey[0],{sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
     Order by: {sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=2769, cost=240, rows=80) (actual rows=0)
+    -> PhysicHashAgg  (inccost=12, cost=1, rows=0) (actual rows=0)
         Output: {partsupp.ps_partkey}[0],{sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]
         Aggregates: sum(partsupp.ps_supplycost[2]*partsupp.ps_availqty[3])
         Group by: partsupp.ps_partkey[0]
         Filter: {sum(partsupp.ps_supplycost*partsupp.ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=2611, cost=82, rows=1) (actual rows=0)
+            -> PhysicHashAgg  (inccost=14, cost=3, rows=1) (actual rows=0)
                 Output: {sum(partsupp__1.ps_supplycost*partsupp__1.ps_availqty)}[0]*0.0001000000
                 Aggregates: sum(partsupp__1.ps_supplycost[1]*partsupp__1.ps_availqty[2])
-                -> PhysicHashJoin  (inccost=2529, cost=1681, rows=80) (actual rows=0)
+                -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
                     Output: {partsupp__1.ps_supplycost*partsupp__1.ps_availqty}[0],partsupp__1.ps_supplycost[1],partsupp__1.ps_availqty[2]
                     Filter: partsupp__1.ps_suppkey[3]=supplier__1.s_suppkey[4]
-                    -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                    -> PhysicScanTable partsupp as partsupp__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                         Output: partsupp__1.ps_supplycost[3]*partsupp__1.ps_availqty[2],partsupp__1.ps_supplycost[3],partsupp__1.ps_availqty[2],partsupp__1.ps_suppkey[1]
-                    -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
                         Output: supplier__1.s_suppkey[1]
                         Filter: supplier__1.s_nationkey[2]=nation__1.n_nationkey[0]
-                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
+                        -> PhysicScanTable nation as nation__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                             Output: nation__1.n_nationkey[0]
                             Filter: nation__1.n_name[1]='GERMANY'
-                        -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                        -> PhysicScanTable supplier as supplier__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                             Output: supplier__1.s_suppkey[0],supplier__1.s_nationkey[3]
-        -> PhysicHashJoin  (inccost=2529, cost=1681, rows=80) (actual rows=0)
+        -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
             Output: partsupp.ps_partkey[0],{partsupp.ps_supplycost*partsupp.ps_availqty}[1],partsupp.ps_supplycost[2],partsupp.ps_availqty[3]
             Filter: partsupp.ps_suppkey[4]=supplier.s_suppkey[5]
-            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=800)
+            -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=800)
                 Output: partsupp.ps_partkey[0],partsupp.ps_supplycost[3]*partsupp.ps_availqty[2],partsupp.ps_supplycost[3],partsupp.ps_availqty[2],partsupp.ps_suppkey[1]
-            -> PhysicHashJoin  (inccost=48, cost=13, rows=1) (actual rows=0)
+            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
                 Output: supplier.s_suppkey[1]
                 Filter: supplier.s_nationkey[2]=nation.n_nationkey[0]
-                -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+                -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=1)
                     Output: nation.n_nationkey[0]
                     Filter: nation.n_name[1]='GERMANY'
-                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
                     Output: supplier.s_suppkey[0],supplier.s_nationkey[3]

--- a/test/primitive/expect/q12.txt
+++ b/test/primitive/expect/q12.txt
@@ -1,16 +1,16 @@
-Total cost: NaN
-PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=2)
+Total cost: 13233.32
+PhysicOrder  (inccost=13233.32, cost=14.32, rows=7) (actual rows=2)
     Output: lineitem.l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: lineitem.l_shipmode[0]
-    -> PhysicHashAgg  (inccost=7, cost=1, rows=0) (actual rows=2)
+    -> PhysicHashAgg  (inccost=13219, cost=914, rows=7) (actual rows=2)
         Output: {lineitem.l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: lineitem.l_shipmode[0]
-        -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=25)
+        -> PhysicHashJoin  (inccost=12305, cost=4800, rows=900) (actual rows=25)
             Output: lineitem.l_shipmode[14],{case with 1}[0],{orders.o_orderpriority='1-URGENT' or orders.o_orderpriority='2-HIGH'}[1],{orders.o_orderpriority='1-URGENT'}[2],orders.o_orderpriority[3],{'1-URGENT'}[4],{orders.o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{orders.o_orderpriority<>'1-URGENT' and orders.o_orderpriority<>'2-HIGH'}[10],{orders.o_orderpriority<>'1-URGENT'}[11],{orders.o_orderpriority<>'2-HIGH'}[12]
             Filter: orders.o_orderkey[13]=lineitem.l_orderkey[15]
-            -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500)
+            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
                 Output: case with 1,orders.o_orderpriority[5]='1-URGENT' or orders.o_orderpriority[5]='2-HIGH',orders.o_orderpriority[5]='1-URGENT',orders.o_orderpriority[5],'1-URGENT',orders.o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,orders.o_orderpriority[5]<>'1-URGENT' and orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderpriority[5]<>'1-URGENT',orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderkey[0]
-            -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=25)
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=900) (actual rows=25)
                 Output: lineitem.l_shipmode[14],lineitem.l_orderkey[0]
                 Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP') and lineitem.l_commitdate[11]<lineitem.l_receiptdate[12] and lineitem.l_shipdate[10]<lineitem.l_commitdate[11] and lineitem.l_receiptdate[12]>='1994-01-01' and lineitem.l_receiptdate[12]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q12.txt
+++ b/test/primitive/expect/q12.txt
@@ -1,0 +1,16 @@
+Total cost: 16056.32
+PhysicOrder  (inccost=16056.32, cost=14.32, rows=7) (actual rows=2)
+    Output: lineitem.l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
+    Order by: lineitem.l_shipmode[0]
+    -> PhysicHashAgg  (inccost=16042, cost=1855, rows=7) (actual rows=2)
+        Output: {lineitem.l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
+        Aggregates: sum(case with 1), sum(case with 1)
+        Group by: lineitem.l_shipmode[0]
+        -> PhysicHashJoin  (inccost=14187, cost=6682, rows=1841) (actual rows=25)
+            Output: lineitem.l_shipmode[14],{case with 1}[0],{orders.o_orderpriority='1-URGENT' or orders.o_orderpriority='2-HIGH'}[1],{orders.o_orderpriority='1-URGENT'}[2],orders.o_orderpriority[3],{'1-URGENT'}[4],{orders.o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{orders.o_orderpriority<>'1-URGENT' and orders.o_orderpriority<>'2-HIGH'}[10],{orders.o_orderpriority<>'1-URGENT'}[11],{orders.o_orderpriority<>'2-HIGH'}[12]
+            Filter: orders.o_orderkey[13]=lineitem.l_orderkey[15]
+            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                Output: case with 1,orders.o_orderpriority[5]='1-URGENT' or orders.o_orderpriority[5]='2-HIGH',orders.o_orderpriority[5]='1-URGENT',orders.o_orderpriority[5],'1-URGENT',orders.o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,orders.o_orderpriority[5]<>'1-URGENT' and orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderpriority[5]<>'1-URGENT',orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderkey[0]
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1841) (actual rows=25)
+                Output: lineitem.l_shipmode[14],lineitem.l_orderkey[0]
+                Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP') and lineitem.l_commitdate[11]<lineitem.l_receiptdate[12] and lineitem.l_shipdate[10]<lineitem.l_commitdate[11] and lineitem.l_receiptdate[12]>='1994-01-01' and lineitem.l_receiptdate[12]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q12.txt
+++ b/test/primitive/expect/q12.txt
@@ -1,16 +1,16 @@
-Total cost: 13233.32
-PhysicOrder  (inccost=13233.32, cost=14.32, rows=7) (actual rows=2)
+Total cost: 11274.32
+PhysicOrder  (inccost=11274.32, cost=14.32, rows=7) (actual rows=2)
     Output: lineitem.l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: lineitem.l_shipmode[0]
-    -> PhysicHashAgg  (inccost=13219, cost=914, rows=7) (actual rows=2)
+    -> PhysicHashAgg  (inccost=11260, cost=261, rows=7) (actual rows=2)
         Output: {lineitem.l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: lineitem.l_shipmode[0]
-        -> PhysicHashJoin  (inccost=12305, cost=4800, rows=900) (actual rows=25)
+        -> PhysicHashJoin  (inccost=10999, cost=3494, rows=247) (actual rows=25)
             Output: lineitem.l_shipmode[14],{case with 1}[0],{orders.o_orderpriority='1-URGENT' or orders.o_orderpriority='2-HIGH'}[1],{orders.o_orderpriority='1-URGENT'}[2],orders.o_orderpriority[3],{'1-URGENT'}[4],{orders.o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{orders.o_orderpriority<>'1-URGENT' and orders.o_orderpriority<>'2-HIGH'}[10],{orders.o_orderpriority<>'1-URGENT'}[11],{orders.o_orderpriority<>'2-HIGH'}[12]
             Filter: orders.o_orderkey[13]=lineitem.l_orderkey[15]
             -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
                 Output: case with 1,orders.o_orderpriority[5]='1-URGENT' or orders.o_orderpriority[5]='2-HIGH',orders.o_orderpriority[5]='1-URGENT',orders.o_orderpriority[5],'1-URGENT',orders.o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,orders.o_orderpriority[5]<>'1-URGENT' and orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderpriority[5]<>'1-URGENT',orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderkey[0]
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=900) (actual rows=25)
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=247) (actual rows=25)
                 Output: lineitem.l_shipmode[14],lineitem.l_orderkey[0]
                 Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP') and lineitem.l_commitdate[11]<lineitem.l_receiptdate[12] and lineitem.l_shipdate[10]<lineitem.l_commitdate[11] and lineitem.l_receiptdate[12]>='1994-01-01' and lineitem.l_receiptdate[12]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q12.txt
+++ b/test/primitive/expect/q12.txt
@@ -1,16 +1,16 @@
-Total cost: 16056.32
-PhysicOrder  (inccost=16056.32, cost=14.32, rows=7) (actual rows=2)
+Total cost: NaN
+PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=2)
     Output: lineitem.l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: lineitem.l_shipmode[0]
-    -> PhysicHashAgg  (inccost=16042, cost=1855, rows=7) (actual rows=2)
+    -> PhysicHashAgg  (inccost=7, cost=1, rows=0) (actual rows=2)
         Output: {lineitem.l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: lineitem.l_shipmode[0]
-        -> PhysicHashJoin  (inccost=14187, cost=6682, rows=1841) (actual rows=25)
+        -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=25)
             Output: lineitem.l_shipmode[14],{case with 1}[0],{orders.o_orderpriority='1-URGENT' or orders.o_orderpriority='2-HIGH'}[1],{orders.o_orderpriority='1-URGENT'}[2],orders.o_orderpriority[3],{'1-URGENT'}[4],{orders.o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{orders.o_orderpriority<>'1-URGENT' and orders.o_orderpriority<>'2-HIGH'}[10],{orders.o_orderpriority<>'1-URGENT'}[11],{orders.o_orderpriority<>'2-HIGH'}[12]
             Filter: orders.o_orderkey[13]=lineitem.l_orderkey[15]
-            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+            -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500)
                 Output: case with 1,orders.o_orderpriority[5]='1-URGENT' or orders.o_orderpriority[5]='2-HIGH',orders.o_orderpriority[5]='1-URGENT',orders.o_orderpriority[5],'1-URGENT',orders.o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,orders.o_orderpriority[5]<>'1-URGENT' and orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderpriority[5]<>'1-URGENT',orders.o_orderpriority[5]<>'2-HIGH',orders.o_orderkey[0]
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1841) (actual rows=25)
+            -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=25)
                 Output: lineitem.l_shipmode[14],lineitem.l_orderkey[0]
                 Filter: lineitem.l_shipmode[14] in ('MAIL','SHIP') and lineitem.l_commitdate[11]<lineitem.l_receiptdate[12] and lineitem.l_shipdate[10]<lineitem.l_commitdate[11] and lineitem.l_receiptdate[12]>='1994-01-01' and lineitem.l_receiptdate[12]<'1/1/1995 12:00:00 AM'

--- a/test/primitive/expect/q13.txt
+++ b/test/primitive/expect/q13.txt
@@ -1,0 +1,22 @@
+Total cost: 8552.1
+PhysicOrder  (inccost=8552.1, cost=0.1, rows=1) (actual rows=27)
+    Output: c_orders.c_count[0],{count(*)(0)}[1]
+    Order by: {count(*)(0)}[1], c_orders.c_count[0]
+    -> PhysicHashAgg  (inccost=8552, cost=152, rows=1) (actual rows=27)
+        Output: {c_orders.c_count}[0],{count(*)(0)}[1]
+        Aggregates: count(*)(0)
+        Group by: c_orders.c_count[0]
+        -> PhysicFromQuery <c_orders> (inccost=8400, cost=150, rows=150) (actual rows=150)
+            Output: c_orders.c_count[1]
+            -> PhysicHashAgg  (inccost=8250, cost=2550, rows=150) (actual rows=150)
+                Output: {customer.c_custkey}[0],{count(orders.o_orderkey)}[1]
+                Aggregates: count(orders.o_orderkey[1])
+                Group by: customer.c_custkey[0]
+                -> PhysicHashJoin Left (inccost=5700, cost=4050, rows=2250) (actual rows=1535)
+                    Output: customer.c_custkey[0],orders.o_orderkey[1]
+                    Filter: customer.c_custkey[0]=orders.o_custkey[2]
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                        Output: customer.c_custkey[0]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1485)
+                        Output: orders.o_orderkey[0],orders.o_custkey[1]
+                        Filter: orders.o_comment[8]not like'%special%requests%'

--- a/test/primitive/expect/q13.txt
+++ b/test/primitive/expect/q13.txt
@@ -1,22 +1,22 @@
-Total cost: 10.1
-PhysicOrder  (inccost=10.1, cost=0.1, rows=1) (actual rows=27)
+Total cost: 8552.1
+PhysicOrder  (inccost=8552.1, cost=0.1, rows=1) (actual rows=27)
     Output: c_orders.c_count[0],{count(*)(0)}[1]
     Order by: {count(*)(0)}[1], c_orders.c_count[0]
-    -> PhysicHashAgg  (inccost=10, cost=3, rows=1) (actual rows=27)
+    -> PhysicHashAgg  (inccost=8552, cost=152, rows=1) (actual rows=27)
         Output: {c_orders.c_count}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: c_orders.c_count[0]
-        -> PhysicFromQuery <c_orders> (inccost=7, cost=0, rows=1) (actual rows=150)
+        -> PhysicFromQuery <c_orders> (inccost=8400, cost=150, rows=150) (actual rows=150)
             Output: c_orders.c_count[1]
-            -> PhysicHashAgg  (inccost=7, cost=1, rows=0) (actual rows=150)
+            -> PhysicHashAgg  (inccost=8250, cost=2550, rows=150) (actual rows=150)
                 Output: {customer.c_custkey}[0],{count(orders.o_orderkey)}[1]
                 Aggregates: count(orders.o_orderkey[1])
                 Group by: customer.c_custkey[0]
-                -> PhysicHashJoin Left (inccost=6, cost=4, rows=1) (actual rows=1535)
+                -> PhysicHashJoin Left (inccost=5700, cost=4050, rows=2250) (actual rows=1535)
                     Output: customer.c_custkey[0],orders.o_orderkey[1]
                     Filter: customer.c_custkey[0]=orders.o_custkey[2]
-                    -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                         Output: customer.c_custkey[0]
-                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1485)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1485)
                         Output: orders.o_orderkey[0],orders.o_custkey[1]
                         Filter: orders.o_comment[8]not like'%special%requests%'

--- a/test/primitive/expect/q13.txt
+++ b/test/primitive/expect/q13.txt
@@ -1,22 +1,22 @@
-Total cost: 8552.1
-PhysicOrder  (inccost=8552.1, cost=0.1, rows=1) (actual rows=27)
+Total cost: 10.1
+PhysicOrder  (inccost=10.1, cost=0.1, rows=1) (actual rows=27)
     Output: c_orders.c_count[0],{count(*)(0)}[1]
     Order by: {count(*)(0)}[1], c_orders.c_count[0]
-    -> PhysicHashAgg  (inccost=8552, cost=152, rows=1) (actual rows=27)
+    -> PhysicHashAgg  (inccost=10, cost=3, rows=1) (actual rows=27)
         Output: {c_orders.c_count}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: c_orders.c_count[0]
-        -> PhysicFromQuery <c_orders> (inccost=8400, cost=150, rows=150) (actual rows=150)
+        -> PhysicFromQuery <c_orders> (inccost=7, cost=0, rows=1) (actual rows=150)
             Output: c_orders.c_count[1]
-            -> PhysicHashAgg  (inccost=8250, cost=2550, rows=150) (actual rows=150)
+            -> PhysicHashAgg  (inccost=7, cost=1, rows=0) (actual rows=150)
                 Output: {customer.c_custkey}[0],{count(orders.o_orderkey)}[1]
                 Aggregates: count(orders.o_orderkey[1])
                 Group by: customer.c_custkey[0]
-                -> PhysicHashJoin Left (inccost=5700, cost=4050, rows=2250) (actual rows=1535)
+                -> PhysicHashJoin Left (inccost=6, cost=4, rows=1) (actual rows=1535)
                     Output: customer.c_custkey[0],orders.o_orderkey[1]
                     Filter: customer.c_custkey[0]=orders.o_custkey[2]
-                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                    -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
                         Output: customer.c_custkey[0]
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1485)
+                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1485)
                         Output: orders.o_orderkey[0],orders.o_custkey[1]
                         Filter: orders.o_comment[8]not like'%special%requests%'

--- a/test/primitive/expect/q14.txt
+++ b/test/primitive/expect/q14.txt
@@ -1,0 +1,12 @@
+Total cost: 12631
+PhysicHashAgg  (inccost=12631, cost=1558, rows=1) (actual rows=1)
+    Output: 100.00*{sum(case with 1)}[0]/{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1](as promo_revenue)
+    Aggregates: sum(case with 1), sum(lineitem.l_extendedprice[5]*1-lineitem.l_discount[8])
+    -> PhysicHashJoin  (inccost=11073, cost=4868, rows=1556) (actual rows=84)
+        Output: case with 1,{part.p_typelike'PROMO%'}[9],part.p_type[8],{'PROMO%'}[2],{lineitem.l_extendedprice*1-lineitem.l_discount}[3],lineitem.l_extendedprice[0],{1-lineitem.l_discount}[4],{1}[5],lineitem.l_discount[1],{0}[6]
+        Filter: lineitem.l_partkey[7]=part.p_partkey[10]
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1556) (actual rows=84)
+            Output: lineitem.l_extendedprice[5],lineitem.l_discount[6],'PROMO%',lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],1-lineitem.l_discount[6],1,0,lineitem.l_partkey[1]
+            Filter: lineitem.l_shipdate[10]>='1995-09-01' and lineitem.l_shipdate[10]<'10/1/1995 12:00:00 AM'
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200)
+            Output: part.p_type[4],part.p_type[4]like'PROMO%',part.p_partkey[0]

--- a/test/primitive/expect/q14.txt
+++ b/test/primitive/expect/q14.txt
@@ -1,12 +1,12 @@
-Total cost: 9
-PhysicHashAgg  (inccost=9, cost=3, rows=1) (actual rows=1)
+Total cost: 6887
+PhysicHashAgg  (inccost=6887, cost=122, rows=1) (actual rows=1)
     Output: 100.00*{sum(case with 1)}[0]/{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1](as promo_revenue)
     Aggregates: sum(case with 1), sum(lineitem.l_extendedprice[5]*1-lineitem.l_discount[8])
-    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=84)
+    -> PhysicHashJoin  (inccost=6765, cost=560, rows=120) (actual rows=84)
         Output: case with 1,{part.p_typelike'PROMO%'}[9],part.p_type[8],{'PROMO%'}[2],{lineitem.l_extendedprice*1-lineitem.l_discount}[3],lineitem.l_extendedprice[0],{1-lineitem.l_discount}[4],{1}[5],lineitem.l_discount[1],{0}[6]
         Filter: lineitem.l_partkey[7]=part.p_partkey[10]
-        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=84)
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=120) (actual rows=84)
             Output: lineitem.l_extendedprice[5],lineitem.l_discount[6],'PROMO%',lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],1-lineitem.l_discount[6],1,0,lineitem.l_partkey[1]
             Filter: lineitem.l_shipdate[10]>='1995-09-01' and lineitem.l_shipdate[10]<'10/1/1995 12:00:00 AM'
-        -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=200)
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200)
             Output: part.p_type[4],part.p_type[4]like'PROMO%',part.p_partkey[0]

--- a/test/primitive/expect/q14.txt
+++ b/test/primitive/expect/q14.txt
@@ -1,12 +1,12 @@
-Total cost: 12631
-PhysicHashAgg  (inccost=12631, cost=1558, rows=1) (actual rows=1)
+Total cost: 9
+PhysicHashAgg  (inccost=9, cost=3, rows=1) (actual rows=1)
     Output: 100.00*{sum(case with 1)}[0]/{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1](as promo_revenue)
     Aggregates: sum(case with 1), sum(lineitem.l_extendedprice[5]*1-lineitem.l_discount[8])
-    -> PhysicHashJoin  (inccost=11073, cost=4868, rows=1556) (actual rows=84)
+    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=84)
         Output: case with 1,{part.p_typelike'PROMO%'}[9],part.p_type[8],{'PROMO%'}[2],{lineitem.l_extendedprice*1-lineitem.l_discount}[3],lineitem.l_extendedprice[0],{1-lineitem.l_discount}[4],{1}[5],lineitem.l_discount[1],{0}[6]
         Filter: lineitem.l_partkey[7]=part.p_partkey[10]
-        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1556) (actual rows=84)
+        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=84)
             Output: lineitem.l_extendedprice[5],lineitem.l_discount[6],'PROMO%',lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],1-lineitem.l_discount[6],1,0,lineitem.l_partkey[1]
             Filter: lineitem.l_shipdate[10]>='1995-09-01' and lineitem.l_shipdate[10]<'10/1/1995 12:00:00 AM'
-        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200)
+        -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=200)
             Output: part.p_type[4],part.p_type[4]like'PROMO%',part.p_partkey[0]

--- a/test/primitive/expect/q15.txt
+++ b/test/primitive/expect/q15.txt
@@ -1,31 +1,31 @@
-Total cost: 8
-PhysicFilter  (inccost=8, cost=1, rows=1) (actual rows=1)
+Total cost: 6335
+PhysicFilter  (inccost=6335, cost=10, rows=10) (actual rows=1)
     Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[3],revenue0.total_revenue[4]
     Filter: revenue0.total_revenue[4]=@1
     <ScalarSubqueryExpr> cached 1
-        -> PhysicHashAgg  (inccost=5, cost=3, rows=1) (actual rows=1)
+        -> PhysicHashAgg  (inccost=6287, cost=12, rows=1) (actual rows=1)
             Output: {max(revenue0__1.total_revenue)}[0]
             Aggregates: max(revenue0__1.total_revenue[0])
-            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=2, cost=0, rows=1) (actual rows=10)
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=6275, cost=10, rows=10) (actual rows=10)
                 Output: revenue0__1.total_revenue[1]
-                -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=10)
+                -> PhysicHashAgg  (inccost=6265, cost=260, rows=10) (actual rows=10)
                     Output: {lineitem.l_suppkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
                     Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
                     Group by: lineitem.l_suppkey[0]
-                    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=201)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=240) (actual rows=201)
                         Output: lineitem.l_suppkey (as supplier_no)[2],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6]
                         Filter: lineitem.l_shipdate[10]>='1996-01-01' and lineitem.l_shipdate[10]<'3/31/1996 12:00:00 AM'
-    -> PhysicHashJoin  (inccost=7, cost=4, rows=1) (actual rows=10)
+    -> PhysicHashJoin  (inccost=6325, cost=40, rows=10) (actual rows=10)
         Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[3],revenue0.total_revenue[4]
         Filter: supplier.s_suppkey[0]=revenue0.supplier_no[5]
-        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
             Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[4]
-        -> PhysicFromQuery <revenue0> (inccost=2, cost=0, rows=1) (actual rows=10)
+        -> PhysicFromQuery <revenue0> (inccost=6275, cost=10, rows=10) (actual rows=10)
             Output: revenue0.total_revenue[1],revenue0.supplier_no[0]
-            -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=10)
+            -> PhysicHashAgg  (inccost=6265, cost=260, rows=10) (actual rows=10)
                 Output: {lineitem.l_suppkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
                 Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
                 Group by: lineitem.l_suppkey[0]
-                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=201)
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=240) (actual rows=201)
                     Output: lineitem.l_suppkey (as supplier_no)[2],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6]
                     Filter: lineitem.l_shipdate[10]>='1996-01-01' and lineitem.l_shipdate[10]<'3/31/1996 12:00:00 AM'

--- a/test/primitive/expect/q15.txt
+++ b/test/primitive/expect/q15.txt
@@ -1,0 +1,31 @@
+Total cost: 7670
+PhysicFilter  (inccost=7670, cost=10, rows=10) (actual rows=1)
+    Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[3],revenue0.total_revenue[4]
+    Filter: revenue0.total_revenue[4]=@1
+    <ScalarSubqueryExpr> cached 1
+        -> PhysicHashAgg  (inccost=7622, cost=12, rows=1) (actual rows=1)
+            Output: {max(revenue0__1.total_revenue)}[0]
+            Aggregates: max(revenue0__1.total_revenue[0])
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7610, cost=10, rows=10) (actual rows=10)
+                Output: revenue0__1.total_revenue[1]
+                -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+                    Output: {lineitem.l_suppkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
+                    Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
+                    Group by: lineitem.l_suppkey[0]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                        Output: lineitem.l_suppkey (as supplier_no)[2],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6]
+                        Filter: lineitem.l_shipdate[10]>='1996-01-01' and lineitem.l_shipdate[10]<'3/31/1996 12:00:00 AM'
+    -> PhysicHashJoin  (inccost=7660, cost=40, rows=10) (actual rows=10)
+        Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[3],revenue0.total_revenue[4]
+        Filter: supplier.s_suppkey[0]=revenue0.supplier_no[5]
+        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+            Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[4]
+        -> PhysicFromQuery <revenue0> (inccost=7610, cost=10, rows=10) (actual rows=10)
+            Output: revenue0.total_revenue[1],revenue0.supplier_no[0]
+            -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+                Output: {lineitem.l_suppkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
+                Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
+                Group by: lineitem.l_suppkey[0]
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                    Output: lineitem.l_suppkey (as supplier_no)[2],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6]
+                    Filter: lineitem.l_shipdate[10]>='1996-01-01' and lineitem.l_shipdate[10]<'3/31/1996 12:00:00 AM'

--- a/test/primitive/expect/q15.txt
+++ b/test/primitive/expect/q15.txt
@@ -1,31 +1,31 @@
-Total cost: 7670
-PhysicFilter  (inccost=7670, cost=10, rows=10) (actual rows=1)
+Total cost: 8
+PhysicFilter  (inccost=8, cost=1, rows=1) (actual rows=1)
     Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[3],revenue0.total_revenue[4]
     Filter: revenue0.total_revenue[4]=@1
     <ScalarSubqueryExpr> cached 1
-        -> PhysicHashAgg  (inccost=7622, cost=12, rows=1) (actual rows=1)
+        -> PhysicHashAgg  (inccost=5, cost=3, rows=1) (actual rows=1)
             Output: {max(revenue0__1.total_revenue)}[0]
             Aggregates: max(revenue0__1.total_revenue[0])
-            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7610, cost=10, rows=10) (actual rows=10)
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=2, cost=0, rows=1) (actual rows=10)
                 Output: revenue0__1.total_revenue[1]
-                -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+                -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=10)
                     Output: {lineitem.l_suppkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
                     Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
                     Group by: lineitem.l_suppkey[0]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=201)
                         Output: lineitem.l_suppkey (as supplier_no)[2],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6]
                         Filter: lineitem.l_shipdate[10]>='1996-01-01' and lineitem.l_shipdate[10]<'3/31/1996 12:00:00 AM'
-    -> PhysicHashJoin  (inccost=7660, cost=40, rows=10) (actual rows=10)
+    -> PhysicHashJoin  (inccost=7, cost=4, rows=1) (actual rows=10)
         Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[3],revenue0.total_revenue[4]
         Filter: supplier.s_suppkey[0]=revenue0.supplier_no[5]
-        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
             Output: supplier.s_suppkey[0],supplier.s_name[1],supplier.s_address[2],supplier.s_phone[4]
-        -> PhysicFromQuery <revenue0> (inccost=7610, cost=10, rows=10) (actual rows=10)
+        -> PhysicFromQuery <revenue0> (inccost=2, cost=0, rows=1) (actual rows=10)
             Output: revenue0.total_revenue[1],revenue0.supplier_no[0]
-            -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+            -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=10)
                 Output: {lineitem.l_suppkey}[0],{sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[1]
                 Aggregates: sum(lineitem.l_extendedprice[2]*1-lineitem.l_discount[5])
                 Group by: lineitem.l_suppkey[0]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=201)
                     Output: lineitem.l_suppkey (as supplier_no)[2],lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6]
                     Filter: lineitem.l_shipdate[10]>='1996-01-01' and lineitem.l_shipdate[10]<'3/31/1996 12:00:00 AM'

--- a/test/primitive/expect/q16.txt
+++ b/test/primitive/expect/q16.txt
@@ -1,12 +1,12 @@
-Total cost: 11427.68
-PhysicOrder  (inccost=11427.68, cost=5427.68, rows=800) (actual rows=0)
+Total cost: 3983.38
+PhysicOrder  (inccost=3983.38, cost=754.38, rows=148) (actual rows=0)
     Output: part.p_brand[0],part.p_type[1],part.p_size[2],{count(partsupp.ps_suppkey)}[3]
     Order by: {count(partsupp.ps_suppkey)}[3], part.p_brand[0], part.p_type[1], part.p_size[2]
-    -> PhysicHashAgg  (inccost=6000, cost=2400, rows=800) (actual rows=0)
+    -> PhysicHashAgg  (inccost=3229, cost=444, rows=148) (actual rows=0)
         Output: {part.p_brand}[0],{part.p_type}[1],{part.p_size}[2],{count(partsupp.ps_suppkey)}[3]
         Aggregates: count(partsupp.ps_suppkey[3])
         Group by: part.p_brand[0], part.p_type[1], part.p_size[2]
-        -> PhysicHashJoin  (inccost=3600, cost=2600, rows=800) (actual rows=0)
+        -> PhysicHashJoin  (inccost=2785, cost=1785, rows=148) (actual rows=0)
             Output: part.p_brand[2],part.p_type[3],part.p_size[4],partsupp.ps_suppkey[0]
             Filter: part.p_partkey[5]=partsupp.ps_partkey[1]
             -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
@@ -16,6 +16,6 @@ PhysicOrder  (inccost=11427.68, cost=5427.68, rows=800) (actual rows=0)
                     -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
                         Output: supplier.s_suppkey[0]
                         Filter: supplier.s_comment[6]like'%Customer%Complaints%'
-            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
+            -> PhysicScanTable part (inccost=200, cost=200, rows=37) (actual rows=0)
                 Output: part.p_brand[3],part.p_type[4],part.p_size[5],part.p_partkey[0]
                 Filter: part.p_brand[3]<>'Brand#45' and part.p_type[4]not like'MEDIUM POLISHED%' and part.p_size[5] in (49,14,23, ... <Total: 8> )

--- a/test/primitive/expect/q16.txt
+++ b/test/primitive/expect/q16.txt
@@ -1,21 +1,21 @@
-Total cost: 11427.68
-PhysicOrder  (inccost=11427.68, cost=5427.68, rows=800) (actual rows=0)
+Total cost: NaN
+PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
     Output: part.p_brand[0],part.p_type[1],part.p_size[2],{count(partsupp.ps_suppkey)}[3]
     Order by: {count(partsupp.ps_suppkey)}[3], part.p_brand[0], part.p_type[1], part.p_size[2]
-    -> PhysicHashAgg  (inccost=6000, cost=2400, rows=800) (actual rows=0)
+    -> PhysicHashAgg  (inccost=7, cost=1, rows=0) (actual rows=0)
         Output: {part.p_brand}[0],{part.p_type}[1],{part.p_size}[2],{count(partsupp.ps_suppkey)}[3]
         Aggregates: count(partsupp.ps_suppkey[3])
         Group by: part.p_brand[0], part.p_type[1], part.p_size[2]
-        -> PhysicHashJoin  (inccost=3600, cost=2600, rows=800) (actual rows=0)
+        -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
             Output: part.p_brand[2],part.p_type[3],part.p_size[4],partsupp.ps_suppkey[0]
             Filter: part.p_partkey[5]=partsupp.ps_partkey[1]
-            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+            -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=0)
                 Output: partsupp.ps_suppkey[1],partsupp.ps_partkey[0]
                 Filter: partsupp.ps_suppkey[1] in @1
                 <InSubqueryExpr> cached 1
-                    -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
+                    -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=0)
                         Output: supplier.s_suppkey[0]
                         Filter: supplier.s_comment[6]like'%Customer%Complaints%'
-            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
+            -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=0)
                 Output: part.p_brand[3],part.p_type[4],part.p_size[5],part.p_partkey[0]
                 Filter: part.p_brand[3]<>'Brand#45' and part.p_type[4]not like'MEDIUM POLISHED%' and part.p_size[5] in (49,14,23, ... <Total: 8> )

--- a/test/primitive/expect/q16.txt
+++ b/test/primitive/expect/q16.txt
@@ -1,21 +1,21 @@
-Total cost: NaN
-PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
+Total cost: 11427.68
+PhysicOrder  (inccost=11427.68, cost=5427.68, rows=800) (actual rows=0)
     Output: part.p_brand[0],part.p_type[1],part.p_size[2],{count(partsupp.ps_suppkey)}[3]
     Order by: {count(partsupp.ps_suppkey)}[3], part.p_brand[0], part.p_type[1], part.p_size[2]
-    -> PhysicHashAgg  (inccost=7, cost=1, rows=0) (actual rows=0)
+    -> PhysicHashAgg  (inccost=6000, cost=2400, rows=800) (actual rows=0)
         Output: {part.p_brand}[0],{part.p_type}[1],{part.p_size}[2],{count(partsupp.ps_suppkey)}[3]
         Aggregates: count(partsupp.ps_suppkey[3])
         Group by: part.p_brand[0], part.p_type[1], part.p_size[2]
-        -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+        -> PhysicHashJoin  (inccost=3600, cost=2600, rows=800) (actual rows=0)
             Output: part.p_brand[2],part.p_type[3],part.p_size[4],partsupp.ps_suppkey[0]
             Filter: part.p_partkey[5]=partsupp.ps_partkey[1]
-            -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=0)
+            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                 Output: partsupp.ps_suppkey[1],partsupp.ps_partkey[0]
                 Filter: partsupp.ps_suppkey[1] in @1
                 <InSubqueryExpr> cached 1
-                    -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=0)
+                    -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
                         Output: supplier.s_suppkey[0]
                         Filter: supplier.s_comment[6]like'%Customer%Complaints%'
-            -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=0)
+            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
                 Output: part.p_brand[3],part.p_type[4],part.p_size[5],part.p_partkey[0]
                 Filter: part.p_brand[3]<>'Brand#45' and part.p_type[4]not like'MEDIUM POLISHED%' and part.p_size[5] in (49,14,23, ... <Total: 8> )

--- a/test/primitive/expect/q16.txt
+++ b/test/primitive/expect/q16.txt
@@ -1,0 +1,21 @@
+Total cost: 11427.68
+PhysicOrder  (inccost=11427.68, cost=5427.68, rows=800) (actual rows=0)
+    Output: part.p_brand[0],part.p_type[1],part.p_size[2],{count(partsupp.ps_suppkey)}[3]
+    Order by: {count(partsupp.ps_suppkey)}[3], part.p_brand[0], part.p_type[1], part.p_size[2]
+    -> PhysicHashAgg  (inccost=6000, cost=2400, rows=800) (actual rows=0)
+        Output: {part.p_brand}[0],{part.p_type}[1],{part.p_size}[2],{count(partsupp.ps_suppkey)}[3]
+        Aggregates: count(partsupp.ps_suppkey[3])
+        Group by: part.p_brand[0], part.p_type[1], part.p_size[2]
+        -> PhysicHashJoin  (inccost=3600, cost=2600, rows=800) (actual rows=0)
+            Output: part.p_brand[2],part.p_type[3],part.p_size[4],partsupp.ps_suppkey[0]
+            Filter: part.p_partkey[5]=partsupp.ps_partkey[1]
+            -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                Output: partsupp.ps_suppkey[1],partsupp.ps_partkey[0]
+                Filter: partsupp.ps_suppkey[1] in @1
+                <InSubqueryExpr> cached 1
+                    -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
+                        Output: supplier.s_suppkey[0]
+                        Filter: supplier.s_comment[6]like'%Customer%Complaints%'
+            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
+                Output: part.p_brand[3],part.p_type[4],part.p_size[5],part.p_partkey[0]
+                Filter: part.p_brand[3]<>'Brand#45' and part.p_type[4]not like'MEDIUM POLISHED%' and part.p_size[5] in (49,14,23, ... <Total: 8> )

--- a/test/primitive/expect/q17.txt
+++ b/test/primitive/expect/q17.txt
@@ -1,24 +1,24 @@
-Total cost: 39118
-PhysicHashAgg  (inccost=39118, cost=32, rows=1) (actual rows=1)
+Total cost: 122
+PhysicHashAgg  (inccost=122, cost=3, rows=1) (actual rows=1)
     Output: {sum(lineitem.l_extendedprice)}[0]/7.0(as avg_yearly)
     Aggregates: sum(lineitem.l_extendedprice[0])
-    -> PhysicFilter  (inccost=39086, cost=30, rows=30) (actual rows=0)
+    -> PhysicFilter  (inccost=119, cost=1, rows=1) (actual rows=0)
         Output: lineitem.l_extendedprice[0]
         Filter: lineitem.l_quantity[1]<0.2*{avg(lineitem__1.l_quantity)}[2]
-        -> PhysicNLJoin Left (inccost=39056, cost=8400, rows=30) (actual rows=0)
+        -> PhysicNLJoin Left (inccost=118, cost=110, rows=1) (actual rows=0)
             Output: lineitem.l_extendedprice[0],lineitem.l_quantity[1],{avg(lineitem__1.l_quantity)}[3]
             Filter: lineitem__1.l_partkey[4]=part.p_partkey[2]
-            -> PhysicHashJoin  (inccost=18246, cost=12041, rows=30) (actual rows=0)
+            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
                 Output: lineitem.l_extendedprice[0],lineitem.l_quantity[1],part.p_partkey[3]
                 Filter: part.p_partkey[3]=lineitem.l_partkey[2]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
                     Output: lineitem.l_extendedprice[5],lineitem.l_quantity[4],lineitem.l_partkey[1]
-                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=0)
                     Output: part.p_partkey[0]
                     Filter: part.p_container[6]='MED BOX' and part.p_brand[3]='Brand#23'
-            -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200) (actual rows=0)
+            -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=0)
                 Output: {avg(lineitem__1.l_quantity)}[1],{lineitem__1.l_partkey}[0]
                 Aggregates: avg(lineitem__1.l_quantity[1])
                 Group by: lineitem__1.l_partkey[0]
-                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                -> PhysicScanTable lineitem as lineitem__1 (inccost=1, cost=1, rows=1) (actual rows=0)
                     Output: lineitem__1.l_partkey[1],lineitem__1.l_quantity[4]

--- a/test/primitive/expect/q17.txt
+++ b/test/primitive/expect/q17.txt
@@ -1,24 +1,24 @@
-Total cost: 122
-PhysicHashAgg  (inccost=122, cost=3, rows=1) (actual rows=1)
+Total cost: 39118
+PhysicHashAgg  (inccost=39118, cost=32, rows=1) (actual rows=1)
     Output: {sum(lineitem.l_extendedprice)}[0]/7.0(as avg_yearly)
     Aggregates: sum(lineitem.l_extendedprice[0])
-    -> PhysicFilter  (inccost=119, cost=1, rows=1) (actual rows=0)
+    -> PhysicFilter  (inccost=39086, cost=30, rows=30) (actual rows=0)
         Output: lineitem.l_extendedprice[0]
         Filter: lineitem.l_quantity[1]<0.2*{avg(lineitem__1.l_quantity)}[2]
-        -> PhysicNLJoin Left (inccost=118, cost=110, rows=1) (actual rows=0)
+        -> PhysicNLJoin Left (inccost=39056, cost=8400, rows=30) (actual rows=0)
             Output: lineitem.l_extendedprice[0],lineitem.l_quantity[1],{avg(lineitem__1.l_quantity)}[3]
             Filter: lineitem__1.l_partkey[4]=part.p_partkey[2]
-            -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+            -> PhysicHashJoin  (inccost=18246, cost=12041, rows=30) (actual rows=0)
                 Output: lineitem.l_extendedprice[0],lineitem.l_quantity[1],part.p_partkey[3]
                 Filter: part.p_partkey[3]=lineitem.l_partkey[2]
-                -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
                     Output: lineitem.l_extendedprice[5],lineitem.l_quantity[4],lineitem.l_partkey[1]
-                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=0)
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
                     Output: part.p_partkey[0]
                     Filter: part.p_container[6]='MED BOX' and part.p_brand[3]='Brand#23'
-            -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=0)
+            -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200) (actual rows=0)
                 Output: {avg(lineitem__1.l_quantity)}[1],{lineitem__1.l_partkey}[0]
                 Aggregates: avg(lineitem__1.l_quantity[1])
                 Group by: lineitem__1.l_partkey[0]
-                -> PhysicScanTable lineitem as lineitem__1 (inccost=1, cost=1, rows=1) (actual rows=0)
+                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                     Output: lineitem__1.l_partkey[1],lineitem__1.l_quantity[4]

--- a/test/primitive/expect/q17.txt
+++ b/test/primitive/expect/q17.txt
@@ -1,0 +1,24 @@
+Total cost: 39118
+PhysicHashAgg  (inccost=39118, cost=32, rows=1) (actual rows=1)
+    Output: {sum(lineitem.l_extendedprice)}[0]/7.0(as avg_yearly)
+    Aggregates: sum(lineitem.l_extendedprice[0])
+    -> PhysicFilter  (inccost=39086, cost=30, rows=30) (actual rows=0)
+        Output: lineitem.l_extendedprice[0]
+        Filter: lineitem.l_quantity[1]<0.2*{avg(lineitem__1.l_quantity)}[2]
+        -> PhysicNLJoin Left (inccost=39056, cost=8400, rows=30) (actual rows=0)
+            Output: lineitem.l_extendedprice[0],lineitem.l_quantity[1],{avg(lineitem__1.l_quantity)}[3]
+            Filter: lineitem__1.l_partkey[4]=part.p_partkey[2]
+            -> PhysicHashJoin  (inccost=18246, cost=12041, rows=30) (actual rows=0)
+                Output: lineitem.l_extendedprice[0],lineitem.l_quantity[1],part.p_partkey[3]
+                Filter: part.p_partkey[3]=lineitem.l_partkey[2]
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                    Output: lineitem.l_extendedprice[5],lineitem.l_quantity[4],lineitem.l_partkey[1]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                    Output: part.p_partkey[0]
+                    Filter: part.p_container[6]='MED BOX' and part.p_brand[3]='Brand#23'
+            -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200) (actual rows=0)
+                Output: {avg(lineitem__1.l_quantity)}[1],{lineitem__1.l_partkey}[0]
+                Aggregates: avg(lineitem__1.l_quantity[1])
+                Group by: lineitem__1.l_partkey[0]
+                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                    Output: lineitem__1.l_partkey[1],lineitem__1.l_quantity[4]

--- a/test/primitive/expect/q18.txt
+++ b/test/primitive/expect/q18.txt
@@ -1,0 +1,31 @@
+Total cost: 152519.25
+PhysicLimit (100) (inccost=152519.25, cost=100, rows=100) (actual rows=0)
+    Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],{sum(lineitem.l_quantity)}[5]
+    -> PhysicOrder  (inccost=152419.25, cost=82916.25, rows=9007) (actual rows=0)
+        Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],{sum(lineitem.l_quantity)}[5]
+        Order by: orders.o_totalprice[4], orders.o_orderdate[3]
+        -> PhysicHashAgg  (inccost=69503, cost=27021, rows=9007) (actual rows=0)
+            Output: {customer.c_name}[0],{customer.c_custkey}[1],{orders.o_orderkey}[2],{orders.o_orderdate}[3],{orders.o_totalprice}[4],{sum(lineitem.l_quantity)}[5]
+            Aggregates: sum(lineitem.l_quantity[5])
+            Group by: customer.c_name[0], customer.c_custkey[1], orders.o_orderkey[2], orders.o_orderdate[3], orders.o_totalprice[4]
+            -> PhysicHashJoin  (inccost=42482, cost=15312, rows=9007) (actual rows=0)
+                Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],lineitem.l_quantity[5]
+                Filter: customer.c_custkey[1]=orders.o_custkey[6]
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                    Output: customer.c_name[1],customer.c_custkey[0]
+                -> PhysicHashJoin  (inccost=27020, cost=19515, rows=6005) (actual rows=0)
+                    Output: orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],lineitem.l_quantity[0],orders.o_custkey[5]
+                    Filter: orders.o_orderkey[2]=lineitem.l_orderkey[1]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                        Output: lineitem.l_quantity[4],lineitem.l_orderkey[0]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
+                        Output: orders.o_orderkey[0],orders.o_orderdate[4],orders.o_totalprice[3],orders.o_custkey[1]
+                        Filter: orders.o_orderkey[0] in @1
+                        <InSubqueryExpr> cached 1
+                            -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500) (actual rows=0)
+                                Output: {lineitem__1.l_orderkey}[0]
+                                Aggregates: sum(lineitem__1.l_quantity[1])
+                                Group by: lineitem__1.l_orderkey[0]
+                                Filter: {sum(lineitem__1.l_quantity)}[1]>300
+                                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                    Output: lineitem__1.l_orderkey[0],lineitem__1.l_quantity[4]

--- a/test/primitive/expect/q18.txt
+++ b/test/primitive/expect/q18.txt
@@ -1,31 +1,31 @@
-Total cost: 152519.25
-PhysicLimit (100) (inccost=152519.25, cost=100, rows=100) (actual rows=0)
+Total cost: NaN
+PhysicLimit (100) (inccost=NaN, cost=100, rows=100) (actual rows=0)
     Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],{sum(lineitem.l_quantity)}[5]
-    -> PhysicOrder  (inccost=152419.25, cost=82916.25, rows=9007) (actual rows=0)
+    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
         Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],{sum(lineitem.l_quantity)}[5]
         Order by: orders.o_totalprice[4], orders.o_orderdate[3]
-        -> PhysicHashAgg  (inccost=69503, cost=27021, rows=9007) (actual rows=0)
+        -> PhysicHashAgg  (inccost=12, cost=1, rows=0) (actual rows=0)
             Output: {customer.c_name}[0],{customer.c_custkey}[1],{orders.o_orderkey}[2],{orders.o_orderdate}[3],{orders.o_totalprice}[4],{sum(lineitem.l_quantity)}[5]
             Aggregates: sum(lineitem.l_quantity[5])
             Group by: customer.c_name[0], customer.c_custkey[1], orders.o_orderkey[2], orders.o_orderdate[3], orders.o_totalprice[4]
-            -> PhysicHashJoin  (inccost=42482, cost=15312, rows=9007) (actual rows=0)
+            -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
                 Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],lineitem.l_quantity[5]
                 Filter: customer.c_custkey[1]=orders.o_custkey[6]
-                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
+                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
                     Output: customer.c_name[1],customer.c_custkey[0]
-                -> PhysicHashJoin  (inccost=27020, cost=19515, rows=6005) (actual rows=0)
+                -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
                     Output: orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],lineitem.l_quantity[0],orders.o_custkey[5]
                     Filter: orders.o_orderkey[2]=lineitem.l_orderkey[1]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
                         Output: lineitem.l_quantity[4],lineitem.l_orderkey[0]
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=0)
                         Output: orders.o_orderkey[0],orders.o_orderdate[4],orders.o_totalprice[3],orders.o_custkey[1]
                         Filter: orders.o_orderkey[0] in @1
                         <InSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500) (actual rows=0)
+                            -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=0)
                                 Output: {lineitem__1.l_orderkey}[0]
                                 Aggregates: sum(lineitem__1.l_quantity[1])
                                 Group by: lineitem__1.l_orderkey[0]
                                 Filter: {sum(lineitem__1.l_quantity)}[1]>300
-                                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+                                -> PhysicScanTable lineitem as lineitem__1 (inccost=1, cost=1, rows=1) (actual rows=6005)
                                     Output: lineitem__1.l_orderkey[0],lineitem__1.l_quantity[4]

--- a/test/primitive/expect/q18.txt
+++ b/test/primitive/expect/q18.txt
@@ -1,31 +1,31 @@
-Total cost: NaN
-PhysicLimit (100) (inccost=NaN, cost=100, rows=100) (actual rows=0)
+Total cost: 152519.25
+PhysicLimit (100) (inccost=152519.25, cost=100, rows=100) (actual rows=0)
     Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],{sum(lineitem.l_quantity)}[5]
-    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
+    -> PhysicOrder  (inccost=152419.25, cost=82916.25, rows=9007) (actual rows=0)
         Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],{sum(lineitem.l_quantity)}[5]
         Order by: orders.o_totalprice[4], orders.o_orderdate[3]
-        -> PhysicHashAgg  (inccost=12, cost=1, rows=0) (actual rows=0)
+        -> PhysicHashAgg  (inccost=69503, cost=27021, rows=9007) (actual rows=0)
             Output: {customer.c_name}[0],{customer.c_custkey}[1],{orders.o_orderkey}[2],{orders.o_orderdate}[3],{orders.o_totalprice}[4],{sum(lineitem.l_quantity)}[5]
             Aggregates: sum(lineitem.l_quantity[5])
             Group by: customer.c_name[0], customer.c_custkey[1], orders.o_orderkey[2], orders.o_orderdate[3], orders.o_totalprice[4]
-            -> PhysicHashJoin  (inccost=11, cost=4, rows=1) (actual rows=0)
+            -> PhysicHashJoin  (inccost=42482, cost=15312, rows=9007) (actual rows=0)
                 Output: customer.c_name[0],customer.c_custkey[1],orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],lineitem.l_quantity[5]
                 Filter: customer.c_custkey[1]=orders.o_custkey[6]
-                -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=150)
+                -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                     Output: customer.c_name[1],customer.c_custkey[0]
-                -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+                -> PhysicHashJoin  (inccost=27020, cost=19515, rows=6005) (actual rows=0)
                     Output: orders.o_orderkey[2],orders.o_orderdate[3],orders.o_totalprice[4],lineitem.l_quantity[0],orders.o_custkey[5]
                     Filter: orders.o_orderkey[2]=lineitem.l_orderkey[1]
-                    -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
                         Output: lineitem.l_quantity[4],lineitem.l_orderkey[0]
-                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
                         Output: orders.o_orderkey[0],orders.o_orderdate[4],orders.o_totalprice[3],orders.o_custkey[1]
                         Filter: orders.o_orderkey[0] in @1
                         <InSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=0)
+                            -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500) (actual rows=0)
                                 Output: {lineitem__1.l_orderkey}[0]
                                 Aggregates: sum(lineitem__1.l_quantity[1])
                                 Group by: lineitem__1.l_orderkey[0]
                                 Filter: {sum(lineitem__1.l_quantity)}[1]>300
-                                -> PhysicScanTable lineitem as lineitem__1 (inccost=1, cost=1, rows=1) (actual rows=6005)
+                                -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
                                     Output: lineitem__1.l_orderkey[0],lineitem__1.l_quantity[4]

--- a/test/primitive/expect/q19.txt
+++ b/test/primitive/expect/q19.txt
@@ -1,11 +1,11 @@
-Total cost: 126
-PhysicHashAgg  (inccost=126, cost=3, rows=1) (actual rows=1)
+Total cost: 2470357
+PhysicHashAgg  (inccost=2470357, cost=1201002, rows=1) (actual rows=1)
     Output: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[0]
     Aggregates: sum(lineitem.l_extendedprice[1]*1-lineitem.l_discount[4])
-    -> PhysicNLJoin  (inccost=123, cost=121, rows=1) (actual rows=0)
+    -> PhysicNLJoin  (inccost=1269355, cost=1263150, rows=1201000) (actual rows=0)
         Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],{1}[3],lineitem.l_discount[4]
         Filter: part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#12' and part.p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and lineitem.l_quantity[6]>=1 and lineitem.l_quantity[6]<=11 and part.p_size[12]>=1 and part.p_size[12]<=5 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON' or part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#23' and part.p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and lineitem.l_quantity[6]>=10 and lineitem.l_quantity[6]<=20 and part.p_size[12]>=1 and part.p_size[12]<=10 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON' or part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#34' and part.p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and lineitem.l_quantity[6]>=20 and lineitem.l_quantity[6]<=30 and part.p_size[12]>=1 and part.p_size[12]<=15 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON'
-        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
             Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6],lineitem.l_partkey[1],lineitem.l_quantity[4],lineitem.l_shipmode[14],lineitem.l_shipinstruct[13]
-        -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=200, loops=6005)
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200, loops=6005)
             Output: part.p_partkey[0],part.p_brand[3],part.p_container[6],part.p_size[5]

--- a/test/primitive/expect/q19.txt
+++ b/test/primitive/expect/q19.txt
@@ -1,11 +1,11 @@
-Total cost: 2470357
-PhysicHashAgg  (inccost=2470357, cost=1201002, rows=1) (actual rows=1)
+Total cost: 126
+PhysicHashAgg  (inccost=126, cost=3, rows=1) (actual rows=1)
     Output: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[0]
     Aggregates: sum(lineitem.l_extendedprice[1]*1-lineitem.l_discount[4])
-    -> PhysicNLJoin  (inccost=1269355, cost=1263150, rows=1201000) (actual rows=0)
+    -> PhysicNLJoin  (inccost=123, cost=121, rows=1) (actual rows=0)
         Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],{1}[3],lineitem.l_discount[4]
         Filter: part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#12' and part.p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and lineitem.l_quantity[6]>=1 and lineitem.l_quantity[6]<=11 and part.p_size[12]>=1 and part.p_size[12]<=5 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON' or part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#23' and part.p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and lineitem.l_quantity[6]>=10 and lineitem.l_quantity[6]<=20 and part.p_size[12]>=1 and part.p_size[12]<=10 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON' or part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#34' and part.p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and lineitem.l_quantity[6]>=20 and lineitem.l_quantity[6]<=30 and part.p_size[12]>=1 and part.p_size[12]<=15 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON'
-        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+        -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=6005)
             Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6],lineitem.l_partkey[1],lineitem.l_quantity[4],lineitem.l_shipmode[14],lineitem.l_shipinstruct[13]
-        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200, loops=6005)
+        -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=200, loops=6005)
             Output: part.p_partkey[0],part.p_brand[3],part.p_container[6],part.p_size[5]

--- a/test/primitive/expect/q19.txt
+++ b/test/primitive/expect/q19.txt
@@ -1,0 +1,11 @@
+Total cost: 2470357
+PhysicHashAgg  (inccost=2470357, cost=1201002, rows=1) (actual rows=1)
+    Output: {sum(lineitem.l_extendedprice*1-lineitem.l_discount)}[0]
+    Aggregates: sum(lineitem.l_extendedprice[1]*1-lineitem.l_discount[4])
+    -> PhysicNLJoin  (inccost=1269355, cost=1263150, rows=1201000) (actual rows=0)
+        Output: {lineitem.l_extendedprice*1-lineitem.l_discount}[0],lineitem.l_extendedprice[1],{1-lineitem.l_discount}[2],{1}[3],lineitem.l_discount[4]
+        Filter: part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#12' and part.p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and lineitem.l_quantity[6]>=1 and lineitem.l_quantity[6]<=11 and part.p_size[12]>=1 and part.p_size[12]<=5 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON' or part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#23' and part.p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and lineitem.l_quantity[6]>=10 and lineitem.l_quantity[6]<=20 and part.p_size[12]>=1 and part.p_size[12]<=10 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON' or part.p_partkey[9]=lineitem.l_partkey[5] and part.p_brand[10]='Brand#34' and part.p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and lineitem.l_quantity[6]>=20 and lineitem.l_quantity[6]<=30 and part.p_size[12]>=1 and part.p_size[12]<=15 and lineitem.l_shipmode[7] in ('AIR','AIR REG') and lineitem.l_shipinstruct[8]='DELIVER IN PERSON'
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)
+            Output: lineitem.l_extendedprice[5]*1-lineitem.l_discount[6],lineitem.l_extendedprice[5],1-lineitem.l_discount[6],1,lineitem.l_discount[6],lineitem.l_partkey[1],lineitem.l_quantity[4],lineitem.l_shipmode[14],lineitem.l_shipinstruct[13]
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200, loops=6005)
+            Output: part.p_partkey[0],part.p_brand[3],part.p_container[6],part.p_size[5]

--- a/test/primitive/expect/q20.txt
+++ b/test/primitive/expect/q20.txt
@@ -1,34 +1,34 @@
-Total cost: 57.1
-PhysicOrder  (inccost=57.1, cost=0.1, rows=1) (actual rows=0)
+Total cost: 6.1
+PhysicOrder  (inccost=6.1, cost=0.1, rows=1) (actual rows=0)
     Output: supplier.s_name[0],supplier.s_address[1]
     Order by: supplier.s_name[0]
-    -> PhysicHashJoin  (inccost=57, cost=22, rows=1) (actual rows=0)
+    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
         Output: supplier.s_name[0],supplier.s_address[1]
         Filter: supplier.s_nationkey[2]=nation.n_nationkey[3]
-        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
             Output: supplier.s_name[1],supplier.s_address[2],supplier.s_nationkey[3]
             Filter: supplier.s_suppkey[0] in @1
             <InSubqueryExpr> cached 1
-                -> PhysicFilter  (inccost=1547350, cost=753, rows=753) (actual rows=47)
+                -> PhysicFilter  (inccost=114, cost=1, rows=1) (actual rows=47)
                     Output: partsupp.ps_suppkey[0]
                     Filter: partsupp.ps_availqty[1]>0.5*{sum(lineitem.l_quantity)}[2]
-                    -> PhysicNLJoin Left (inccost=1546597, cost=1534140, rows=753) (actual rows=60)
+                    -> PhysicNLJoin Left (inccost=113, cost=110, rows=1) (actual rows=60)
                         Output: partsupp.ps_suppkey[0],partsupp.ps_availqty[1],{sum(lineitem.l_quantity)}[3]
                         Filter: lineitem.l_partkey[4]=partsupp.ps_partkey[2] and lineitem.l_suppkey[5]=partsupp.ps_suppkey[0]
-                        -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=60)
+                        -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=60)
                             Output: partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_partkey[0]
                             Filter: partsupp.ps_partkey[0] in @2
                             <InSubqueryExpr> cached 2
-                                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=15)
+                                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=15)
                                     Output: part.p_partkey[0]
                                     Filter: part.p_name[1]like'forest%'
-                        -> PhysicHashAgg  (inccost=11657, cost=5652, rows=1884) (actual rows=499, loops=60)
+                        -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=499, loops=60)
                             Output: {sum(lineitem.l_quantity)}[2],{lineitem.l_partkey}[0],{lineitem.l_suppkey}[1]
                             Aggregates: sum(lineitem.l_quantity[2])
                             Group by: lineitem.l_partkey[0], lineitem.l_suppkey[1]
-                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1884) (actual rows=922, loops=60)
+                            -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=922, loops=60)
                                 Output: lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_quantity[4]
                                 Filter: lineitem.l_shipdate[10]>='1994-01-01' and lineitem.l_shipdate[10]<'1/1/1995 12:00:00 AM'
-        -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+        -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=1)
             Output: nation.n_nationkey[0]
             Filter: nation.n_name[1]='CANADA'

--- a/test/primitive/expect/q20.txt
+++ b/test/primitive/expect/q20.txt
@@ -1,0 +1,34 @@
+Total cost: 57.1
+PhysicOrder  (inccost=57.1, cost=0.1, rows=1) (actual rows=0)
+    Output: supplier.s_name[0],supplier.s_address[1]
+    Order by: supplier.s_name[0]
+    -> PhysicHashJoin  (inccost=57, cost=22, rows=1) (actual rows=0)
+        Output: supplier.s_name[0],supplier.s_address[1]
+        Filter: supplier.s_nationkey[2]=nation.n_nationkey[3]
+        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+            Output: supplier.s_name[1],supplier.s_address[2],supplier.s_nationkey[3]
+            Filter: supplier.s_suppkey[0] in @1
+            <InSubqueryExpr> cached 1
+                -> PhysicFilter  (inccost=1547350, cost=753, rows=753) (actual rows=47)
+                    Output: partsupp.ps_suppkey[0]
+                    Filter: partsupp.ps_availqty[1]>0.5*{sum(lineitem.l_quantity)}[2]
+                    -> PhysicNLJoin Left (inccost=1546597, cost=1534140, rows=753) (actual rows=60)
+                        Output: partsupp.ps_suppkey[0],partsupp.ps_availqty[1],{sum(lineitem.l_quantity)}[3]
+                        Filter: lineitem.l_partkey[4]=partsupp.ps_partkey[2] and lineitem.l_suppkey[5]=partsupp.ps_suppkey[0]
+                        -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=60)
+                            Output: partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_partkey[0]
+                            Filter: partsupp.ps_partkey[0] in @2
+                            <InSubqueryExpr> cached 2
+                                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=15)
+                                    Output: part.p_partkey[0]
+                                    Filter: part.p_name[1]like'forest%'
+                        -> PhysicHashAgg  (inccost=11657, cost=5652, rows=1884) (actual rows=499, loops=60)
+                            Output: {sum(lineitem.l_quantity)}[2],{lineitem.l_partkey}[0],{lineitem.l_suppkey}[1]
+                            Aggregates: sum(lineitem.l_quantity[2])
+                            Group by: lineitem.l_partkey[0], lineitem.l_suppkey[1]
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1884) (actual rows=922, loops=60)
+                                Output: lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_quantity[4]
+                                Filter: lineitem.l_shipdate[10]>='1994-01-01' and lineitem.l_shipdate[10]<'1/1/1995 12:00:00 AM'
+        -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+            Output: nation.n_nationkey[0]
+            Filter: nation.n_name[1]='CANADA'

--- a/test/primitive/expect/q20.txt
+++ b/test/primitive/expect/q20.txt
@@ -1,34 +1,34 @@
-Total cost: 6.1
-PhysicOrder  (inccost=6.1, cost=0.1, rows=1) (actual rows=0)
+Total cost: 57.1
+PhysicOrder  (inccost=57.1, cost=0.1, rows=1) (actual rows=0)
     Output: supplier.s_name[0],supplier.s_address[1]
     Order by: supplier.s_name[0]
-    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=0)
+    -> PhysicHashJoin  (inccost=57, cost=22, rows=1) (actual rows=0)
         Output: supplier.s_name[0],supplier.s_address[1]
         Filter: supplier.s_nationkey[2]=nation.n_nationkey[3]
-        -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
             Output: supplier.s_name[1],supplier.s_address[2],supplier.s_nationkey[3]
             Filter: supplier.s_suppkey[0] in @1
             <InSubqueryExpr> cached 1
-                -> PhysicFilter  (inccost=114, cost=1, rows=1) (actual rows=47)
+                -> PhysicFilter  (inccost=795769, cost=384, rows=384) (actual rows=47)
                     Output: partsupp.ps_suppkey[0]
                     Filter: partsupp.ps_availqty[1]>0.5*{sum(lineitem.l_quantity)}[2]
-                    -> PhysicNLJoin Left (inccost=113, cost=110, rows=1) (actual rows=60)
+                    -> PhysicNLJoin Left (inccost=795385, cost=785700, rows=384) (actual rows=60)
                         Output: partsupp.ps_suppkey[0],partsupp.ps_availqty[1],{sum(lineitem.l_quantity)}[3]
                         Filter: lineitem.l_partkey[4]=partsupp.ps_partkey[2] and lineitem.l_suppkey[5]=partsupp.ps_suppkey[0]
-                        -> PhysicScanTable partsupp (inccost=1, cost=1, rows=1) (actual rows=60)
+                        -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=60)
                             Output: partsupp.ps_suppkey[1],partsupp.ps_availqty[2],partsupp.ps_partkey[0]
                             Filter: partsupp.ps_partkey[0] in @2
                             <InSubqueryExpr> cached 2
-                                -> PhysicScanTable part (inccost=1, cost=1, rows=1) (actual rows=15)
+                                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=15)
                                     Output: part.p_partkey[0]
                                     Filter: part.p_name[1]like'forest%'
-                        -> PhysicHashAgg  (inccost=2, cost=1, rows=0) (actual rows=499, loops=60)
+                        -> PhysicHashAgg  (inccost=8885, cost=2880, rows=960) (actual rows=499, loops=60)
                             Output: {sum(lineitem.l_quantity)}[2],{lineitem.l_partkey}[0],{lineitem.l_suppkey}[1]
                             Aggregates: sum(lineitem.l_quantity[2])
                             Group by: lineitem.l_partkey[0], lineitem.l_suppkey[1]
-                            -> PhysicScanTable lineitem (inccost=1, cost=1, rows=1) (actual rows=922, loops=60)
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=960) (actual rows=922, loops=60)
                                 Output: lineitem.l_partkey[1],lineitem.l_suppkey[2],lineitem.l_quantity[4]
                                 Filter: lineitem.l_shipdate[10]>='1994-01-01' and lineitem.l_shipdate[10]<'1/1/1995 12:00:00 AM'
-        -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=1)
+        -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
             Output: nation.n_nationkey[0]
             Filter: nation.n_name[1]='CANADA'

--- a/test/primitive/expect/q21.txt
+++ b/test/primitive/expect/q21.txt
@@ -1,46 +1,46 @@
-Total cost: 38077031.02
-PhysicLimit (100) (inccost=38077031.02, cost=100, rows=100) (actual rows=0)
+Total cost: NaN
+PhysicLimit (100) (inccost=NaN, cost=100, rows=100) (actual rows=0)
     Output: supplier.s_name[0],{count(*)(0)}[1]
-    -> PhysicOrder  (inccost=38076931.02, cost=24.02, rows=10) (actual rows=0)
+    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
         Output: supplier.s_name[0],{count(*)(0)}[1]
         Order by: {count(*)(0)}[1], supplier.s_name[0]
-        -> PhysicHashAgg  (inccost=38076907, cost=6025, rows=10) (actual rows=0)
+        -> PhysicHashAgg  (inccost=140, cost=1, rows=0) (actual rows=0)
             Output: {supplier.s_name}[0],{count(*)(0)}[1]
             Aggregates: count(*)(0)
             Group by: supplier.s_name[0]
-            -> PhysicFilter  (inccost=38070882, cost=6005, rows=6005) (actual rows=0)
+            -> PhysicFilter  (inccost=139, cost=1, rows=1) (actual rows=0)
                 Output: supplier.s_name[1]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=38064877, cost=36060025, rows=6005) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=138, cost=1, rows=1) (actual rows=0)
                     Output: #marker,supplier.s_name[0]
                     Filter: l2.l_orderkey[3]=l1.l_orderkey[1] and l2.l_suppkey[4]<>l1.l_suppkey[2]
-                    -> PhysicFilter  (inccost=1998847, cost=6005, rows=6005) (actual rows=0)
+                    -> PhysicFilter  (inccost=136, cost=1, rows=1) (actual rows=0)
                         Output: supplier.s_name[1],l1.l_orderkey[2],l1.l_suppkey[3]
                         Filter: {#marker}[0]
-                        -> PhysicMarkJoin Left (inccost=1992842, cost=1933610, rows=6005) (actual rows=0)
+                        -> PhysicMarkJoin Left (inccost=135, cost=1, rows=1) (actual rows=0)
                             Output: #marker,supplier.s_name[0],l1.l_orderkey[1],l1.l_suppkey[2]
                             Filter: l3.l_orderkey[3]=l1.l_orderkey[1] and l3.l_suppkey[4]<>l1.l_suppkey[2]
-                            -> PhysicHashJoin  (inccost=53227, cost=3248, rows=322) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=133, cost=4, rows=1) (actual rows=0)
                                 Output: supplier.s_name[0],l1.l_orderkey[3],l1.l_suppkey[4]
                                 Filter: supplier.s_suppkey[1]=l1.l_suppkey[4] and supplier.s_nationkey[2]=nation.n_nationkey[5]
-                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
                                     Output: supplier.s_name[1],supplier.s_suppkey[0],supplier.s_nationkey[3]
-                                -> PhysicNLJoin  (inccost=49969, cost=32076, rows=2906) (actual rows=1783)
+                                -> PhysicNLJoin  (inccost=128, cost=121, rows=1) (actual rows=1783)
                                     Output: l1.l_orderkey[1],l1.l_suppkey[2],nation.n_nationkey[0]
-                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+                                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=1)
                                         Output: nation.n_nationkey[0]
                                         Filter: nation.n_name[1]='SAUDI ARABIA'
-                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906) (actual rows=1783)
+                                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=1783)
                                         Output: l1.l_orderkey[1],l1.l_suppkey[2]
                                         Filter: orders.o_orderkey[0]=l1.l_orderkey[1]
-                                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=726)
+                                        -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=726)
                                             Output: orders.o_orderkey[0]
                                             Filter: orders.o_orderstatus[2]='F'
-                                        -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=3752)
+                                        -> PhysicScanTable lineitem as l1 (inccost=1, cost=1, rows=1) (actual rows=3752)
                                             Output: l1.l_orderkey[0],l1.l_suppkey[2]
                                             Filter: l1.l_receiptdate[12]>l1.l_commitdate[11]
-                            -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                            -> PhysicScanTable lineitem as l3 (inccost=1, cost=1, rows=1) (actual rows=0)
                                 Output: l3.l_orderkey[0],l3.l_suppkey[2]
                                 Filter: l3.l_receiptdate[12]>l3.l_commitdate[11]
-                    -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                    -> PhysicScanTable lineitem as l2 (inccost=1, cost=1, rows=1) (actual rows=0)
                         Output: l2.l_orderkey[0],l2.l_suppkey[2]

--- a/test/primitive/expect/q21.txt
+++ b/test/primitive/expect/q21.txt
@@ -1,0 +1,46 @@
+Total cost: 38077031.02
+PhysicLimit (100) (inccost=38077031.02, cost=100, rows=100) (actual rows=0)
+    Output: supplier.s_name[0],{count(*)(0)}[1]
+    -> PhysicOrder  (inccost=38076931.02, cost=24.02, rows=10) (actual rows=0)
+        Output: supplier.s_name[0],{count(*)(0)}[1]
+        Order by: {count(*)(0)}[1], supplier.s_name[0]
+        -> PhysicHashAgg  (inccost=38076907, cost=6025, rows=10) (actual rows=0)
+            Output: {supplier.s_name}[0],{count(*)(0)}[1]
+            Aggregates: count(*)(0)
+            Group by: supplier.s_name[0]
+            -> PhysicFilter  (inccost=38070882, cost=6005, rows=6005) (actual rows=0)
+                Output: supplier.s_name[1]
+                Filter: {#marker}[0]
+                -> PhysicMarkJoin Left (inccost=38064877, cost=36060025, rows=6005) (actual rows=0)
+                    Output: #marker,supplier.s_name[0]
+                    Filter: l2.l_orderkey[3]=l1.l_orderkey[1] and l2.l_suppkey[4]<>l1.l_suppkey[2]
+                    -> PhysicFilter  (inccost=1998847, cost=6005, rows=6005) (actual rows=0)
+                        Output: supplier.s_name[1],l1.l_orderkey[2],l1.l_suppkey[3]
+                        Filter: {#marker}[0]
+                        -> PhysicMarkJoin Left (inccost=1992842, cost=1933610, rows=6005) (actual rows=0)
+                            Output: #marker,supplier.s_name[0],l1.l_orderkey[1],l1.l_suppkey[2]
+                            Filter: l3.l_orderkey[3]=l1.l_orderkey[1] and l3.l_suppkey[4]<>l1.l_suppkey[2]
+                            -> PhysicHashJoin  (inccost=53227, cost=3248, rows=322) (actual rows=0)
+                                Output: supplier.s_name[0],l1.l_orderkey[3],l1.l_suppkey[4]
+                                Filter: supplier.s_suppkey[1]=l1.l_suppkey[4] and supplier.s_nationkey[2]=nation.n_nationkey[5]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
+                                    Output: supplier.s_name[1],supplier.s_suppkey[0],supplier.s_nationkey[3]
+                                -> PhysicNLJoin  (inccost=49969, cost=32076, rows=2906) (actual rows=1783)
+                                    Output: l1.l_orderkey[1],l1.l_suppkey[2],nation.n_nationkey[0]
+                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
+                                        Output: nation.n_nationkey[0]
+                                        Filter: nation.n_name[1]='SAUDI ARABIA'
+                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906) (actual rows=1783)
+                                        Output: l1.l_orderkey[1],l1.l_suppkey[2]
+                                        Filter: orders.o_orderkey[0]=l1.l_orderkey[1]
+                                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=726)
+                                            Output: orders.o_orderkey[0]
+                                            Filter: orders.o_orderstatus[2]='F'
+                                        -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=3752)
+                                            Output: l1.l_orderkey[0],l1.l_suppkey[2]
+                                            Filter: l1.l_receiptdate[12]>l1.l_commitdate[11]
+                            -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                Output: l3.l_orderkey[0],l3.l_suppkey[2]
+                                Filter: l3.l_receiptdate[12]>l3.l_commitdate[11]
+                    -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l2.l_orderkey[0],l2.l_suppkey[2]

--- a/test/primitive/expect/q21.txt
+++ b/test/primitive/expect/q21.txt
@@ -1,46 +1,46 @@
-Total cost: NaN
-PhysicLimit (100) (inccost=NaN, cost=100, rows=100) (actual rows=0)
+Total cost: 38077031.02
+PhysicLimit (100) (inccost=38077031.02, cost=100, rows=100) (actual rows=0)
     Output: supplier.s_name[0],{count(*)(0)}[1]
-    -> PhysicOrder  (inccost=NaN, cost=NaN, rows=1) (actual rows=0)
+    -> PhysicOrder  (inccost=38076931.02, cost=24.02, rows=10) (actual rows=0)
         Output: supplier.s_name[0],{count(*)(0)}[1]
         Order by: {count(*)(0)}[1], supplier.s_name[0]
-        -> PhysicHashAgg  (inccost=140, cost=1, rows=0) (actual rows=0)
+        -> PhysicHashAgg  (inccost=38076907, cost=6025, rows=10) (actual rows=0)
             Output: {supplier.s_name}[0],{count(*)(0)}[1]
             Aggregates: count(*)(0)
             Group by: supplier.s_name[0]
-            -> PhysicFilter  (inccost=139, cost=1, rows=1) (actual rows=0)
+            -> PhysicFilter  (inccost=38070882, cost=6005, rows=6005) (actual rows=0)
                 Output: supplier.s_name[1]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=138, cost=1, rows=1) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=38064877, cost=36060025, rows=6005) (actual rows=0)
                     Output: #marker,supplier.s_name[0]
                     Filter: l2.l_orderkey[3]=l1.l_orderkey[1] and l2.l_suppkey[4]<>l1.l_suppkey[2]
-                    -> PhysicFilter  (inccost=136, cost=1, rows=1) (actual rows=0)
+                    -> PhysicFilter  (inccost=1998847, cost=6005, rows=6005) (actual rows=0)
                         Output: supplier.s_name[1],l1.l_orderkey[2],l1.l_suppkey[3]
                         Filter: {#marker}[0]
-                        -> PhysicMarkJoin Left (inccost=135, cost=1, rows=1) (actual rows=0)
+                        -> PhysicMarkJoin Left (inccost=1992842, cost=1933610, rows=6005) (actual rows=0)
                             Output: #marker,supplier.s_name[0],l1.l_orderkey[1],l1.l_suppkey[2]
                             Filter: l3.l_orderkey[3]=l1.l_orderkey[1] and l3.l_suppkey[4]<>l1.l_suppkey[2]
-                            -> PhysicHashJoin  (inccost=133, cost=4, rows=1) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=53227, cost=3248, rows=322) (actual rows=0)
                                 Output: supplier.s_name[0],l1.l_orderkey[3],l1.l_suppkey[4]
                                 Filter: supplier.s_suppkey[1]=l1.l_suppkey[4] and supplier.s_nationkey[2]=nation.n_nationkey[5]
-                                -> PhysicScanTable supplier (inccost=1, cost=1, rows=1) (actual rows=10)
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                                     Output: supplier.s_name[1],supplier.s_suppkey[0],supplier.s_nationkey[3]
-                                -> PhysicNLJoin  (inccost=128, cost=121, rows=1) (actual rows=1783)
+                                -> PhysicNLJoin  (inccost=49969, cost=32076, rows=2906) (actual rows=1783)
                                     Output: l1.l_orderkey[1],l1.l_suppkey[2],nation.n_nationkey[0]
-                                    -> PhysicScanTable nation (inccost=1, cost=1, rows=1) (actual rows=1)
+                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1)
                                         Output: nation.n_nationkey[0]
                                         Filter: nation.n_name[1]='SAUDI ARABIA'
-                                    -> PhysicHashJoin  (inccost=6, cost=4, rows=1) (actual rows=1783)
+                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906) (actual rows=1783)
                                         Output: l1.l_orderkey[1],l1.l_suppkey[2]
                                         Filter: orders.o_orderkey[0]=l1.l_orderkey[1]
-                                        -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=726)
+                                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=726)
                                             Output: orders.o_orderkey[0]
                                             Filter: orders.o_orderstatus[2]='F'
-                                        -> PhysicScanTable lineitem as l1 (inccost=1, cost=1, rows=1) (actual rows=3752)
+                                        -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=3752)
                                             Output: l1.l_orderkey[0],l1.l_suppkey[2]
                                             Filter: l1.l_receiptdate[12]>l1.l_commitdate[11]
-                            -> PhysicScanTable lineitem as l3 (inccost=1, cost=1, rows=1) (actual rows=0)
+                            -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                                 Output: l3.l_orderkey[0],l3.l_suppkey[2]
                                 Filter: l3.l_receiptdate[12]>l3.l_commitdate[11]
-                    -> PhysicScanTable lineitem as l2 (inccost=1, cost=1, rows=1) (actual rows=0)
+                    -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                         Output: l2.l_orderkey[0],l2.l_suppkey[2]

--- a/test/primitive/expect/q22.txt
+++ b/test/primitive/expect/q22.txt
@@ -1,28 +1,28 @@
-Total cost: 8.1
-PhysicOrder  (inccost=8.1, cost=0.1, rows=1) (actual rows=7)
+Total cost: 233402.1
+PhysicOrder  (inccost=233402.1, cost=0.1, rows=1) (actual rows=7)
     Output: custsale.cntrycode[0],{count(*)(0)}[1],{sum(custsale.c_acctbal)}[2]
     Order by: custsale.cntrycode[0]
-    -> PhysicHashAgg  (inccost=8, cost=3, rows=1) (actual rows=7)
+    -> PhysicHashAgg  (inccost=233402, cost=2252, rows=1) (actual rows=7)
         Output: {custsale.cntrycode}[0],{count(*)(0)}[1],{sum(custsale.c_acctbal)}[2]
         Aggregates: count(*)(0), sum(custsale.c_acctbal[1])
         Group by: custsale.cntrycode[0]
-        -> PhysicFromQuery <custsale> (inccost=5, cost=1, rows=1) (actual rows=9)
+        -> PhysicFromQuery <custsale> (inccost=231150, cost=2250, rows=2250) (actual rows=9)
             Output: custsale.cntrycode[0],custsale.c_acctbal[1]
-            -> PhysicFilter  (inccost=4, cost=1, rows=1) (actual rows=9)
+            -> PhysicFilter  (inccost=228900, cost=2250, rows=2250) (actual rows=9)
                 Output: {substring(customer.c_phone,1,2)}[1],customer.c_acctbal[2]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=3, cost=1, rows=1) (actual rows=17)
+                -> PhysicMarkJoin Left (inccost=226650, cost=225000, rows=2250) (actual rows=17)
                     Output: #marker,{substring(customer.c_phone,1,2)}[0],customer.c_acctbal[1]
                     Filter: orders.o_custkey[3]=customer.c_custkey[2]
-                    -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=17)
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=17)
                         Output: substring(customer.c_phone[4],1,2),customer.c_acctbal[5],customer.c_custkey[0]
                         Filter: substring(customer.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and customer.c_acctbal[5]>@1
                         <ScalarSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=1)
+                            -> PhysicHashAgg  (inccost=284, cost=134, rows=1) (actual rows=1)
                                 Output: {avg(customer__1.c_acctbal)}[0]
                                 Aggregates: avg(customer__1.c_acctbal[0])
-                                -> PhysicScanTable customer as customer__1 (inccost=1, cost=1, rows=1) (actual rows=35)
+                                -> PhysicScanTable customer as customer__1 (inccost=150, cost=150, rows=132) (actual rows=35)
                                     Output: customer__1.c_acctbal[5]
                                     Filter: customer__1.c_acctbal[5]>0.00 and substring(customer__1.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
-                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500, loops=17)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=17)
                         Output: orders.o_custkey[1]

--- a/test/primitive/expect/q22.txt
+++ b/test/primitive/expect/q22.txt
@@ -1,0 +1,28 @@
+Total cost: 233402.1
+PhysicOrder  (inccost=233402.1, cost=0.1, rows=1) (actual rows=7)
+    Output: custsale.cntrycode[0],{count(*)(0)}[1],{sum(custsale.c_acctbal)}[2]
+    Order by: custsale.cntrycode[0]
+    -> PhysicHashAgg  (inccost=233402, cost=2252, rows=1) (actual rows=7)
+        Output: {custsale.cntrycode}[0],{count(*)(0)}[1],{sum(custsale.c_acctbal)}[2]
+        Aggregates: count(*)(0), sum(custsale.c_acctbal[1])
+        Group by: custsale.cntrycode[0]
+        -> PhysicFromQuery <custsale> (inccost=231150, cost=2250, rows=2250) (actual rows=9)
+            Output: custsale.cntrycode[0],custsale.c_acctbal[1]
+            -> PhysicFilter  (inccost=228900, cost=2250, rows=2250) (actual rows=9)
+                Output: {substring(customer.c_phone,1,2)}[1],customer.c_acctbal[2]
+                Filter: {#marker}[0]
+                -> PhysicMarkJoin Left (inccost=226650, cost=225000, rows=2250) (actual rows=17)
+                    Output: #marker,{substring(customer.c_phone,1,2)}[0],customer.c_acctbal[1]
+                    Filter: orders.o_custkey[3]=customer.c_custkey[2]
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=17)
+                        Output: substring(customer.c_phone[4],1,2),customer.c_acctbal[5],customer.c_custkey[0]
+                        Filter: substring(customer.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and customer.c_acctbal[5]>@1
+                        <ScalarSubqueryExpr> cached 1
+                            -> PhysicHashAgg  (inccost=284, cost=134, rows=1) (actual rows=1)
+                                Output: {avg(customer__1.c_acctbal)}[0]
+                                Aggregates: avg(customer__1.c_acctbal[0])
+                                -> PhysicScanTable customer as customer__1 (inccost=150, cost=150, rows=132) (actual rows=35)
+                                    Output: customer__1.c_acctbal[5]
+                                    Filter: customer__1.c_acctbal[5]>0.00 and substring(customer__1.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=17)
+                        Output: orders.o_custkey[1]

--- a/test/primitive/expect/q22.txt
+++ b/test/primitive/expect/q22.txt
@@ -1,28 +1,28 @@
-Total cost: 233402.1
-PhysicOrder  (inccost=233402.1, cost=0.1, rows=1) (actual rows=7)
+Total cost: 8.1
+PhysicOrder  (inccost=8.1, cost=0.1, rows=1) (actual rows=7)
     Output: custsale.cntrycode[0],{count(*)(0)}[1],{sum(custsale.c_acctbal)}[2]
     Order by: custsale.cntrycode[0]
-    -> PhysicHashAgg  (inccost=233402, cost=2252, rows=1) (actual rows=7)
+    -> PhysicHashAgg  (inccost=8, cost=3, rows=1) (actual rows=7)
         Output: {custsale.cntrycode}[0],{count(*)(0)}[1],{sum(custsale.c_acctbal)}[2]
         Aggregates: count(*)(0), sum(custsale.c_acctbal[1])
         Group by: custsale.cntrycode[0]
-        -> PhysicFromQuery <custsale> (inccost=231150, cost=2250, rows=2250) (actual rows=9)
+        -> PhysicFromQuery <custsale> (inccost=5, cost=1, rows=1) (actual rows=9)
             Output: custsale.cntrycode[0],custsale.c_acctbal[1]
-            -> PhysicFilter  (inccost=228900, cost=2250, rows=2250) (actual rows=9)
+            -> PhysicFilter  (inccost=4, cost=1, rows=1) (actual rows=9)
                 Output: {substring(customer.c_phone,1,2)}[1],customer.c_acctbal[2]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=226650, cost=225000, rows=2250) (actual rows=17)
+                -> PhysicMarkJoin Left (inccost=3, cost=1, rows=1) (actual rows=17)
                     Output: #marker,{substring(customer.c_phone,1,2)}[0],customer.c_acctbal[1]
                     Filter: orders.o_custkey[3]=customer.c_custkey[2]
-                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=17)
+                    -> PhysicScanTable customer (inccost=1, cost=1, rows=1) (actual rows=17)
                         Output: substring(customer.c_phone[4],1,2),customer.c_acctbal[5],customer.c_custkey[0]
                         Filter: substring(customer.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and customer.c_acctbal[5]>@1
                         <ScalarSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=284, cost=134, rows=1) (actual rows=1)
+                            -> PhysicHashAgg  (inccost=4, cost=3, rows=1) (actual rows=1)
                                 Output: {avg(customer__1.c_acctbal)}[0]
                                 Aggregates: avg(customer__1.c_acctbal[0])
-                                -> PhysicScanTable customer as customer__1 (inccost=150, cost=150, rows=132) (actual rows=35)
+                                -> PhysicScanTable customer as customer__1 (inccost=1, cost=1, rows=1) (actual rows=35)
                                     Output: customer__1.c_acctbal[5]
                                     Filter: customer__1.c_acctbal[5]>0.00 and substring(customer__1.c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=17)
+                    -> PhysicScanTable orders (inccost=1, cost=1, rows=1) (actual rows=1500, loops=17)
                         Output: orders.o_custkey[1]


### PR DESCRIPTION
This branch respond to #43 and part of #91 . It consists of three main parts:

1. Unit tests for cardinality estimation, primitive tests and TPCH queries.
All the tests are built using TPCH 0001 (to save time, can be changed to 0001). Currently, the primitive tests are referring to the previously failed cardinality estimation steps of TPCH sample queries. It is not as organized but will serve as the starting point, more test will be added.

2. Same column filter.
Previously, the filters on the same column are not combined.
`  PhysicScanTable orders (inccost=1500, cost=1500, rows=300) (actual rows=48)`
`   Output: o_orderpriority[5],o_orderkey[0]`
`    Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'`
The current fix is creating a dictionary for each column, if multiple filters are on the same column, sum up the fraction that will be filtered out, if it is in (0,1), use 1.0-filtered_out as the selectivity on that column. If is this > 1.0, then use the product of all the selectivity on the column.
This method only works well for >, <, = expressions. 

3. IN expression.
IN is implemented in selectivity estimation. The selectivity is the sum of individual equality filter selectivity.

Note: after the modification of CE, the expected results for TPCH benchmark will change, unittest.Ubenchmarks.TestBenchmarks will not pass due to different row estimation. All the other unittests should be able to pass.