### PR TITLE
Add cardinality estimation for IN expression

### DIFF
--- a/qpmodel/Statis.cs
+++ b/qpmodel/Statis.cs
@@ -313,7 +313,21 @@ namespace qpmodel.stat
                     }
                 }
             }
-
+            if (filter is InListExpr inPred)
+            {
+                // implementation of IN estimation
+                if (inPred.children_[0] is ColExpr pl && pl.tabRef_ is BaseTableRef bpl)
+                {
+                    selectivity = 0.0;
+                    var stat = Catalog.sysstat_.GetColumnStat(bpl.relname_, pl.colName_);
+                    for (int i = 1; i < inPred.children_.Count; ++i)
+                    {
+                        if (inPred.children_[i] is LiteralExpr pr)
+                            selectivity += stat.EstSelectivity("=", pr.val_);
+                    }
+                    return Math.Min(1.0, selectivity);
+                }
+            }
             return selectivity;
         }
 

--- a/test/regress/expect/tpch0001/q12.txt
+++ b/test/regress/expect/tpch0001/q12.txt
@@ -26,22 +26,22 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 16056.32
-PhysicOrder  (inccost=16056.32, cost=14.32, rows=7) (actual rows=2)
+Total cost: 11057.32
+PhysicOrder  (inccost=11057.32, cost=14.32, rows=7) (actual rows=2)
     Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=16042, cost=1855, rows=7) (actual rows=2)
+    -> PhysicHashAgg  (inccost=11043, cost=520, rows=7) (actual rows=2)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicHashJoin  (inccost=14187, cost=6682, rows=1841) (actual rows=25)
-            Output: l_shipmode[14],{case with 1}[0],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[1],{o_orderpriority='1-URGENT'}[2],o_orderpriority[3],{'1-URGENT'}[4],{o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[10],{o_orderpriority<>'1-URGENT'}[11],{o_orderpriority<>'2-HIGH'}[12]
-            Filter: o_orderkey[13]=l_orderkey[15]
-            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
-                Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],'1-URGENT',o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1841) (actual rows=25)
-                Output: l_shipmode[14],l_orderkey[0]
+        -> PhysicHashJoin  (inccost=10523, cost=3018, rows=506) (actual rows=25)
+            Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
+            Filter: o_orderkey[15]=l_orderkey[5]
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=506) (actual rows=25)
+                Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                 Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
+            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
+                Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
 MAIL,5,5
 SHIP,5,10
 

--- a/test/regress/expect/tpch0001/q16.txt
+++ b/test/regress/expect/tpch0001/q16.txt
@@ -28,18 +28,18 @@ order by
 	p_brand,
 	p_type,
 	p_size
-Total cost: 10827.68
-PhysicOrder  (inccost=10827.68, cost=5427.68, rows=800) (actual rows=0)
+Total cost: 3220.38
+PhysicOrder  (inccost=3220.38, cost=754.38, rows=148) (actual rows=0)
     Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
     Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
-    -> PhysicHashAgg  (inccost=5400, cost=2400, rows=800) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2466, cost=444, rows=148) (actual rows=0)
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicHashJoin  (inccost=3000, cost=2000, rows=800) (actual rows=0)
+        -> PhysicHashJoin  (inccost=2022, cost=1022, rows=148) (actual rows=0)
             Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
             Filter: p_partkey[3]=ps_partkey[5]
-            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=34)
+            -> PhysicScanTable part (inccost=200, cost=200, rows=37) (actual rows=34)
                 Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
                 Filter: p_brand[3]<>'Brand#45' and p_type[4]not like'MEDIUM POLISHED%' and p_size[5] in (49,14,23, ... <Total: 8> )
             -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)

--- a/test/regress/expect/tpch1/q12.txt
+++ b/test/regress/expect/tpch1/q12.txt
@@ -26,21 +26,21 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 16021159.32
-PhysicOrder  (inccost=16021159.32, cost=14.32, rows=7) (actual rows=0)
+Total cost: 11105051.32
+PhysicOrder  (inccost=11105051.32, cost=14.32, rows=7) (actual rows=0)
     Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=16021145, cost=1839986, rows=7) (actual rows=0)
+    -> PhysicHashAgg  (inccost=11105037, cost=525966, rows=7) (actual rows=0)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicHashJoin  (inccost=14181159, cost=6679944, rows=1839972) (actual rows=0)
-            Output: l_shipmode[14],{case with 1}[0],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[1],{o_orderpriority='1-URGENT'}[2],o_orderpriority[3],{'1-URGENT'}[4],{o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[10],{o_orderpriority<>'1-URGENT'}[11],{o_orderpriority<>'2-HIGH'}[12]
-            Filter: o_orderkey[13]=l_orderkey[15]
-            -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
-                Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],'1-URGENT',o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
-            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1839972) (actual rows=0)
-                Output: l_shipmode[14],l_orderkey[0]
+        -> PhysicHashJoin  (inccost=10579071, cost=3077856, rows=525952) (actual rows=0)
+            Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
+            Filter: o_orderkey[15]=l_orderkey[5]
+            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=525952) (actual rows=0)
+                Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                 Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
+            -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
+                Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
 
 

--- a/test/regress/expect/tpch1/q16.txt
+++ b/test/regress/expect/tpch1/q16.txt
@@ -28,18 +28,18 @@ order by
 	p_brand,
 	p_type,
 	p_size
-Total cost: 6470287.64
-PhysicOrder  (inccost=6470287.64, cost=2295287.64, rows=187500) (actual rows=0)
+Total cost: 3881902.61
+PhysicOrder  (inccost=3881902.61, cost=1509052.61, rows=127300) (actual rows=0)
     Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
     Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
-    -> PhysicHashAgg  (inccost=4175000, cost=1175000, rows=187500) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2372850, cost=381900, rows=127300) (actual rows=0)
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicHashJoin  (inccost=3000000, cost=2000000, rows=800000) (actual rows=0)
+        -> PhysicHashJoin  (inccost=1990950, cost=990950, rows=127300) (actual rows=0)
             Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
             Filter: p_partkey[3]=ps_partkey[5]
-            -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000) (actual rows=0)
+            -> PhysicScanTable part (inccost=200000, cost=200000, rows=31825) (actual rows=0)
                 Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
                 Filter: p_brand[3]<>'Brand#45' and p_type[4]not like'MEDIUM POLISHED%' and p_size[5] in (49,14,23, ... <Total: 8> )
             -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000) (actual rows=0)


### PR DESCRIPTION
Added CE for IN expression. This is done by understanding IN expression as multiple equality expressions connected by OR. Thus, the selectivity is the sum of selectivity for each equality.

Results for TPCH benchmark test changed after this change in CE, namely q12 and q16. The expected results are updated accordingly. All unit tests are able to pass.