### PR TITLE
Implementation of EXPLAIN

### DIFF
--- a/psql/Program.cs
+++ b/psql/Program.cs
@@ -31,7 +31,7 @@ namespace psql
             option.optimize_.remove_from_ = false;
 
             option.explain_.show_output_ = true;
-            option.explain_.show_cost_ = option.optimize_.use_memo_;
+            option.explain_.mode_ = option.optimize_.use_memo_ ? ExplainMode.analyze : ExplainMode.plain;
 
             // get a list of sql query fine names from the sql directory
             string[] sqlFiles = Directory.GetFiles(sql_dir_fn);

--- a/psql/Program.cs
+++ b/psql/Program.cs
@@ -24,14 +24,14 @@ namespace psql
             return true;
         }
 
-        public string SQLQueryVerify(string sql_dir_fn, string write_dir_fn, string expect_dir_fn, string[] badQueries)
+        public string SQLQueryVerify(string sql_dir_fn, string write_dir_fn, string expect_dir_fn, string[] badQueries, bool explainOnly)
         {
             QueryOption option = new QueryOption();
             option.optimize_.TurnOnAllOptimizations();
             option.optimize_.remove_from_ = false;
 
             option.explain_.show_output_ = true;
-            option.explain_.mode_ = option.optimize_.use_memo_ ? ExplainMode.analyze : ExplainMode.plain;
+            option.explain_.mode_ = explainOnly ? ExplainMode.explain : ExplainMode.analyze;
 
             // get a list of sql query fine names from the sql directory
             string[] sqlFiles = Directory.GetFiles(sql_dir_fn);

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1412,7 +1412,8 @@ namespace qpmodel.physic
                             newr[i] = r[i];
                     }
                     rows_.Add(newr);
-                    Console.WriteLine($"{newr}");
+                    if ((int)context.option_.explain_.mode_ < 2)
+                        Console.WriteLine($"{newr}");
                 }
                 return cs;
             });

--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -116,13 +116,19 @@ namespace qpmodel.logic
 
         public void PopCodeGen() => optimize_.use_codegen_ = saved_use_codegen_;
     }
-
+    public enum ExplainMode
+    {
+        none, // physical plan only
+        plain, // physical plan with actual cost
+        explain, // physical plan with estimated cost, execution skipped
+        analyze, // physical plan, estimates, actual cardinality, results muted
+    }
     public class ExplainOption
     {
 
         [ThreadStatic]
         public static bool show_tablename_ = true;
-        public bool show_cost_ { get; set; } = false;
+        public ExplainMode mode_ = ExplainMode.plain;
         public bool show_output_ { get; set; } = true;
         public bool show_id_ { get; set; } = false;
         public ExplainOption Clone() => (ExplainOption)MemberwiseClone();
@@ -149,8 +155,9 @@ namespace qpmodel.logic
         public string Explain(ExplainOption option = null, int depth = 0)
         {
             string r = null;
-            bool exp_showcost = option?.show_cost_ ?? false;
             bool exp_output = option?.show_output_ ?? true;
+            bool exp_showcost = option is null ? false : (int)option.mode_ > 1;
+            bool exp_showactual = option is null ? true : (option.mode_ == ExplainMode.plain || option.mode_ == ExplainMode.analyze);
             bool exp_id = option?.show_id_ ?? false;
 
             if (!(this is PhysicProfiling) && !(this is PhysicCollect))
@@ -175,12 +182,14 @@ namespace qpmodel.logic
                         var cost = Math.Truncate(phynode.Cost() * 100) / 100;
                         r += $" (inccost={incCost}, cost={cost}, rows={phynode.logic_.Card()})";
                     }
-
-                    var profile = phynode.profile_;
-                    if (profile.nloops_ == 1 || profile.nloops_ == 0)
-                        r += $" (actual rows={profile.nrows_})";
-                    else
-                        r += $" (actual rows={profile.nrows_ / profile.nloops_}, loops={profile.nloops_})";
+                    if (exp_showactual)
+                    {
+                        var profile = phynode.profile_;
+                        if (profile.nloops_ == 1 || profile.nloops_ == 0)
+                            r += $" (actual rows={profile.nrows_})";
+                        else
+                            r += $" (actual rows={profile.nrows_ / profile.nloops_}, loops={profile.nloops_})";
+                    }
                 }
                 r += "\n";
                 var details = ExplainMoreDetails(depth, option);

--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -187,7 +187,7 @@ namespace qpmodel
             a.queryOpt_.optimize_.memo_use_joinorder_solver_ = false;
             a.queryOpt_.explain_.show_output_ = true;
             a.queryOpt_.explain_.show_id_ = false;
-            a.queryOpt_.explain_.show_cost_ = a.queryOpt_.optimize_.use_memo_;
+            a.queryOpt_.explain_.mode_ = a.queryOpt_.optimize_.use_memo_ ? ExplainMode.analyze : ExplainMode.plain;
 
             // -- Semantic analysis:
             //  - bind the query

--- a/qpmodel/SQLParser.cs
+++ b/qpmodel/SQLParser.cs
@@ -549,10 +549,6 @@ namespace qpmodel.sqlparser
         {
             SQLStatement r = null;
 
-            bool isExplain = false;
-            if (context.K_EXPLAIN() != null)
-                isExplain = true;
-
             if (context.select_stmt() != null)
                 r = Visit(context.select_stmt()) as SQLStatement;
             else if (context.create_table_stmt() != null)
@@ -571,8 +567,13 @@ namespace qpmodel.sqlparser
             if (r is null)
                 throw new NotImplementedException();
 
-            Debug.Assert(!r.explainOnly_);
-            r.explainOnly_ = isExplain;
+            if (context.K_EXPLAIN() != null)
+            {
+                if (context.K_EXECUTE() != null)
+                    r.queryOpt_.explain_.mode_ = ExplainMode.analyze;
+                else
+                    r.queryOpt_.explain_.mode_ = ExplainMode.explain;
+            }
             return r;
         }
 

--- a/qpmodel/SQLite.g4
+++ b/qpmodel/SQLite.g4
@@ -50,7 +50,7 @@ sql_stmt_list
  ;
 
 sql_stmt
- : ( K_EXPLAIN ( K_EXECUTE )( K_VERBOSE )? )? (
+ : ( K_EXPLAIN ( K_EXECUTE )? ( K_VERBOSE )? )? (
                                       analyze_stmt
                                       | create_index_stmt
                                       | create_table_stmt

--- a/qpmodel/SQLite.g4
+++ b/qpmodel/SQLite.g4
@@ -50,7 +50,7 @@ sql_stmt_list
  ;
 
 sql_stmt
- : ( K_EXPLAIN ( K_ANALYZE K_VERBOSE )? )? (
+ : ( K_EXPLAIN ( K_EXECUTE )( K_VERBOSE )? )? (
                                       analyze_stmt
                                       | create_index_stmt
                                       | create_table_stmt
@@ -369,6 +369,7 @@ keyword
  | K_ESCAPE
  | K_EXCEPT
  | K_EXCLUSIVE
+ | K_EXECUTE
  | K_EXISTS
  | K_EXPLAIN
  | K_FOR
@@ -571,6 +572,7 @@ K_END : E N D;
 K_ESCAPE : E S C A P E;
 K_EXCEPT : E X C E P T;
 K_EXCLUSIVE : E X C L U S I V E;
+K_EXECUTE : E X E C U T E;
 K_EXISTS : E X I S T S;
 K_EXPLAIN : E X P L A I N;
 K_FOR : F O R;

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -54,7 +54,6 @@ namespace qpmodel.logic
         public PhysicNode physicPlan_;
 
         // others
-        public bool explainOnly_ = false;
         public Optimizer optimizer_ = new Optimizer();
         public QueryOption queryOpt_ = new QueryOption();
 
@@ -91,8 +90,12 @@ namespace qpmodel.logic
                 optimizer_.OptimizeRootPlan(this, null);
                 physicPlan_ = optimizer_.CopyOutOptimalPlan();
             }
-            if (explainOnly_)
-                return null;
+
+            if (queryOpt_.explain_.mode_ == ExplainMode.explain)
+            {
+                Console.WriteLine(physicPlan_.Explain(queryOpt_.explain_));
+                return null; // empty list
+            }
 
             // actual execution is needed
             var finalplan = new PhysicCollect(physicPlan_);
@@ -111,6 +114,10 @@ namespace qpmodel.logic
                 CodeWriter.WriteLine(code);
                 Compiler.Run(Compiler.Compile(), this, context);
             }
+            if (queryOpt_.explain_.mode_ == ExplainMode.analyze)
+            {
+                Console.WriteLine(physicPlan_.Explain(queryOpt_.explain_));
+            }
             return finalplan.rows_;
         }
 
@@ -126,7 +133,7 @@ namespace qpmodel.logic
                 var result = stmt.Exec();
                 physicplan = "";
                 if (stmt.physicPlan_ != null)
-                    physicplan = stmt.physicPlan_.Explain(option?.explain_);
+                    physicplan = stmt.physicPlan_.Explain(option?.explain_ ?? stmt.queryOpt_.explain_);
                 error = "";
                 return result;
             }

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -301,7 +301,7 @@ namespace qpmodel.unittest
             try
             {
                 ExplainOption.show_tablename_ = false;
-                RunFolderAndVerify(sql_dir_fn, write_dir_fn, expect_dir_fn, badQueries);
+                RunFolderAndVerify(sql_dir_fn, write_dir_fn, expect_dir_fn, badQueries, scale == "1");
             }
             finally
             {
@@ -333,10 +333,10 @@ namespace qpmodel.unittest
             }
         }
 
-        void RunFolderAndVerify(string sql_dir_fn, string write_dir_fn, string expect_dir_fn, string[] badQueries)
+        void RunFolderAndVerify(string sql_dir_fn, string write_dir_fn, string expect_dir_fn, string[] badQueries, bool explainOnly = false)
         {
             QueryVerify qv = new QueryVerify();
-            var result = qv.SQLQueryVerify(sql_dir_fn, write_dir_fn, expect_dir_fn, badQueries);
+            var result = qv.SQLQueryVerify(sql_dir_fn, write_dir_fn, expect_dir_fn, badQueries, explainOnly);
             if (result != null) Debug.WriteLine(result);
             Assert.IsNull(result);
         }

--- a/test/regress/expect/tpch1/q01.txt
+++ b/test/regress/expect/tpch1/q01.txt
@@ -20,15 +20,13 @@ order by
 	l_returnflag,
 	l_linestatus
 Total cost: 11882428.35
-PhysicOrder  (inccost=11882428.35, cost=11.35, rows=6) (actual rows=0)
+PhysicOrder  (inccost=11882428.35, cost=11.35, rows=6)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=11882417, cost=5881202, rows=6) (actual rows=0)
+    -> PhysicHashAgg  (inccost=11882417, cost=5881202, rows=6)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*1-l_discount[7]), sum(l_extendedprice[3]*1-l_discount[7]*1+l_tax[10]), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=5881190) (actual rows=0)
+        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=5881190)
             Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
             Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
-
-

--- a/test/regress/expect/tpch1/q02.txt
+++ b/test/regress/expect/tpch1/q02.txt
@@ -43,62 +43,60 @@ order by
 	p_partkey
 limit 100
 Total cost: 6176277.59
-PhysicLimit (100) (inccost=6176277.59, cost=100, rows=100) (actual rows=0)
+PhysicLimit (100) (inccost=6176277.59, cost=100, rows=100)
     Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
-    -> PhysicOrder  (inccost=6176177.59, cost=3.59, rows=3) (actual rows=0)
+    -> PhysicOrder  (inccost=6176177.59, cost=3.59, rows=3)
         Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
         Order by: s_acctbal[0], n_name[2], s_name[1], p_partkey[3]
-        -> PhysicFilter  (inccost=6176174, cost=3, rows=3) (actual rows=0)
+        -> PhysicFilter  (inccost=6176174, cost=3, rows=3)
             Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
             Filter: ps_supplycost[8]={min(ps_supplycost)}[9]
-            -> PhysicHashJoin Left (inccost=6176171, cost=160011, rows=3) (actual rows=0)
+            -> PhysicHashJoin Left (inccost=6176171, cost=160011, rows=3)
                 Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
                 Filter: p_partkey[3]=ps_partkey[10]
-                -> PhysicHashJoin  (inccost=3750088, cost=160016, rows=4) (actual rows=0)
+                -> PhysicHashJoin  (inccost=3750088, cost=160016, rows=4)
                     Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
                     Filter: p_partkey[0]=ps_partkey[9]
-                    -> PhysicScanTable part (inccost=200000, cost=200000, rows=6) (actual rows=0)
+                    -> PhysicScanTable part (inccost=200000, cost=200000, rows=6)
                         Output: p_partkey[0],p_mfgr[2]
                         Filter: p_size[5]=15 and p_type[4]like'%BRASS'
-                    -> PhysicHashJoin  (inccost=3390072, cost=960010, rows=160000) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=3390072, cost=960010, rows=160000)
                         Output: s_acctbal[2],s_name[3],n_name[0],s_address[4],s_phone[5],s_comment[6],ps_supplycost[7],ps_partkey[8]
                         Filter: s_nationkey[9]=n_nationkey[1]
-                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5)
                             Output: n_name[1],n_nationkey[2]
                             Filter: n_regionkey[3]=r_regionkey[0]
-                            -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                            -> PhysicScanTable region (inccost=5, cost=5, rows=1)
                                 Output: r_regionkey[0]
                                 Filter: r_name[1]='EUROPE'
-                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
                                 Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                        -> PhysicHashJoin  (inccost=2430000, cost=1620000, rows=800000) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=2430000, cost=1620000, rows=800000)
                             Output: s_acctbal[0],s_name[1],s_address[2],s_phone[3],s_comment[4],ps_supplycost[7],ps_partkey[8],s_nationkey[5]
                             Filter: s_suppkey[6]=ps_suppkey[9]
-                            -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                            -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                                 Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
-                            -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+                            -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000)
                                 Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
-                -> PhysicHashAgg  (inccost=2266072, cost=480000, rows=160000) (actual rows=0)
+                -> PhysicHashAgg  (inccost=2266072, cost=480000, rows=160000)
                     Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
                     Aggregates: min(ps_supplycost[1])
                     Group by: ps_partkey[0]
-                    -> PhysicHashJoin  (inccost=1786072, cost=964000, rows=160000) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=1786072, cost=964000, rows=160000)
                         Output: ps_partkey[1],ps_supplycost[2]
                         Filter: s_suppkey[0]=ps_suppkey[3]
-                        -> PhysicHashJoin  (inccost=22072, cost=12010, rows=2000) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=22072, cost=12010, rows=2000)
                             Output: s_suppkey[1]
                             Filter: s_nationkey[2]=n_nationkey[0]
-                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5)
                                 Output: n_nationkey[1]
                                 Filter: n_regionkey[2]=r_regionkey[0]
-                                -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=0)
+                                -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1)
                                     Output: r_regionkey[0]
                                     Filter: r_name[1]='EUROPE'
-                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25)
                                     Output: n_nationkey[0],n_regionkey[2]
-                            -> PhysicScanTable supplier as supplier__1 (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                            -> PhysicScanTable supplier as supplier__1 (inccost=10000, cost=10000, rows=10000)
                                 Output: s_suppkey[0],s_nationkey[3]
-                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800000, cost=800000, rows=800000)
                             Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
-
-

--- a/test/regress/expect/tpch1/q03.txt
+++ b/test/regress/expect/tpch1/q03.txt
@@ -22,29 +22,27 @@ order by
 	o_orderdate
 limit 10
 Total cost: 23823672.82
-PhysicLimit (10) (inccost=23823672.82, cost=10, rows=10) (actual rows=0)
+PhysicLimit (10) (inccost=23823672.82, cost=10, rows=10)
     Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
-    -> PhysicOrder  (inccost=23823662.82, cost=6292599.82, rows=477564) (actual rows=0)
+    -> PhysicOrder  (inccost=23823662.82, cost=6292599.82, rows=477564)
         Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
         Order by: {sum(l_extendedprice*1-l_discount)}[1], o_orderdate[2]
-        -> PhysicHashAgg  (inccost=17531063, cost=1432692, rows=477564) (actual rows=0)
+        -> PhysicHashAgg  (inccost=17531063, cost=1432692, rows=477564)
             Output: {l_orderkey}[0],{sum(l_extendedprice*1-l_discount)}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*1-l_discount[7])
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicHashJoin  (inccost=16098371, cost=2122168, rows=477564) (actual rows=0)
+            -> PhysicHashJoin  (inccost=16098371, cost=2122168, rows=477564)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
                 Filter: c_custkey[1]=o_custkey[9]
-                -> PhysicScanTable customer (inccost=150000, cost=150000, rows=30142) (actual rows=0)
+                -> PhysicScanTable customer (inccost=150000, cost=150000, rows=30142)
                     Output: 1,c_custkey[0]
                     Filter: c_mktsegment[6]='BUILDING'
-                -> PhysicHashJoin  (inccost=13826203, cost=6324988, rows=1584320) (actual rows=0)
+                -> PhysicHashJoin  (inccost=13826203, cost=6324988, rows=1584320)
                     Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],l_discount[8],o_custkey[2]
                     Filter: l_orderkey[4]=o_orderkey[3]
-                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=720000) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=720000)
                         Output: o_orderdate[4],o_shippriority[7],o_custkey[1],o_orderkey[0]
                         Filter: o_orderdate[4]<'1995-03-15'
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=3300668) (actual rows=0)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=3300668)
                         Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
                         Filter: l_shipdate[10]>'1995-03-15'
-
-

--- a/test/regress/expect/tpch1/q04.txt
+++ b/test/regress/expect/tpch1/q04.txt
@@ -20,24 +20,22 @@ group by
 order by
 	o_orderpriority
 Total cost: 1825579538325.54
-PhysicOrder  (inccost=1825579538325.54, cost=8.54, rows=5) (actual rows=0)
+PhysicOrder  (inccost=1825579538325.54, cost=8.54, rows=5)
     Output: o_orderpriority[0],{count(*)(0)}[1]
     Order by: o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=1825579538317, cost=1217056, rows=5) (actual rows=0)
+    -> PhysicHashAgg  (inccost=1825579538317, cost=1217056, rows=5)
         Output: {o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: o_orderpriority[0]
-        -> PhysicFilter  (inccost=1825578321261, cost=1217046, rows=1217046) (actual rows=0)
+        -> PhysicFilter  (inccost=1825578321261, cost=1217046, rows=1217046)
             Output: o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=1825577104215, cost=1825569603000, rows=1217046) (actual rows=0)
+            -> PhysicMarkJoin Left (inccost=1825577104215, cost=1825569603000, rows=1217046)
                 Output: #marker,o_orderpriority[0]
                 Filter: l_orderkey[2]=o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=304200) (actual rows=0)
+                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=304200)
                     Output: o_orderpriority[5],o_orderkey[0]
                     Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'
-                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
                     Output: l_orderkey[0]
                     Filter: l_commitdate[11]<l_receiptdate[12]
-
-

--- a/test/regress/expect/tpch1/q05.txt
+++ b/test/regress/expect/tpch1/q05.txt
@@ -23,41 +23,39 @@ group by
 order by
 	revenue desc
 Total cost: 18125642.97
-PhysicOrder  (inccost=18125642.97, cost=82.97, rows=25) (actual rows=0)
+PhysicOrder  (inccost=18125642.97, cost=82.97, rows=25)
     Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
     Order by: {sum(l_extendedprice*1-l_discount)}[1]
-    -> PhysicHashAgg  (inccost=18125560, cost=22735, rows=25) (actual rows=0)
+    -> PhysicHashAgg  (inccost=18125560, cost=22735, rows=25)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicHashJoin  (inccost=18102825, cost=700761, rows=22685) (actual rows=0)
+        -> PhysicHashJoin  (inccost=18102825, cost=700761, rows=22685)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
             Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
-            -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000) (actual rows=0)
+            -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                 Output: 1,c_custkey[0],c_nationkey[3]
-            -> PhysicHashJoin  (inccost=17252064, cost=2523319, rows=378076) (actual rows=0)
+            -> PhysicHashJoin  (inccost=17252064, cost=2523319, rows=378076)
                 Output: n_name[2],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[0],s_nationkey[7]
                 Filter: l_orderkey[8]=o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=472500) (actual rows=0)
+                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=472500)
                     Output: o_custkey[1],o_orderkey[0]
                     Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
-                -> PhysicHashJoin  (inccost=13228745, cost=7205458, rows=1200243) (actual rows=0)
+                -> PhysicHashJoin  (inccost=13228745, cost=7205458, rows=1200243)
                     Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],s_nationkey[1],l_orderkey[7]
                     Filter: l_suppkey[8]=s_suppkey[2]
-                    -> PhysicHashJoin  (inccost=22072, cost=12010, rows=2000) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=22072, cost=12010, rows=2000)
                         Output: n_name[0],s_nationkey[2],s_suppkey[3]
                         Filter: s_nationkey[2]=n_nationkey[1]
-                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5)
                             Output: n_name[1],n_nationkey[2]
                             Filter: n_regionkey[3]=r_regionkey[0]
-                            -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                            -> PhysicScanTable region (inccost=5, cost=5, rows=1)
                                 Output: r_regionkey[0]
                                 Filter: r_name[1]='ASIA'
-                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
                                 Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                             Output: s_nationkey[3],s_suppkey[0]
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
                         Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0],l_suppkey[2]
-
-

--- a/test/regress/expect/tpch1/q06.txt
+++ b/test/regress/expect/tpch1/q06.txt
@@ -8,11 +8,9 @@ where
 	and l_discount between (.06 - 0.01 , .06 + 0.01)
 	and l_quantity < 24
 Total cost: 6883854
-PhysicHashAgg  (inccost=6883854, cost=882639, rows=1) (actual rows=1)
+PhysicHashAgg  (inccost=6883854, cost=882639, rows=1)
     Output: {sum(l_extendedprice*l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*l_discount[2])
-    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=882637) (actual rows=0)
+    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=882637)
         Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
         Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM' and l_discount[6]>=0.05 and l_discount[6]<=0.07 and l_quantity[4]<24
-
-

--- a/test/regress/expect/tpch1/q07.txt
+++ b/test/regress/expect/tpch1/q07.txt
@@ -38,42 +38,40 @@ order by
 	cust_nation,
 	l_year
 Total cost: 228240249.1
-PhysicOrder  (inccost=228240249.1, cost=0.1, rows=1) (actual rows=0)
+PhysicOrder  (inccost=228240249.1, cost=0.1, rows=1)
     Output: supp_nation[0],cust_nation[1],l_year[2],{sum(volume)}[3]
     Order by: supp_nation[0], cust_nation[1], l_year[2]
-    -> PhysicHashAgg  (inccost=228240249, cost=3811525, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=228240249, cost=3811525, rows=1)
         Output: {supp_nation}[0],{cust_nation}[1],{l_year}[2],{sum(volume)}[3]
         Aggregates: sum(volume[3])
         Group by: supp_nation[0], cust_nation[1], l_year[2]
-        -> PhysicFromQuery <shipping> (inccost=224428724, cost=3811523, rows=3811523) (actual rows=0)
+        -> PhysicFromQuery <shipping> (inccost=224428724, cost=3811523, rows=3811523)
             Output: supp_nation[0],cust_nation[1],l_year[2],volume[3]
-            -> PhysicHashJoin  (inccost=220617201, cost=99119598, rows=3811523) (actual rows=0)
+            -> PhysicHashJoin  (inccost=220617201, cost=99119598, rows=3811523)
                 Output: n_name (as supp_nation)[2],n_name (as cust_nation)[3],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5]
                 Filter: s_suppkey[0]=l_suppkey[6] and s_nationkey[1]=n_nationkey[7]
-                -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                     Output: s_suppkey[0],s_nationkey[3]
-                -> PhysicHashJoin  (inccost=121487603, cost=99100848, rows=95288075) (actual rows=0)
+                -> PhysicHashJoin  (inccost=121487603, cost=99100848, rows=95288075)
                     Output: n_name (as supp_nation)[0],n_name (as cust_nation)[1],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5],l_suppkey[6],n_nationkey[2]
                     Filter: c_nationkey[7]=n_nationkey[3]
-                    -> PhysicNLJoin  (inccost=1275, cost=1225, rows=625) (actual rows=0)
+                    -> PhysicNLJoin  (inccost=1275, cost=1225, rows=625)
                         Output: n_name (as supp_nation)[2],n_name (as cust_nation)[0],n_nationkey[3],n_nationkey[1]
                         Filter: n_name[2]='FRANCE' and n_name[0]='GERMANY' or n_name[2]='GERMANY' and n_name[0]='FRANCE'
-                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=0)
+                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25)
                             Output: n_name (as cust_nation)[1],n_nationkey[0]
-                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25)
                             Output: n_name (as supp_nation)[1],n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=22385480, cost=6652437, rows=3811523) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=22385480, cost=6652437, rows=3811523)
                         Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],c_nationkey[0]
                         Filter: c_custkey[1]=o_custkey[5]
-                        -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000) (actual rows=0)
+                        -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                             Output: c_nationkey[3],c_custkey[0]
-                        -> PhysicHashJoin  (inccost=15583043, cost=8081828, rows=2540914) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=15583043, cost=8081828, rows=2540914)
                             Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],o_custkey[0]
                             Filter: o_orderkey[1]=l_orderkey[5]
-                            -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
+                            -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)
                                 Output: o_custkey[1],o_orderkey[0]
-                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=2540914) (actual rows=0)
+                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=2540914)
                                 Output: year(l_shipdate[10]),l_extendedprice[5]*1-l_discount[6](as volume),l_suppkey[2],l_orderkey[0]
                                 Filter: l_shipdate[10]>='1995-01-01' and l_shipdate[10]<='1996-12-31'
-
-

--- a/test/regress/expect/tpch1/q08.txt
+++ b/test/regress/expect/tpch1/q08.txt
@@ -36,54 +36,52 @@ group by
 order by
 	o_year
 Total cost: 41660333.1
-PhysicOrder  (inccost=41660333.1, cost=0.1, rows=1) (actual rows=0)
+PhysicOrder  (inccost=41660333.1, cost=0.1, rows=1)
     Output: o_year[0],{sum(case with 1)/sum(volume)(as mkt_share)}[1]
     Order by: o_year[0]
-    -> PhysicHashAgg  (inccost=41660333, cost=2475, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=41660333, cost=2475, rows=1)
         Output: {o_year}[0],{sum(case with 1)}[1]/{sum(volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(volume[5])
         Group by: o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=41657858, cost=2473, rows=2473) (actual rows=0)
+        -> PhysicFromQuery <all_nations> (inccost=41657858, cost=2473, rows=2473)
             Output: o_year[0],case with 1,nation[2]='BRAZIL',nation[2],'BRAZIL',volume[1],0
-            -> PhysicHashJoin  (inccost=41655385, cost=746485, rows=2473) (actual rows=0)
+            -> PhysicHashJoin  (inccost=41655385, cost=746485, rows=2473)
                 Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3]
                 Filter: p_partkey[0]=l_partkey[4]
-                -> PhysicScanTable part (inccost=200000, cost=200000, rows=666) (actual rows=0)
+                -> PhysicScanTable part (inccost=200000, cost=200000, rows=666)
                     Output: p_partkey[0]
                     Filter: p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=40708900, cost=4456082, rows=742680) (actual rows=0)
+                -> PhysicHashJoin  (inccost=40708900, cost=4456082, rows=742680)
                     Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3],l_partkey[4]
                     Filter: n_regionkey[5]=r_regionkey[0]
-                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                    -> PhysicScanTable region (inccost=5, cost=5, rows=1)
                         Output: r_regionkey[0]
                         Filter: r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=36252813, cost=7426850, rows=3713400) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=36252813, cost=7426850, rows=3713400)
                         Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],n_name (as nation)[0],l_partkey[4],n_regionkey[5]
                         Filter: s_nationkey[6]=n_nationkey[1]
-                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=0)
+                        -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25)
                             Output: n_name (as nation)[1],n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=28825938, cost=7446798, rows=3713399) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=28825938, cost=7446798, rows=3713399)
                             Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[5],s_nationkey[0]
                             Filter: s_suppkey[1]=l_suppkey[6]
-                            -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                            -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                                 Output: s_nationkey[3],s_suppkey[0]
-                            -> PhysicHashJoin  (inccost=21369140, cost=11570938, rows=3713399) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=21369140, cost=11570938, rows=3713399)
                                 Output: {year(o_orderdate)}[0],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[1],l_suppkey[5]
                                 Filter: l_orderkey[6]=o_orderkey[2]
-                                -> PhysicHashJoin  (inccost=3796987, cost=1846912, rows=928162) (actual rows=0)
+                                -> PhysicHashJoin  (inccost=3796987, cost=1846912, rows=928162)
                                     Output: {year(o_orderdate)}[2],n_regionkey[0],o_orderkey[3]
                                     Filter: o_custkey[4]=c_custkey[1]
-                                    -> PhysicHashJoin  (inccost=450075, cost=300050, rows=150000) (actual rows=0)
+                                    -> PhysicHashJoin  (inccost=450075, cost=300050, rows=150000)
                                         Output: n_regionkey[0],c_custkey[2]
                                         Filter: c_nationkey[3]=n_nationkey[1]
-                                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                                        -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25)
                                             Output: n_regionkey[2],n_nationkey[0]
-                                        -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000) (actual rows=0)
+                                        -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                                             Output: c_custkey[0],c_nationkey[3]
-                                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=618750) (actual rows=0)
+                                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=618750)
                                         Output: year(o_orderdate[4]),o_orderkey[0],o_custkey[1]
                                         Filter: o_orderdate[4]>='1995-01-01' and o_orderdate[4]<='1996-12-31'
-                                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
                                     Output: l_extendedprice[5]*1-l_discount[6](as volume),l_partkey[1],l_suppkey[2],l_orderkey[0]
-
-

--- a/test/regress/expect/tpch1/q09.txt
+++ b/test/regress/expect/tpch1/q09.txt
@@ -31,42 +31,40 @@ order by
 	nation,
 	o_year desc
 Total cost: 17649764.1
-PhysicOrder  (inccost=17649764.1, cost=0.1, rows=1) (actual rows=0)
+PhysicOrder  (inccost=17649764.1, cost=0.1, rows=1)
     Output: nation[0],o_year[1],{sum(amount)}[2]
     Order by: nation[0], o_year[1]
-    -> PhysicHashAgg  (inccost=17649764, cost=21, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=17649764, cost=21, rows=1)
         Output: {nation}[0],{o_year}[1],{sum(amount)}[2]
         Aggregates: sum(amount[2])
         Group by: nation[0], o_year[1]
-        -> PhysicFromQuery <profit> (inccost=17649743, cost=19, rows=19) (actual rows=0)
+        -> PhysicFromQuery <profit> (inccost=17649743, cost=19, rows=19)
             Output: nation[0],o_year[1],amount[2]
-            -> PhysicHashJoin  (inccost=17649724, cost=5619, rows=19) (actual rows=0)
+            -> PhysicHashJoin  (inccost=17649724, cost=5619, rows=19)
                 Output: n_name (as nation)[1],{year(o_orderdate)}[2],{l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[3]
                 Filter: p_partkey[0]=l_partkey[4]
-                -> PhysicScanTable part (inccost=200000, cost=200000, rows=1600) (actual rows=0)
+                -> PhysicScanTable part (inccost=200000, cost=200000, rows=1600)
                     Output: p_partkey[0]
                     Filter: p_name[1]like'%green%'
-                -> PhysicHashJoin  (inccost=17444105, cost=4850, rows=2400) (actual rows=0)
+                -> PhysicHashJoin  (inccost=17444105, cost=4850, rows=2400)
                     Output: n_name (as nation)[0],{year(o_orderdate)}[2],{l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[3],l_partkey[4]
                     Filter: s_nationkey[5]=n_nationkey[1]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
                         Output: n_name (as nation)[1],n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=17439230, cost=1507200, rows=2400) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=17439230, cost=1507200, rows=2400)
                         Output: {year(o_orderdate)}[4],{l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[0],l_partkey[1],s_nationkey[2]
                         Filter: o_orderkey[5]=l_orderkey[3]
-                        -> PhysicHashJoin  (inccost=14432030, cost=17200, rows=2400) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=14432030, cost=17200, rows=2400)
                             Output: {l_extendedprice*1-l_discount-ps_supplycost*l_quantity(as amount)}[0],l_partkey[1],s_nationkey[4],l_orderkey[2]
                             Filter: s_suppkey[5]=l_suppkey[3]
-                            -> PhysicHashJoin  (inccost=14404830, cost=7603615, rows=2400) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=14404830, cost=7603615, rows=2400)
                                 Output: l_extendedprice[3]*1-l_discount[4]-ps_supplycost[0]*l_quantity[5](as amount),l_partkey[6],l_orderkey[7],l_suppkey[8]
                                 Filter: ps_suppkey[1]=l_suppkey[8] and ps_partkey[2]=l_partkey[6]
-                                -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+                                -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000)
                                     Output: ps_supplycost[3],ps_suppkey[1],ps_partkey[0]
-                                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
                                     Output: l_extendedprice[5],l_discount[6],l_quantity[4],l_partkey[1],l_orderkey[0],l_suppkey[2]
-                            -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                            -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                                 Output: s_nationkey[3],s_suppkey[0]
-                        -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
+                        -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)
                             Output: year(o_orderdate[4]),o_orderkey[0]
-
-

--- a/test/regress/expect/tpch1/q10.txt
+++ b/test/regress/expect/tpch1/q10.txt
@@ -31,33 +31,31 @@ order by
 	revenue desc
 limit 20
 Total cost: 19527058.97
-PhysicLimit (20) (inccost=19527058.97, cost=20, rows=20) (actual rows=0)
+PhysicLimit (20) (inccost=19527058.97, cost=20, rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=19527038.97, cost=6504328.97, rows=492483) (actual rows=0)
+    -> PhysicOrder  (inccost=19527038.97, cost=6504328.97, rows=492483)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*1-l_discount)}[2]
-        -> PhysicHashAgg  (inccost=13022710, cost=1477449, rows=492483) (actual rows=0)
+        -> PhysicHashAgg  (inccost=13022710, cost=1477449, rows=492483)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicHashJoin  (inccost=11545261, cost=1120792, rows=492483) (actual rows=0)
+            -> PhysicHashJoin  (inccost=11545261, cost=1120792, rows=492483)
                 Output: c_custkey[0],c_name[1],c_acctbal[2],n_name[3],c_address[4],c_phone[5],c_comment[6],{l_extendedprice*1-l_discount}[8],l_extendedprice[9],{1-l_discount}[10],1,l_discount[11]
                 Filter: c_custkey[0]=o_custkey[12]
-                -> PhysicHashJoin  (inccost=450075, cost=300050, rows=150000) (actual rows=0)
+                -> PhysicHashJoin  (inccost=450075, cost=300050, rows=150000)
                     Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{1}[1]
                     Filter: c_nationkey[9]=n_nationkey[2]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
                         Output: n_name[1],1,n_nationkey[0]
-                    -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000) (actual rows=0)
+                    -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                         Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
-                -> PhysicHashJoin  (inccost=9974394, cost=2473179, rows=328309) (actual rows=0)
+                -> PhysicHashJoin  (inccost=9974394, cost=2473179, rows=328309)
                     Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
                     Filter: l_orderkey[6]=o_orderkey[1]
-                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=333000) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=333000)
                         Output: o_custkey[1],o_orderkey[0]
                         Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1478870) (actual rows=0)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1478870)
                         Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
                         Filter: l_returnflag[8]='R'
-
-

--- a/test/regress/expect/tpch1/q11.txt
+++ b/test/regress/expect/tpch1/q11.txt
@@ -26,43 +26,41 @@ group by
 order by
 	value desc
 Total cost: 2084378.71
-PhysicOrder  (inccost=2084378.71, cost=335151.71, rows=32000) (actual rows=0)
+PhysicOrder  (inccost=2084378.71, cost=335151.71, rows=32000)
     Output: ps_partkey[0],{sum(ps_supplycost*ps_availqty)}[1]
     Order by: {sum(ps_supplycost*ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=1749227, cost=96000, rows=32000) (actual rows=0)
+    -> PhysicHashAgg  (inccost=1749227, cost=96000, rows=32000)
         Output: {ps_partkey}[0],{sum(ps_supplycost*ps_availqty)}[1]
         Aggregates: sum(ps_supplycost[2]*ps_availqty[3])
         Group by: ps_partkey[0]
         Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=1685229, cost=32002, rows=1) (actual rows=0)
+            -> PhysicHashAgg  (inccost=1685229, cost=32002, rows=1)
                 Output: {sum(ps_supplycost*ps_availqty)}[0]*0.0001
                 Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                -> PhysicHashJoin  (inccost=1653227, cost=832800, rows=32000) (actual rows=0)
+                -> PhysicHashJoin  (inccost=1653227, cost=832800, rows=32000)
                     Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
                     Filter: ps_suppkey[4]=s_suppkey[0]
-                    -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400)
                         Output: s_suppkey[1]
                         Filter: s_nationkey[2]=n_nationkey[0]
-                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
+                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1)
                             Output: n_nationkey[0]
                             Filter: n_name[1]='GERMANY'
-                        -> PhysicScanTable supplier as supplier__1 (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                        -> PhysicScanTable supplier as supplier__1 (inccost=10000, cost=10000, rows=10000)
                             Output: s_suppkey[0],s_nationkey[3]
-                    -> PhysicScanTable partsupp as partsupp__1 (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+                    -> PhysicScanTable partsupp as partsupp__1 (inccost=800000, cost=800000, rows=800000)
                         Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-        -> PhysicHashJoin  (inccost=1653227, cost=832800, rows=32000) (actual rows=0)
+        -> PhysicHashJoin  (inccost=1653227, cost=832800, rows=32000)
             Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
             Filter: ps_suppkey[5]=s_suppkey[0]
-            -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400) (actual rows=0)
+            -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400)
                 Output: s_suppkey[1]
                 Filter: s_nationkey[2]=n_nationkey[0]
-                -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=0)
+                -> PhysicScanTable nation (inccost=25, cost=25, rows=1)
                     Output: n_nationkey[0]
                     Filter: n_name[1]='GERMANY'
-                -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                     Output: s_suppkey[0],s_nationkey[3]
-            -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+            -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000)
                 Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-
-

--- a/test/regress/expect/tpch1/q12.txt
+++ b/test/regress/expect/tpch1/q12.txt
@@ -27,20 +27,18 @@ group by
 order by
 	l_shipmode
 Total cost: 11105051.32
-PhysicOrder  (inccost=11105051.32, cost=14.32, rows=7) (actual rows=0)
+PhysicOrder  (inccost=11105051.32, cost=14.32, rows=7)
     Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=11105037, cost=525966, rows=7) (actual rows=0)
+    -> PhysicHashAgg  (inccost=11105037, cost=525966, rows=7)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicHashJoin  (inccost=10579071, cost=3077856, rows=525952) (actual rows=0)
+        -> PhysicHashJoin  (inccost=10579071, cost=3077856, rows=525952)
             Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
             Filter: o_orderkey[15]=l_orderkey[5]
-            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=525952) (actual rows=0)
+            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=525952)
                 Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                 Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
-            -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
+            -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)
                 Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
-
-

--- a/test/regress/expect/tpch1/q14.txt
+++ b/test/regress/expect/tpch1/q14.txt
@@ -12,16 +12,14 @@ where
 	and l_shipdate >= date '1995-09-01'
 	and l_shipdate < date '1995-09-01' + interval '1' month
 Total cost: 11170541
-PhysicHashAgg  (inccost=11170541, cost=1523110, rows=1) (actual rows=1)
+PhysicHashAgg  (inccost=11170541, cost=1523110, rows=1)
     Output: 100*{sum(case with 1)}[0]/{sum(l_extendedprice*1-l_discount)}[1](as promo_revenue)
     Aggregates: sum(case with 1), sum(l_extendedprice[5]*1-l_discount[8])
-    -> PhysicHashJoin  (inccost=9647431, cost=3446216, rows=1523108) (actual rows=0)
+    -> PhysicHashJoin  (inccost=9647431, cost=3446216, rows=1523108)
         Output: case with 1,{p_typelike'PROMO%'}[1],p_type[0],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[8],l_extendedprice[6],{1-l_discount}[9],{1}[3],l_discount[7],{0}[4]
         Filter: l_partkey[10]=p_partkey[5]
-        -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000) (actual rows=0)
+        -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000)
             Output: p_type[4],p_type[4]like'PROMO%','PROMO%',1,0,p_partkey[0]
-        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1523108) (actual rows=0)
+        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1523108)
             Output: l_extendedprice[5],l_discount[6],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],l_partkey[1]
             Filter: l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM'
-
-

--- a/test/regress/expect/tpch1/q15.txt
+++ b/test/regress/expect/tpch1/q15.txt
@@ -29,35 +29,33 @@ where
 			revenue0
 	)
 Total cost: 7628726
-PhysicFilter  (inccost=7628726, cost=10000, rows=10000) (actual rows=0)
+PhysicFilter  (inccost=7628726, cost=10000, rows=10000)
     Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
     Filter: total_revenue[4]=@1
     <ScalarSubqueryExpr> cached 1
-        -> PhysicHashAgg  (inccost=7578728, cost=10002, rows=1) (actual rows=0)
+        -> PhysicHashAgg  (inccost=7578728, cost=10002, rows=1)
             Output: {max(total_revenue)}[0]
             Aggregates: max(total_revenue[0])
-            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7568726, cost=10000, rows=10000) (actual rows=0)
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7568726, cost=10000, rows=10000)
                 Output: total_revenue[1]
-                -> PhysicHashAgg  (inccost=7558726, cost=1557511, rows=10000) (actual rows=0)
+                -> PhysicHashAgg  (inccost=7558726, cost=1557511, rows=10000)
                     Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
                     Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
                     Group by: l_suppkey[0]
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1537511) (actual rows=0)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1537511)
                         Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
                         Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
-    -> PhysicHashJoin  (inccost=7618726, cost=40000, rows=10000) (actual rows=0)
+    -> PhysicHashJoin  (inccost=7618726, cost=40000, rows=10000)
         Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
         Filter: s_suppkey[0]=supplier_no[5]
-        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
             Output: s_suppkey[0],s_name[1],s_address[2],s_phone[4]
-        -> PhysicFromQuery <revenue0> (inccost=7568726, cost=10000, rows=10000) (actual rows=0)
+        -> PhysicFromQuery <revenue0> (inccost=7568726, cost=10000, rows=10000)
             Output: total_revenue[1],supplier_no[0]
-            -> PhysicHashAgg  (inccost=7558726, cost=1557511, rows=10000) (actual rows=0)
+            -> PhysicHashAgg  (inccost=7558726, cost=1557511, rows=10000)
                 Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
                 Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
                 Group by: l_suppkey[0]
-                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1537511) (actual rows=0)
+                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1537511)
                     Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
                     Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
-
-

--- a/test/regress/expect/tpch1/q16.txt
+++ b/test/regress/expect/tpch1/q16.txt
@@ -29,25 +29,23 @@ order by
 	p_type,
 	p_size
 Total cost: 3881902.61
-PhysicOrder  (inccost=3881902.61, cost=1509052.61, rows=127300) (actual rows=0)
+PhysicOrder  (inccost=3881902.61, cost=1509052.61, rows=127300)
     Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
     Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
-    -> PhysicHashAgg  (inccost=2372850, cost=381900, rows=127300) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2372850, cost=381900, rows=127300)
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicHashJoin  (inccost=1990950, cost=990950, rows=127300) (actual rows=0)
+        -> PhysicHashJoin  (inccost=1990950, cost=990950, rows=127300)
             Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
             Filter: p_partkey[3]=ps_partkey[5]
-            -> PhysicScanTable part (inccost=200000, cost=200000, rows=31825) (actual rows=0)
+            -> PhysicScanTable part (inccost=200000, cost=200000, rows=31825)
                 Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
                 Filter: p_brand[3]<>'Brand#45' and p_type[4]not like'MEDIUM POLISHED%' and p_size[5] in (49,14,23, ... <Total: 8> )
-            -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+            -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000)
                 Output: ps_suppkey[1],ps_partkey[0]
                 Filter: ps_suppkey[1] in @1
                 <InSubqueryExpr> cached 1
-                    -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=1) (actual rows=0)
+                    -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=1)
                         Output: s_suppkey[0]
                         Filter: s_comment[6]like'%Customer%Complaints%'
-
-

--- a/test/regress/expect/tpch1/q17.txt
+++ b/test/regress/expect/tpch1/q17.txt
@@ -16,28 +16,26 @@ where
 			l_partkey = p_partkey
 	)
 Total cost: 24840904
-PhysicHashAgg  (inccost=24840904, cost=5943, rows=1) (actual rows=1)
+PhysicHashAgg  (inccost=24840904, cost=5943, rows=1)
     Output: {sum(l_extendedprice)}[0]/7(as avg_yearly)
     Aggregates: sum(l_extendedprice[0])
-    -> PhysicFilter  (inccost=24834961, cost=5941, rows=5941) (actual rows=0)
+    -> PhysicFilter  (inccost=24834961, cost=5941, rows=5941)
         Output: l_extendedprice[0]
         Filter: l_quantity[1]<0.2*{avg(l_quantity)}[2]
-        -> PhysicHashJoin Left (inccost=24829020, cost=217823, rows=5941) (actual rows=0)
+        -> PhysicHashJoin Left (inccost=24829020, cost=217823, rows=5941)
             Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
             Filter: l_partkey[4]=p_partkey[2]
-            -> PhysicHashJoin  (inccost=12208767, cost=6007552, rows=5941) (actual rows=0)
+            -> PhysicHashJoin  (inccost=12208767, cost=6007552, rows=5941)
                 Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
                 Filter: p_partkey[0]=l_partkey[3]
-                -> PhysicScanTable part (inccost=200000, cost=200000, rows=198) (actual rows=0)
+                -> PhysicScanTable part (inccost=200000, cost=200000, rows=198)
                     Output: p_partkey[0]
                     Filter: p_container[6]='MED BOX' and p_brand[3]='Brand#23'
-                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
                     Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
-            -> PhysicHashAgg  (inccost=12402430, cost=6401215, rows=200000) (actual rows=0)
+            -> PhysicHashAgg  (inccost=12402430, cost=6401215, rows=200000)
                 Output: {avg(l_quantity)}[1],{l_partkey}[0]
                 Aggregates: avg(l_quantity[1])
                 Group by: l_partkey[0]
-                -> PhysicScanTable lineitem as lineitem__1 (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                -> PhysicScanTable lineitem as lineitem__1 (inccost=6001215, cost=6001215, rows=6001215)
                     Output: l_partkey[1],l_quantity[4]
-
-

--- a/test/regress/expect/tpch1/q18.txt
+++ b/test/regress/expect/tpch1/q18.txt
@@ -32,35 +32,33 @@ order by
 	o_orderdate
 limit 100
 Total cost: 210015644.47
-PhysicLimit (100) (inccost=210015644.47, cost=100, rows=100) (actual rows=0)
+PhysicLimit (100) (inccost=210015644.47, cost=100, rows=100)
     Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
-    -> PhysicOrder  (inccost=210015544.47, cost=145051956.47, rows=9002182) (actual rows=0)
+    -> PhysicOrder  (inccost=210015544.47, cost=145051956.47, rows=9002182)
         Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
         Order by: o_totalprice[4], o_orderdate[3]
-        -> PhysicHashAgg  (inccost=64963588, cost=27006546, rows=9002182) (actual rows=0)
+        -> PhysicHashAgg  (inccost=64963588, cost=27006546, rows=9002182)
             Output: {c_name}[0],{c_custkey}[1],{o_orderkey}[2],{o_orderdate}[3],{o_totalprice}[4],{sum(l_quantity)}[5]
             Aggregates: sum(l_quantity[5])
             Group by: c_name[0], c_custkey[1], o_orderkey[2], o_orderdate[3], o_totalprice[4]
-            -> PhysicHashJoin  (inccost=37957042, cost=15303397, rows=9002182) (actual rows=0)
+            -> PhysicHashJoin  (inccost=37957042, cost=15303397, rows=9002182)
                 Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],l_quantity[5]
                 Filter: c_custkey[1]=o_custkey[6]
-                -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000) (actual rows=0)
+                -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                     Output: c_name[1],c_custkey[0]
-                -> PhysicHashJoin  (inccost=22503645, cost=15002430, rows=6001215) (actual rows=0)
+                -> PhysicHashJoin  (inccost=22503645, cost=15002430, rows=6001215)
                     Output: o_orderkey[0],o_orderdate[1],o_totalprice[2],l_quantity[4],o_custkey[3]
                     Filter: o_orderkey[0]=l_orderkey[5]
-                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)
                         Output: o_orderkey[0],o_orderdate[4],o_totalprice[3],o_custkey[1]
                         Filter: o_orderkey[0] in @1
                         <InSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=15002430, cost=9001215, rows=1500000) (actual rows=0)
+                            -> PhysicHashAgg  (inccost=15002430, cost=9001215, rows=1500000)
                                 Output: {l_orderkey}[0]
                                 Aggregates: sum(l_quantity[1])
                                 Group by: l_orderkey[0]
                                 Filter: {sum(l_quantity)}[1]>300
-                                -> PhysicScanTable lineitem as lineitem__1 (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                                -> PhysicScanTable lineitem as lineitem__1 (inccost=6001215, cost=6001215, rows=6001215)
                                     Output: l_orderkey[0],l_quantity[4]
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
                         Output: l_quantity[4],l_orderkey[0]
-
-

--- a/test/regress/expect/tpch1/q19.txt
+++ b/test/regress/expect/tpch1/q19.txt
@@ -34,15 +34,13 @@ where
 		and l_shipinstruct = 'DELIVER IN PERSON'
 	)
 Total cost: 2400554213467
-PhysicHashAgg  (inccost=2400554213467, cost=1200243000002, rows=1) (actual rows=1)
+PhysicHashAgg  (inccost=2400554213467, cost=1200243000002, rows=1)
     Output: {sum(l_extendedprice*1-l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*1-l_discount[4])
-    -> PhysicNLJoin  (inccost=1200311213465, cost=1200305012250, rows=1200243000000) (actual rows=0)
+    -> PhysicNLJoin  (inccost=1200311213465, cost=1200305012250, rows=1200243000000)
         Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],{1}[3],l_discount[4]
         Filter: p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12' and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and l_quantity[6]>=1 and l_quantity[6]<=11 and p_size[12]>=1 and p_size[12]<=5 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23' and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and l_quantity[6]>=10 and l_quantity[6]<=20 and p_size[12]>=1 and p_size[12]<=10 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34' and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and l_quantity[6]>=20 and l_quantity[6]<=30 and p_size[12]>=1 and p_size[12]<=15 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON'
-        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
             Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
-        -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000) (actual rows=0)
+        -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000)
             Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
-
-

--- a/test/regress/expect/tpch1/q20.txt
+++ b/test/regress/expect/tpch1/q20.txt
@@ -36,38 +36,36 @@ where
 order by
 	s_name
 Total cost: 22863.58
-PhysicOrder  (inccost=22863.58, cost=2436.58, rows=400) (actual rows=0)
+PhysicOrder  (inccost=22863.58, cost=2436.58, rows=400)
     Output: s_name[0],s_address[1]
     Order by: s_name[0]
-    -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400) (actual rows=0)
+    -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400)
         Output: s_name[1],s_address[2]
         Filter: s_nationkey[3]=n_nationkey[0]
-        -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=0)
+        -> PhysicScanTable nation (inccost=25, cost=25, rows=1)
             Output: n_nationkey[0]
             Filter: n_name[1]='CANADA'
-        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
             Output: s_name[1],s_address[2],s_nationkey[3]
             Filter: s_suppkey[0] in @1
             <InSubqueryExpr> cached 1
-                -> PhysicFilter  (inccost=15762573, cost=735, rows=735) (actual rows=0)
+                -> PhysicFilter  (inccost=15762573, cost=735, rows=735)
                     Output: ps_suppkey[0]
                     Filter: ps_availqty[1]>0.5*{sum(l_quantity)}[2]
-                    -> PhysicHashJoin Left (inccost=15761838, cost=3440707, rows=735) (actual rows=0)
+                    -> PhysicHashJoin Left (inccost=15761838, cost=3440707, rows=735)
                         Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
                         Filter: l_partkey[4]=ps_partkey[2] and l_suppkey[5]=ps_suppkey[0]
-                        -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000) (actual rows=0)
+                        -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000)
                             Output: ps_suppkey[1],ps_availqty[2],ps_partkey[0]
                             Filter: ps_partkey[0] in @2
                             <InSubqueryExpr> cached 2
-                                -> PhysicScanTable part (inccost=200000, cost=200000, rows=64) (actual rows=0)
+                                -> PhysicScanTable part (inccost=200000, cost=200000, rows=64)
                                     Output: p_partkey[0]
                                     Filter: p_name[1]like'forest%'
-                        -> PhysicHashAgg  (inccost=11521131, cost=5519916, rows=1839972) (actual rows=0)
+                        -> PhysicHashAgg  (inccost=11521131, cost=5519916, rows=1839972)
                             Output: {sum(l_quantity)}[2],{l_partkey}[0],{l_suppkey}[1]
                             Aggregates: sum(l_quantity[2])
                             Group by: l_partkey[0], l_suppkey[1]
-                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1839972) (actual rows=0)
+                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1839972)
                                 Output: l_partkey[1],l_suppkey[2],l_quantity[4]
                                 Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM'
-
-

--- a/test/regress/expect/tpch1/q21.txt
+++ b/test/regress/expect/tpch1/q21.txt
@@ -39,51 +39,49 @@ order by
 	s_name
 limit 100
 Total cost: 36715148356934.4
-PhysicLimit (100) (inccost=36715148356934.4, cost=100, rows=100) (actual rows=0)
+PhysicLimit (100) (inccost=36715148356934.4, cost=100, rows=100)
     Output: s_name[0],{count(*)(0)}[1]
-    -> PhysicOrder  (inccost=36715148356834.4, cost=93103.4, rows=10000) (actual rows=0)
+    -> PhysicOrder  (inccost=36715148356834.4, cost=93103.4, rows=10000)
         Output: s_name[0],{count(*)(0)}[1]
         Order by: {count(*)(0)}[1], s_name[0]
-        -> PhysicHashAgg  (inccost=36715148263731, cost=6021215, rows=10000) (actual rows=0)
+        -> PhysicHashAgg  (inccost=36715148263731, cost=6021215, rows=10000)
             Output: {s_name}[0],{count(*)(0)}[1]
             Aggregates: count(*)(0)
             Group by: s_name[0]
-            -> PhysicFilter  (inccost=36715142242516, cost=6001215, rows=6001215) (actual rows=0)
+            -> PhysicFilter  (inccost=36715142242516, cost=6001215, rows=6001215)
                 Output: s_name[1]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=36715136241301, cost=36014581476225, rows=6001215) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=36715136241301, cost=36014581476225, rows=6001215)
                     Output: #marker,s_name[0]
                     Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
-                    -> PhysicFilter  (inccost=700548763861, cost=6001215, rows=6001215) (actual rows=0)
+                    -> PhysicFilter  (inccost=700548763861, cost=6001215, rows=6001215)
                         Output: s_name[1],l_orderkey[2],l_suppkey[3]
                         Filter: {#marker}[0]
-                        -> PhysicMarkJoin Left (inccost=700542762646, cost=700515825735, rows=6001215) (actual rows=0)
+                        -> PhysicMarkJoin Left (inccost=700542762646, cost=700515825735, rows=6001215)
                             Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
                             Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
-                            -> PhysicHashJoin  (inccost=20935696, cost=3035771, rows=116729) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=20935696, cost=3035771, rows=116729)
                                 Output: s_name[0],l_orderkey[2],l_suppkey[3]
                                 Filter: s_suppkey[1]=l_suppkey[3]
-                                -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400) (actual rows=0)
+                                -> PhysicHashJoin  (inccost=20427, cost=10402, rows=400)
                                     Output: s_name[1],s_suppkey[2]
                                     Filter: s_nationkey[3]=n_nationkey[0]
-                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=0)
+                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=1)
                                         Output: n_nationkey[0]
                                         Filter: n_name[1]='SAUDI ARABIA'
-                                    -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000) (actual rows=0)
+                                    -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                                         Output: s_name[1],s_suppkey[0],s_nationkey[3]
-                                -> PhysicHashJoin  (inccost=17879498, cost=10378283, rows=2918242) (actual rows=0)
+                                -> PhysicHashJoin  (inccost=17879498, cost=10378283, rows=2918242)
                                     Output: l_orderkey[1],l_suppkey[2]
                                     Filter: o_orderkey[0]=l_orderkey[1]
-                                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=729413) (actual rows=0)
+                                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=729413)
                                         Output: o_orderkey[0]
                                         Filter: o_orderstatus[2]='F'
-                                    -> PhysicScanTable lineitem as l1 (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                                    -> PhysicScanTable lineitem as l1 (inccost=6001215, cost=6001215, rows=6001215)
                                         Output: l_orderkey[0],l_suppkey[2]
                                         Filter: l_receiptdate[12]>l_commitdate[11]
-                            -> PhysicScanTable lineitem as l3 (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                            -> PhysicScanTable lineitem as l3 (inccost=6001215, cost=6001215, rows=6001215)
                                 Output: l_orderkey[0],l_suppkey[2]
                                 Filter: l_receiptdate[12]>l_commitdate[11]
-                    -> PhysicScanTable lineitem as l2 (inccost=6001215, cost=6001215, rows=6001215) (actual rows=0)
+                    -> PhysicScanTable lineitem as l2 (inccost=6001215, cost=6001215, rows=6001215)
                         Output: l_orderkey[0],l_suppkey[2]
-
-

--- a/test/regress/expect/tpch1/q22.txt
+++ b/test/regress/expect/tpch1/q22.txt
@@ -36,32 +36,30 @@ group by
 order by
 	cntrycode
 Total cost: 225008400272.1
-PhysicOrder  (inccost=225008400272.1, cost=0.1, rows=1) (actual rows=0)
+PhysicOrder  (inccost=225008400272.1, cost=0.1, rows=1)
     Output: cntrycode[0],{count(*)(0)}[1],{sum(c_acctbal)}[2]
     Order by: cntrycode[0]
-    -> PhysicHashAgg  (inccost=225008400272, cost=2250092, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=225008400272, cost=2250092, rows=1)
         Output: {cntrycode}[0],{count(*)(0)}[1],{sum(c_acctbal)}[2]
         Aggregates: count(*)(0), sum(c_acctbal[1])
         Group by: cntrycode[0]
-        -> PhysicFromQuery <custsale> (inccost=225006150180, cost=2250090, rows=2250090) (actual rows=0)
+        -> PhysicFromQuery <custsale> (inccost=225006150180, cost=2250090, rows=2250090)
             Output: cntrycode[0],c_acctbal[1]
-            -> PhysicFilter  (inccost=225003900090, cost=2250090, rows=2250090) (actual rows=0)
+            -> PhysicFilter  (inccost=225003900090, cost=2250090, rows=2250090)
                 Output: {substring(c_phone,1,2)}[1],c_acctbal[2]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=225001650000, cost=225000000000, rows=2250090) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=225001650000, cost=225000000000, rows=2250090)
                     Output: #marker,{substring(c_phone,1,2)}[0],c_acctbal[1]
                     Filter: o_custkey[3]=c_custkey[2]
-                    -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000) (actual rows=0)
+                    -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                         Output: substring(c_phone[4],1,2),c_acctbal[5],c_custkey[0]
                         Filter: substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and c_acctbal[5]>@1
                         <ScalarSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=286502, cost=136502, rows=1) (actual rows=0)
+                            -> PhysicHashAgg  (inccost=286502, cost=136502, rows=1)
                                 Output: {avg(c_acctbal)}[0]
                                 Aggregates: avg(c_acctbal[0])
-                                -> PhysicScanTable customer as customer__1 (inccost=150000, cost=150000, rows=136500) (actual rows=0)
+                                -> PhysicScanTable customer as customer__1 (inccost=150000, cost=150000, rows=136500)
                                     Output: c_acctbal[5]
                                     Filter: c_acctbal[5]>0 and substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
-                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)
                         Output: o_custkey[1]
-
-


### PR DESCRIPTION
This branch is a new implementation for #107 .

This branch does three things:
1. Add EXPLAIN/ EXPLAIN EXECUTE to parser
Now EXPLAIN/ EXPLAIN EXECUTE + query can be interpreted. EXPLAIN EXECUTE works like EXPLAIN ANALYZE in PostgreSQL.
2. Change the explain options
Change the previous show_cost parameter to enum class for 4 different cases. Only physical plan, physical plan + actual cardinality, physical plan + estimated cost (without query execution), and full information.
3. Change TPCH 1G test
Make the TPCH 1G test to be explain only, which returns the physical plan and estimates without execution.