### PR TITLE
Patch for statistics part

### DIFF
--- a/qpmodel/Expr.cs
+++ b/qpmodel/Expr.cs
@@ -355,17 +355,22 @@ namespace qpmodel.expr
 
         // a>5 => [a > 5]
         // a>5 AND c>7 => [a>5, c>7]
-        public static List<Expr> FilterToAndList(this Expr filter)
+        public static List<Expr> FilterToAndOrList(this Expr filter, bool isAndOnly = false)
         {
             Debug.Assert(filter.IsBoolean());
-            var andlist = new List<Expr>();
+            var andorlist = new List<Expr>();
             if (filter is LogicAndExpr andexpr)
-                andlist = andexpr.BreakToList();
+                andorlist = andexpr.BreakToList(true);
+            else if (!isAndOnly && filter is LogicOrExpr orexpr)
+                andorlist = orexpr.BreakToList(false);
             else
-                andlist.Add(filter);
+                andorlist.Add(filter);
 
-            return andlist;
+            return andorlist;
         }
+
+        public static List<Expr> FilterToAndList(this Expr filter)
+            => filter.FilterToAndOrList(true);
 
         // Join filter pushdown may depends on join order.
         // Consider 

--- a/qpmodel/ExprFunc.cs
+++ b/qpmodel/ExprFunc.cs
@@ -992,6 +992,21 @@ namespace qpmodel.expr
             type_ = new BoolType(); Debug.Assert(Clone().Equals(this));
             Debug.Assert(this.IsBoolean());
         }
+        public List<Expr> BreakToList(bool isAnd)
+        {
+            var andorlist = new List<Expr>();
+            for (int i = 0; i < 2; i++)
+            {
+                Expr e = i == 0 ? l_() : r_();
+                if (isAnd && e is LogicAndExpr ea)
+                    andorlist.AddRange(ea.BreakToList(isAnd));
+                else if (!isAnd && e is LogicOrExpr eo)
+                    andorlist.AddRange(eo.BreakToList(isAnd));
+                else
+                    andorlist.Add(e);
+            }
+            return andorlist;
+        }
     }
 
     public class LogicAndExpr : LogicAndOrExpr
@@ -1009,20 +1024,6 @@ namespace qpmodel.expr
 
         // a AND (b OR c) AND d => [a, b OR c, d]
         //
-        public List<Expr> BreakToList()
-        {
-            var andlist = new List<Expr>();
-            for (int i = 0; i < 2; i++)
-            {
-                Expr e = i == 0 ? l_() : r_();
-                if (e is LogicAndExpr ea)
-                    andlist.AddRange(ea.BreakToList());
-                else
-                    andlist.Add(e);
-            }
-
-            return andlist;
-        }
     }
 
     public class LogicOrExpr : LogicAndOrExpr

--- a/qpmodel/LogicCard.cs
+++ b/qpmodel/LogicCard.cs
@@ -183,7 +183,7 @@ namespace qpmodel.logic
                     mindlr = 0;
                     break;
                 }
-                mindlr = mindlr * Math.Max(dl, dr);
+                mindlr = mindlr * Math.Min(dl, dr);
             }
             
             if (mindlr != 0)

--- a/qpmodel/LogicCard.cs
+++ b/qpmodel/LogicCard.cs
@@ -183,9 +183,9 @@ namespace qpmodel.logic
                     mindlr = 0;
                     break;
                 }
-                mindlr = mindlr * Math.Min(dl, dr);
+                mindlr = mindlr * Math.Max(dl, dr);
             }
-
+            
             if (mindlr != 0)
                 card = Math.Max(1, (cardl * cardr) / mindlr);
             else

--- a/qpmodel/Statis.cs
+++ b/qpmodel/Statis.cs
@@ -413,9 +413,10 @@ namespace qpmodel.stat
             double backupsel = 1.0;
             foreach (double sel in listsel)
             {
-                selectivity = isAnd ? selectivity - (1.0 - sel) : Math.Max(selectivity, sel);
+                selectivity = isAnd ? selectivity - (1.0 - sel) : selectivity + sel;
                 backupsel *= sel;
             }
+            if (!isAnd) selectivity = Math.Min(selectivity, 1.0);
             if (selectivity < 0 || selectivity > 1.0) selectivity = backupsel;
             return selectivity;
         }

--- a/test/regress/expect/tpch0001/q01.txt
+++ b/test/regress/expect/tpch0001/q01.txt
@@ -19,15 +19,15 @@ group by
 order by
 	l_returnflag,
 	l_linestatus
-Total cost: 11912.35
-PhysicOrder  (inccost=11912.35, cost=11.35, rows=6) (actual rows=4)
+Total cost: 11941.35
+PhysicOrder  (inccost=11941.35, cost=11.35, rows=6) (actual rows=4)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=11901, cost=5896, rows=6) (actual rows=4)
+    -> PhysicHashAgg  (inccost=11930, cost=5925, rows=6) (actual rows=4)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*1-l_discount[7]), sum(l_extendedprice[3]*1-l_discount[7]*1+l_tax[10]), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5884) (actual rows=5914)
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5913) (actual rows=5914)
             Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
             Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
 A,F,37474,37569624.64,35676192.097,37101416.2224,25.3918,25457.0114,0.05,1478

--- a/test/regress/expect/tpch0001/q03.txt
+++ b/test/regress/expect/tpch0001/q03.txt
@@ -21,29 +21,29 @@ order by
 	revenue desc,
 	o_orderdate
 limit 10
-Total cost: 20328.13
-PhysicLimit (10) (inccost=20328.13, cost=10, rows=10) (actual rows=8)
+Total cost: 20261.68
+PhysicLimit (10) (inccost=20261.68, cost=10, rows=10) (actual rows=8)
     Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
-    -> PhysicOrder  (inccost=20318.13, cost=2859.13, rows=459) (actual rows=8)
+    -> PhysicOrder  (inccost=20251.68, cost=2844.68, rows=457) (actual rows=8)
         Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
         Order by: {sum(l_extendedprice*1-l_discount)}[1], o_orderdate[2]
-        -> PhysicHashAgg  (inccost=17459, cost=1377, rows=459) (actual rows=8)
+        -> PhysicHashAgg  (inccost=17407, cost=1371, rows=457) (actual rows=8)
             Output: {l_orderkey}[0],{sum(l_extendedprice*1-l_discount)}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*1-l_discount[7])
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicHashJoin  (inccost=16082, cost=2101, rows=459) (actual rows=14)
+            -> PhysicHashJoin  (inccost=16036, cost=2093, rows=457) (actual rows=14)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
                 Filter: c_custkey[1]=o_custkey[9]
                 -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=29)
                     Output: 1,c_custkey[0]
                     Filter: c_mktsegment[6]='BUILDING'
-                -> PhysicHashJoin  (inccost=13831, cost=6326, rows=1584) (actual rows=133)
+                -> PhysicHashJoin  (inccost=13793, cost=6288, rows=1578) (actual rows=133)
                     Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],l_discount[8],o_custkey[2]
                     Filter: l_orderkey[4]=o_orderkey[3]
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=720) (actual rows=726)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=727) (actual rows=726)
                         Output: o_orderdate[4],o_shippriority[7],o_custkey[1],o_orderkey[0]
                         Filter: o_orderdate[4]<'1995-03-15'
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3302) (actual rows=3252)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3256) (actual rows=3252)
                         Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
                         Filter: l_shipdate[10]>'1995-03-15'
 1637,164224.9253,2/8/1995 12:00:00 AM,0

--- a/test/regress/expect/tpch0001/q04.txt
+++ b/test/regress/expect/tpch0001/q04.txt
@@ -19,21 +19,21 @@ group by
 	o_orderpriority
 order by
 	o_orderpriority
-Total cost: 1811425.54
-PhysicOrder  (inccost=1811425.54, cost=8.54, rows=5) (actual rows=5)
+Total cost: 284121.54
+PhysicOrder  (inccost=284121.54, cost=8.54, rows=5) (actual rows=5)
     Output: o_orderpriority[0],{count(*)(0)}[1]
     Order by: o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=1811417, cost=1211, rows=5) (actual rows=5)
+    -> PhysicHashAgg  (inccost=284113, cost=194, rows=5) (actual rows=5)
         Output: {o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: o_orderpriority[0]
-        -> PhysicFilter  (inccost=1810206, cost=1201, rows=1201) (actual rows=44)
+        -> PhysicFilter  (inccost=283919, cost=184, rows=184) (actual rows=44)
             Output: o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=1809005, cost=1801500, rows=1201) (actual rows=48)
+            -> PhysicMarkJoin Left (inccost=283735, cost=276230, rows=184) (actual rows=48)
                 Output: #marker,o_orderpriority[0]
                 Filter: l_orderkey[2]=o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=300) (actual rows=48)
+                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=46) (actual rows=48)
                     Output: o_orderpriority[5],o_orderkey[0]
                     Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'
                 -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=3752, loops=48)

--- a/test/regress/expect/tpch0001/q05.txt
+++ b/test/regress/expect/tpch0001/q05.txt
@@ -22,20 +22,20 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 21323.97
-PhysicOrder  (inccost=21323.97, cost=82.97, rows=25) (actual rows=0)
+Total cost: 17565.97
+PhysicOrder  (inccost=17565.97, cost=82.97, rows=25) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
     Order by: {sum(l_extendedprice*1-l_discount)}[1]
-    -> PhysicHashAgg  (inccost=21241, cost=226, rows=25) (actual rows=0)
+    -> PhysicHashAgg  (inccost=17483, cost=133, rows=25) (actual rows=0)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicHashJoin  (inccost=21015, cost=1534, rows=176) (actual rows=0)
+        -> PhysicHashJoin  (inccost=17350, cost=883, rows=83) (actual rows=0)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
             Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
             -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                 Output: 1,c_custkey[0],c_nationkey[3]
-            -> PhysicHashJoin  (inccost=19331, cost=2867, rows=952) (actual rows=0)
+            -> PhysicHashJoin  (inccost=16317, cost=1360, rows=450) (actual rows=0)
                 Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[1]
                 Filter: l_suppkey[8]=s_suppkey[2]
                 -> PhysicHashJoin  (inccost=97, cost=25, rows=5) (actual rows=0)
@@ -51,10 +51,10 @@ PhysicOrder  (inccost=21323.97, cost=82.97, rows=25) (actual rows=0)
                             Output: n_name[1],n_nationkey[0],n_regionkey[2]
                     -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                         Output: s_nationkey[3],s_suppkey[0]
-                -> PhysicHashJoin  (inccost=16367, cost=8862, rows=1905) (actual rows=0)
+                -> PhysicHashJoin  (inccost=14860, cost=7355, rows=900) (actual rows=0)
                     Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0],l_suppkey[6]
                     Filter: l_orderkey[7]=o_orderkey[1]
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=476) (actual rows=0)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=225) (actual rows=0)
                         Output: o_custkey[1],o_orderkey[0]
                         Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)

--- a/test/regress/expect/tpch0001/q06.txt
+++ b/test/regress/expect/tpch0001/q06.txt
@@ -7,11 +7,11 @@ where
 	and l_shipdate < date '1994-01-01' + interval '1' year
 	and l_discount between (.06 - 0.01 , .06 + 0.01)
 	and l_quantity < 24
-Total cost: 7891
-PhysicHashAgg  (inccost=7891, cost=1886, rows=1) (actual rows=1)
+Total cost: 6087
+PhysicHashAgg  (inccost=6087, cost=82, rows=1) (actual rows=1)
     Output: {sum(l_extendedprice*l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*l_discount[2])
-    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1884) (actual rows=74)
+    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=80) (actual rows=74)
         Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
         Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM' and l_discount[6]>=0.05 and l_discount[6]<=0.07 and l_quantity[4]<24
 48090.8586

--- a/test/regress/expect/tpch0001/q07.txt
+++ b/test/regress/expect/tpch0001/q07.txt
@@ -37,22 +37,22 @@ order by
 	supp_nation,
 	cust_nation,
 	l_year
-Total cost: 243894.1
-PhysicOrder  (inccost=243894.1, cost=0.1, rows=1) (actual rows=0)
+Total cost: 181623.1
+PhysicOrder  (inccost=181623.1, cost=0.1, rows=1) (actual rows=0)
     Output: supp_nation[0],cust_nation[1],l_year[2],{sum(volume)}[3]
     Order by: supp_nation[0], cust_nation[1], l_year[2]
-    -> PhysicHashAgg  (inccost=243894, cost=10268, rows=1) (actual rows=0)
+    -> PhysicHashAgg  (inccost=181623, cost=7493, rows=1) (actual rows=0)
         Output: {supp_nation}[0],{cust_nation}[1],{l_year}[2],{sum(volume)}[3]
         Aggregates: sum(volume[3])
         Group by: supp_nation[0], cust_nation[1], l_year[2]
-        -> PhysicFromQuery <shipping> (inccost=233626, cost=10266, rows=10266) (actual rows=0)
+        -> PhysicFromQuery <shipping> (inccost=174130, cost=7491, rows=7491) (actual rows=0)
             Output: supp_nation[0],cust_nation[1],l_year[2],volume[3]
-            -> PhysicHashJoin  (inccost=223360, cost=102686, rows=10266) (actual rows=0)
+            -> PhysicHashJoin  (inccost=166639, cost=74936, rows=7491) (actual rows=0)
                 Output: n_name (as supp_nation)[2],n_name (as cust_nation)[3],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5]
                 Filter: s_suppkey[0]=l_suppkey[6] and s_nationkey[1]=n_nationkey[7]
                 -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                     Output: s_suppkey[0],s_nationkey[3]
-                -> PhysicHashJoin  (inccost=120664, cost=97346, rows=92400) (actual rows=61)
+                -> PhysicHashJoin  (inccost=91693, cost=71372, rows=67425) (actual rows=61)
                     Output: n_name (as supp_nation)[0],n_name (as cust_nation)[1],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5],l_suppkey[6],n_nationkey[2]
                     Filter: c_nationkey[7]=n_nationkey[3]
                     -> PhysicNLJoin  (inccost=1275, cost=1225, rows=625) (actual rows=2)
@@ -62,17 +62,17 @@ PhysicOrder  (inccost=243894.1, cost=0.1, rows=1) (actual rows=0)
                             Output: n_name (as cust_nation)[1],n_nationkey[0]
                         -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=25)
                             Output: n_name (as supp_nation)[1],n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=22043, cost=6460, rows=3696) (actual rows=1793)
+                    -> PhysicHashJoin  (inccost=19046, cost=4795, rows=2697) (actual rows=1793)
                         Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],c_nationkey[0]
                         Filter: c_custkey[1]=o_custkey[5]
                         -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                             Output: c_nationkey[3],c_custkey[0]
-                        -> PhysicHashJoin  (inccost=15433, cost=7928, rows=2464) (actual rows=1793)
+                        -> PhysicHashJoin  (inccost=14101, cost=6596, rows=1798) (actual rows=1793)
                             Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],o_custkey[0]
                             Filter: o_orderkey[1]=l_orderkey[5]
                             -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)
                                 Output: o_custkey[1],o_orderkey[0]
-                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=2464) (actual rows=1793)
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1798) (actual rows=1793)
                                 Output: year(l_shipdate[10]),l_extendedprice[5]*1-l_discount[6](as volume),l_suppkey[2],l_orderkey[0]
                                 Filter: l_shipdate[10]>='1995-01-01' and l_shipdate[10]<='1996-12-31'
 

--- a/test/regress/expect/tpch0001/q08.txt
+++ b/test/regress/expect/tpch0001/q08.txt
@@ -35,42 +35,42 @@ group by
 	o_year
 order by
 	o_year
-Total cost: 57478.1
-PhysicOrder  (inccost=57478.1, cost=0.1, rows=1) (actual rows=2)
+Total cost: 46099.1
+PhysicOrder  (inccost=46099.1, cost=0.1, rows=1) (actual rows=2)
     Output: o_year[0],{sum(case with 1)/sum(volume)(as mkt_share)}[1]
     Order by: o_year[0]
-    -> PhysicHashAgg  (inccost=57478, cost=22, rows=1) (actual rows=2)
+    -> PhysicHashAgg  (inccost=46099, cost=9, rows=1) (actual rows=2)
         Output: {o_year}[0],{sum(case with 1)}[1]/{sum(volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(volume[5])
         Group by: o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=57456, cost=20, rows=20) (actual rows=5)
+        -> PhysicFromQuery <all_nations> (inccost=46090, cost=7, rows=7) (actual rows=5)
             Output: o_year[0],case with 1,nation[2]='BRAZIL',nation[2],'BRAZIL',volume[1],0
-            -> PhysicHashJoin  (inccost=57436, cost=2075, rows=20) (actual rows=5)
+            -> PhysicHashJoin  (inccost=46083, cost=1516, rows=7) (actual rows=5)
                 Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3]
                 Filter: p_partkey[0]=l_partkey[4]
-                -> PhysicScanTable part (inccost=200, cost=200, rows=2) (actual rows=1)
+                -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=1)
                     Output: p_partkey[0]
                     Filter: p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=55161, cost=12311, rows=2051) (actual rows=385)
+                -> PhysicHashJoin  (inccost=44367, cost=9045, rows=1507) (actual rows=385)
                     Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3],l_partkey[4]
                     Filter: n_regionkey[5]=r_regionkey[0]
                     -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
                         Output: r_regionkey[0]
                         Filter: r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=42845, cost=14001, rows=10258) (actual rows=1810)
+                    -> PhysicHashJoin  (inccost=35317, cost=10299, rows=7536) (actual rows=1810)
                         Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],n_name (as nation)[0],l_partkey[4],n_regionkey[5]
                         Filter: s_nationkey[6]=n_nationkey[1]
                         -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
                             Output: n_name (as nation)[1],n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=28819, cost=7402, rows=3691) (actual rows=1810)
+                        -> PhysicHashJoin  (inccost=24993, cost=5448, rows=2714) (actual rows=1810)
                             Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[5],s_nationkey[0]
                             Filter: s_suppkey[1]=l_suppkey[6]
                             -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
                                 Output: s_nationkey[3],s_suppkey[0]
-                            -> PhysicHashJoin  (inccost=21407, cost=11540, rows=3691) (actual rows=1810)
+                            -> PhysicHashJoin  (inccost=19535, cost=10075, rows=2714) (actual rows=1810)
                                 Output: {year(o_orderdate)}[0],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[1],l_suppkey[5]
                                 Filter: l_orderkey[6]=o_orderkey[2]
-                                -> PhysicHashJoin  (inccost=3862, cost=1837, rows=922) (actual rows=452)
+                                -> PhysicHashJoin  (inccost=3455, cost=1430, rows=678) (actual rows=452)
                                     Output: {year(o_orderdate)}[2],n_regionkey[0],o_orderkey[3]
                                     Filter: o_custkey[4]=c_custkey[1]
                                     -> PhysicHashJoin  (inccost=525, cost=350, rows=150) (actual rows=150)
@@ -80,7 +80,7 @@ PhysicOrder  (inccost=57478.1, cost=0.1, rows=1) (actual rows=2)
                                             Output: n_regionkey[2],n_nationkey[0]
                                         -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                                             Output: c_custkey[0],c_nationkey[3]
-                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=615) (actual rows=452)
+                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=452) (actual rows=452)
                                         Output: year(o_orderdate[4]),o_orderkey[0],o_custkey[1]
                                         Filter: o_orderdate[4]>='1995-01-01' and o_orderdate[4]<='1996-12-31'
                                 -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=6005)

--- a/test/regress/expect/tpch0001/q10.txt
+++ b/test/regress/expect/tpch0001/q10.txt
@@ -30,35 +30,35 @@ group by
 order by
 	revenue desc
 limit 20
-Total cost: 16331.61
-PhysicLimit (20) (inccost=16331.61, cost=20, rows=20) (actual rows=20)
+Total cost: 10631.58
+PhysicLimit (20) (inccost=10631.58, cost=20, rows=20) (actual rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=16311.61, cost=3164.61, rows=501) (actual rows=20)
+    -> PhysicOrder  (inccost=10611.58, cost=419.58, rows=91) (actual rows=20)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*1-l_discount)}[2]
-        -> PhysicHashAgg  (inccost=13147, cost=1503, rows=501) (actual rows=43)
+        -> PhysicHashAgg  (inccost=10192, cost=273, rows=91) (actual rows=43)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicHashJoin  (inccost=11644, cost=1135, rows=501) (actual rows=140)
-                Output: c_custkey[0],c_name[1],c_acctbal[2],n_name[3],c_address[4],c_phone[5],c_comment[6],{l_extendedprice*1-l_discount}[8],l_extendedprice[9],{1-l_discount}[10],1,l_discount[11]
-                Filter: c_custkey[0]=o_custkey[12]
-                -> PhysicHashJoin  (inccost=525, cost=350, rows=150) (actual rows=150)
-                    Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{1}[1]
-                    Filter: c_nationkey[9]=n_nationkey[2]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
-                        Output: n_name[1],1,n_nationkey[0]
+            -> PhysicHashJoin  (inccost=9919, cost=232, rows=91) (actual rows=140)
+                Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
+                Filter: c_nationkey[13]=n_nationkey[2]
+                -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25)
+                    Output: n_name[1],1,n_nationkey[0]
+                -> PhysicHashJoin  (inccost=9662, cost=363, rows=91) (actual rows=140)
+                    Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],c_nationkey[11]
+                    Filter: c_custkey[5]=o_custkey[4]
+                    -> PhysicHashJoin  (inccost=9149, cost=1644, rows=61) (actual rows=140)
+                        Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
+                        Filter: l_orderkey[6]=o_orderkey[1]
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=63) (actual rows=64)
+                            Output: o_custkey[1],o_orderkey[0]
+                            Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
+                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=1457)
+                            Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
+                            Filter: l_returnflag[8]='R'
                     -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                         Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
-                -> PhysicHashJoin  (inccost=9984, cost=2479, rows=334) (actual rows=140)
-                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
-                    Filter: l_orderkey[6]=o_orderkey[1]
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=344) (actual rows=64)
-                        Output: o_custkey[1],o_orderkey[0]
-                        Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=1457)
-                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
-                        Filter: l_returnflag[8]='R'
 121,Customer#000000121,282635.1719,6428.32,PERU,tv nCR2YKupGN73mQudO,27-411-990-2959,uriously stealthy ideas. carefully final courts use carefully
 124,Customer#000000124,222182.5188,1842.49,CHINA,aTbyVAW5tCd,v09O,28-183-750-7809,le fluffily even dependencies. quietly s
 106,Customer#000000106,190241.3334,3288.42,ARGENTINA,xGCOEAUjUNG,11-751-989-4627,lose slyly. ironic accounts along the evenly regular theodolites wake about the special, final gifts.

--- a/test/regress/expect/tpch0001/q12.txt
+++ b/test/regress/expect/tpch0001/q12.txt
@@ -26,18 +26,18 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 11057.32
-PhysicOrder  (inccost=11057.32, cost=14.32, rows=7) (actual rows=2)
+Total cost: 10041.32
+PhysicOrder  (inccost=10041.32, cost=14.32, rows=7) (actual rows=2)
     Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=11043, cost=520, rows=7) (actual rows=2)
+    -> PhysicHashAgg  (inccost=10027, cost=266, rows=7) (actual rows=2)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicHashJoin  (inccost=10523, cost=3018, rows=506) (actual rows=25)
+        -> PhysicHashJoin  (inccost=9761, cost=2256, rows=252) (actual rows=25)
             Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
             Filter: o_orderkey[15]=l_orderkey[5]
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=506) (actual rows=25)
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=252) (actual rows=25)
                 Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                 Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
             -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500)

--- a/test/regress/expect/tpch0001/q14.txt
+++ b/test/regress/expect/tpch0001/q14.txt
@@ -11,17 +11,17 @@ where
 	l_partkey = p_partkey
 	and l_shipdate >= date '1995-09-01'
 	and l_shipdate < date '1995-09-01' + interval '1' month
-Total cost: 11275
-PhysicHashAgg  (inccost=11275, cost=1558, rows=1) (actual rows=1)
+Total cost: 6715
+PhysicHashAgg  (inccost=6715, cost=79, rows=1) (actual rows=1)
     Output: 100*{sum(case with 1)}[0]/{sum(l_extendedprice*1-l_discount)}[1](as promo_revenue)
     Aggregates: sum(case with 1), sum(l_extendedprice[5]*1-l_discount[8])
-    -> PhysicHashJoin  (inccost=9717, cost=3512, rows=1556) (actual rows=84)
-        Output: case with 1,{p_typelike'PROMO%'}[1],p_type[0],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[8],l_extendedprice[6],{1-l_discount}[9],{1}[3],l_discount[7],{0}[4]
-        Filter: l_partkey[10]=p_partkey[5]
-        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200)
-            Output: p_type[4],p_type[4]like'PROMO%','PROMO%',1,0,p_partkey[0]
-        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1556) (actual rows=84)
-            Output: l_extendedprice[5],l_discount[6],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],l_partkey[1]
+    -> PhysicHashJoin  (inccost=6636, cost=431, rows=77) (actual rows=84)
+        Output: case with 1,{p_typelike'PROMO%'}[9],p_type[8],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[3],l_extendedprice[0],{1-l_discount}[4],{1}[5],l_discount[1],{0}[6]
+        Filter: l_partkey[7]=p_partkey[10]
+        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=77) (actual rows=84)
+            Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,0,l_partkey[1]
             Filter: l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM'
+        -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=200)
+            Output: p_type[4],p_type[4]like'PROMO%',p_partkey[0]
 15.2302
 

--- a/test/regress/expect/tpch0001/q15.txt
+++ b/test/regress/expect/tpch0001/q15.txt
@@ -28,35 +28,35 @@ where
 		from
 			revenue0
 	)
-Total cost: 7670
-PhysicFilter  (inccost=7670, cost=10, rows=10) (actual rows=1)
+Total cost: 6296
+PhysicFilter  (inccost=6296, cost=10, rows=10) (actual rows=1)
     Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
     Filter: total_revenue[4]=@1
     <ScalarSubqueryExpr> cached 1
-        -> PhysicHashAgg  (inccost=7622, cost=12, rows=1) (actual rows=1)
+        -> PhysicHashAgg  (inccost=6248, cost=12, rows=1) (actual rows=1)
             Output: {max(total_revenue)}[0]
             Aggregates: max(total_revenue[0])
-            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7610, cost=10, rows=10) (actual rows=10)
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=6236, cost=10, rows=10) (actual rows=10)
                 Output: total_revenue[1]
-                -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+                -> PhysicHashAgg  (inccost=6226, cost=221, rows=10) (actual rows=10)
                     Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
                     Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
                     Group by: l_suppkey[0]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=201) (actual rows=201)
                         Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
                         Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
-    -> PhysicHashJoin  (inccost=7660, cost=40, rows=10) (actual rows=10)
+    -> PhysicHashJoin  (inccost=6286, cost=40, rows=10) (actual rows=10)
         Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
         Filter: s_suppkey[0]=supplier_no[5]
         -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)
             Output: s_suppkey[0],s_name[1],s_address[2],s_phone[4]
-        -> PhysicFromQuery <revenue0> (inccost=7610, cost=10, rows=10) (actual rows=10)
+        -> PhysicFromQuery <revenue0> (inccost=6236, cost=10, rows=10) (actual rows=10)
             Output: total_revenue[1],supplier_no[0]
-            -> PhysicHashAgg  (inccost=7600, cost=1595, rows=10) (actual rows=10)
+            -> PhysicHashAgg  (inccost=6226, cost=221, rows=10) (actual rows=10)
                 Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
                 Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
                 Group by: l_suppkey[0]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1575) (actual rows=201)
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=201) (actual rows=201)
                     Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
                     Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
 10,Supplier#000000010,Saygah3gYWMp72i PY,34-852-489-8585,772262.2438

--- a/test/regress/expect/tpch0001/q20.txt
+++ b/test/regress/expect/tpch0001/q20.txt
@@ -49,10 +49,10 @@ PhysicOrder  (inccost=48.1, cost=0.1, rows=1) (actual rows=0)
             Output: s_name[1],s_address[2],s_nationkey[3]
             Filter: s_suppkey[0] in @1
             <InSubqueryExpr> cached 1
-                -> PhysicFilter  (inccost=17447, cost=753, rows=753) (actual rows=47)
+                -> PhysicFilter  (inccost=12811, cost=367, rows=367) (actual rows=47)
                     Output: ps_suppkey[0]
                     Filter: ps_availqty[1]>0.5*{sum(l_quantity)}[2]
-                    -> PhysicHashJoin Left (inccost=16694, cost=4237, rows=753) (actual rows=60)
+                    -> PhysicHashJoin Left (inccost=12444, cost=2885, rows=367) (actual rows=60)
                         Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
                         Filter: l_partkey[4]=ps_partkey[2] and l_suppkey[5]=ps_suppkey[0]
                         -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=60)
@@ -62,11 +62,11 @@ PhysicOrder  (inccost=48.1, cost=0.1, rows=1) (actual rows=0)
                                 -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=15)
                                     Output: p_partkey[0]
                                     Filter: p_name[1]like'forest%'
-                        -> PhysicHashAgg  (inccost=11657, cost=5652, rows=1884) (actual rows=499)
+                        -> PhysicHashAgg  (inccost=8759, cost=2754, rows=918) (actual rows=499)
                             Output: {sum(l_quantity)}[2],{l_partkey}[0],{l_suppkey}[1]
                             Aggregates: sum(l_quantity[2])
                             Group by: l_partkey[0], l_suppkey[1]
-                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1884) (actual rows=922)
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=918) (actual rows=922)
                                 Output: l_partkey[1],l_suppkey[2],l_quantity[4]
                                 Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM'
 

--- a/test/regress/expect/tpch0001/q22.txt
+++ b/test/regress/expect/tpch0001/q22.txt
@@ -55,10 +55,10 @@ PhysicOrder  (inccost=233402.1, cost=0.1, rows=1) (actual rows=7)
                         Output: substring(c_phone[4],1,2),c_acctbal[5],c_custkey[0]
                         Filter: substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and c_acctbal[5]>@1
                         <ScalarSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=284, cost=134, rows=1) (actual rows=1)
+                            -> PhysicHashAgg  (inccost=290, cost=140, rows=1) (actual rows=1)
                                 Output: {avg(c_acctbal)}[0]
                                 Aggregates: avg(c_acctbal[0])
-                                -> PhysicScanTable customer as customer__1 (inccost=150, cost=150, rows=132) (actual rows=35)
+                                -> PhysicScanTable customer as customer__1 (inccost=150, cost=150, rows=138) (actual rows=35)
                                     Output: c_acctbal[5]
                                     Filter: c_acctbal[5]>0 and substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
                     -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=1500, loops=17)

--- a/test/regress/expect/tpch1/q01.txt
+++ b/test/regress/expect/tpch1/q01.txt
@@ -19,14 +19,14 @@ group by
 order by
 	l_returnflag,
 	l_linestatus
-Total cost: 11882428.35
-PhysicOrder  (inccost=11882428.35, cost=11.35, rows=6)
+Total cost: 11854298.35
+PhysicOrder  (inccost=11854298.35, cost=11.35, rows=6)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=11882417, cost=5881202, rows=6)
+    -> PhysicHashAgg  (inccost=11854287, cost=5853072, rows=6)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*1-l_discount[7]), sum(l_extendedprice[3]*1-l_discount[7]*1+l_tax[10]), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=5881190)
+        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=5853060)
             Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
             Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'

--- a/test/regress/expect/tpch1/q03.txt
+++ b/test/regress/expect/tpch1/q03.txt
@@ -21,28 +21,28 @@ order by
 	revenue desc,
 	o_orderdate
 limit 10
-Total cost: 23823672.82
-PhysicLimit (10) (inccost=23823672.82, cost=10, rows=10)
+Total cost: 23696660.69
+PhysicLimit (10) (inccost=23696660.69, cost=10, rows=10)
     Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
-    -> PhysicOrder  (inccost=23823662.82, cost=6292599.82, rows=477564)
+    -> PhysicOrder  (inccost=23696650.69, cost=6227183.69, rows=472948)
         Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
         Order by: {sum(l_extendedprice*1-l_discount)}[1], o_orderdate[2]
-        -> PhysicHashAgg  (inccost=17531063, cost=1432692, rows=477564)
+        -> PhysicHashAgg  (inccost=17469467, cost=1418844, rows=472948)
             Output: {l_orderkey}[0],{sum(l_extendedprice*1-l_discount)}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*1-l_discount[7])
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicHashJoin  (inccost=16098371, cost=2122168, rows=477564)
+            -> PhysicHashJoin  (inccost=16050623, cost=2102236, rows=472948)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
                 Filter: c_custkey[1]=o_custkey[9]
                 -> PhysicScanTable customer (inccost=150000, cost=150000, rows=30142)
                     Output: 1,c_custkey[0]
                     Filter: c_mktsegment[6]='BUILDING'
-                -> PhysicHashJoin  (inccost=13826203, cost=6324988, rows=1584320)
+                -> PhysicHashJoin  (inccost=13798387, cost=6297172, rows=1569004)
                     Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],l_discount[8],o_custkey[2]
                     Filter: l_orderkey[4]=o_orderkey[3]
-                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=720000)
+                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=712500)
                         Output: o_orderdate[4],o_shippriority[7],o_custkey[1],o_orderkey[0]
                         Filter: o_orderdate[4]<'1995-03-15'
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=3300668)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=3303168)
                         Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
                         Filter: l_shipdate[10]>'1995-03-15'

--- a/test/regress/expect/tpch1/q04.txt
+++ b/test/regress/expect/tpch1/q04.txt
@@ -19,21 +19,21 @@ group by
 	o_orderpriority
 order by
 	o_orderpriority
-Total cost: 1825579538325.54
-PhysicOrder  (inccost=1825579538325.54, cost=8.54, rows=5)
+Total cost: 335127796089.54
+PhysicOrder  (inccost=335127796089.54, cost=8.54, rows=5)
     Output: o_orderpriority[0],{count(*)(0)}[1]
     Order by: o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=1825579538317, cost=1217056, rows=5)
+    -> PhysicHashAgg  (inccost=335127796081, cost=223423, rows=5)
         Output: {o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: o_orderpriority[0]
-        -> PhysicFilter  (inccost=1825578321261, cost=1217046, rows=1217046)
+        -> PhysicFilter  (inccost=335127572658, cost=223413, rows=223413)
             Output: o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=1825577104215, cost=1825569603000, rows=1217046)
+            -> PhysicMarkJoin Left (inccost=335127349245, cost=335119848030, rows=223413)
                 Output: #marker,o_orderpriority[0]
                 Filter: l_orderkey[2]=o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=304200)
+                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=55842)
                     Output: o_orderpriority[5],o_orderkey[0]
                     Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'
                 -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)

--- a/test/regress/expect/tpch1/q05.txt
+++ b/test/regress/expect/tpch1/q05.txt
@@ -22,40 +22,40 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 18125642.97
-PhysicOrder  (inccost=18125642.97, cost=82.97, rows=25)
+Total cost: 16639908.97
+PhysicOrder  (inccost=16639908.97, cost=82.97, rows=25)
     Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
     Order by: {sum(l_extendedprice*1-l_discount)}[1]
-    -> PhysicHashAgg  (inccost=18125560, cost=22735, rows=25)
+    -> PhysicHashAgg  (inccost=16639826, cost=10972, rows=25)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicHashJoin  (inccost=18102825, cost=700761, rows=22685)
+        -> PhysicHashJoin  (inccost=16628854, cost=492958, rows=10922)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
             Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
             -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                 Output: 1,c_custkey[0],c_nationkey[3]
-            -> PhysicHashJoin  (inccost=17252064, cost=2523319, rows=378076)
-                Output: n_name[2],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[0],s_nationkey[7]
-                Filter: l_orderkey[8]=o_orderkey[1]
-                -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=472500)
-                    Output: o_custkey[1],o_orderkey[0]
-                    Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
-                -> PhysicHashJoin  (inccost=13228745, cost=7205458, rows=1200243)
-                    Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],s_nationkey[1],l_orderkey[7]
-                    Filter: l_suppkey[8]=s_suppkey[2]
-                    -> PhysicHashJoin  (inccost=22072, cost=12010, rows=2000)
-                        Output: n_name[0],s_nationkey[2],s_suppkey[3]
-                        Filter: s_nationkey[2]=n_nationkey[1]
-                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5)
-                            Output: n_name[1],n_nationkey[2]
-                            Filter: n_regionkey[3]=r_regionkey[0]
-                            -> PhysicScanTable region (inccost=5, cost=5, rows=1)
-                                Output: r_regionkey[0]
-                                Filter: r_name[1]='ASIA'
-                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
-                                Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                        -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
-                            Output: s_nationkey[3],s_suppkey[0]
+            -> PhysicHashJoin  (inccost=15985896, cost=1096216, rows=182036)
+                Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[1]
+                Filter: l_suppkey[8]=s_suppkey[2]
+                -> PhysicHashJoin  (inccost=22072, cost=12010, rows=2000)
+                    Output: n_name[0],s_nationkey[2],s_suppkey[3]
+                    Filter: s_nationkey[2]=n_nationkey[1]
+                    -> PhysicHashJoin  (inccost=62, cost=32, rows=5)
+                        Output: n_name[1],n_nationkey[2]
+                        Filter: n_regionkey[3]=r_regionkey[0]
+                        -> PhysicScanTable region (inccost=5, cost=5, rows=1)
+                            Output: r_regionkey[0]
+                            Filter: r_name[1]='ASIA'
+                        -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
+                            Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                    -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
+                        Output: s_nationkey[3],s_suppkey[0]
+                -> PhysicHashJoin  (inccost=14867608, cost=7366393, rows=910180)
+                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0],l_suppkey[6]
+                    Filter: l_orderkey[7]=o_orderkey[1]
+                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=227499)
+                        Output: o_custkey[1],o_orderkey[0]
+                        Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
                     -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)
-                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0],l_suppkey[2]
+                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_suppkey[2],l_orderkey[0]

--- a/test/regress/expect/tpch1/q06.txt
+++ b/test/regress/expect/tpch1/q06.txt
@@ -7,10 +7,10 @@ where
 	and l_shipdate < date '1994-01-01' + interval '1' year
 	and l_discount between (.06 - 0.01 , .06 + 0.01)
 	and l_quantity < 24
-Total cost: 6883854
-PhysicHashAgg  (inccost=6883854, cost=882639, rows=1)
+Total cost: 9361244
+PhysicHashAgg  (inccost=9361244, cost=3360029, rows=1)
     Output: {sum(l_extendedprice*l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*l_discount[2])
-    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=882637)
+    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=3360027)
         Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
         Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM' and l_discount[6]>=0.05 and l_discount[6]<=0.07 and l_quantity[4]<24

--- a/test/regress/expect/tpch1/q07.txt
+++ b/test/regress/expect/tpch1/q07.txt
@@ -37,22 +37,22 @@ order by
 	supp_nation,
 	cust_nation,
 	l_year
-Total cost: 228240249.1
-PhysicOrder  (inccost=228240249.1, cost=0.1, rows=1)
+Total cost: 167058814.1
+PhysicOrder  (inccost=167058814.1, cost=0.1, rows=1)
     Output: supp_nation[0],cust_nation[1],l_year[2],{sum(volume)}[3]
     Order by: supp_nation[0], cust_nation[1], l_year[2]
-    -> PhysicHashAgg  (inccost=228240249, cost=3811525, rows=1)
+    -> PhysicHashAgg  (inccost=167058814, cost=2738165, rows=1)
         Output: {supp_nation}[0],{cust_nation}[1],{l_year}[2],{sum(volume)}[3]
         Aggregates: sum(volume[3])
         Group by: supp_nation[0], cust_nation[1], l_year[2]
-        -> PhysicFromQuery <shipping> (inccost=224428724, cost=3811523, rows=3811523)
+        -> PhysicFromQuery <shipping> (inccost=164320649, cost=2738163, rows=2738163)
             Output: supp_nation[0],cust_nation[1],l_year[2],volume[3]
-            -> PhysicHashJoin  (inccost=220617201, cost=99119598, rows=3811523)
+            -> PhysicHashJoin  (inccost=161582486, cost=71212238, rows=2738163)
                 Output: n_name (as supp_nation)[2],n_name (as cust_nation)[3],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5]
                 Filter: s_suppkey[0]=l_suppkey[6] and s_nationkey[1]=n_nationkey[7]
                 -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                     Output: s_suppkey[0],s_nationkey[3]
-                -> PhysicHashJoin  (inccost=121487603, cost=99100848, rows=95288075)
+                -> PhysicHashJoin  (inccost=90360248, cost=71193488, rows=68454075)
                     Output: n_name (as supp_nation)[0],n_name (as cust_nation)[1],{year(l_shipdate)}[4],{l_extendedprice*1-l_discount(as volume)}[5],l_suppkey[6],n_nationkey[2]
                     Filter: c_nationkey[7]=n_nationkey[3]
                     -> PhysicNLJoin  (inccost=1275, cost=1225, rows=625)
@@ -62,16 +62,16 @@ PhysicOrder  (inccost=228240249.1, cost=0.1, rows=1)
                             Output: n_name (as cust_nation)[1],n_nationkey[0]
                         -> PhysicScanTable nation as n1 (inccost=25, cost=25, rows=25)
                             Output: n_name (as supp_nation)[1],n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=22385480, cost=6652437, rows=3811523)
+                    -> PhysicHashJoin  (inccost=19165485, cost=4863532, rows=2738163)
                         Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],c_nationkey[0]
                         Filter: c_custkey[1]=o_custkey[5]
                         -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                             Output: c_nationkey[3],c_custkey[0]
-                        -> PhysicHashJoin  (inccost=15583043, cost=8081828, rows=2540914)
+                        -> PhysicHashJoin  (inccost=14151953, cost=6650738, rows=1825369)
                             Output: {year(l_shipdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_suppkey[4],o_custkey[0]
                             Filter: o_orderkey[1]=l_orderkey[5]
                             -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)
                                 Output: o_custkey[1],o_orderkey[0]
-                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=2540914)
+                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1825369)
                                 Output: year(l_shipdate[10]),l_extendedprice[5]*1-l_discount[6](as volume),l_suppkey[2],l_orderkey[0]
                                 Filter: l_shipdate[10]>='1995-01-01' and l_shipdate[10]<='1996-12-31'

--- a/test/regress/expect/tpch1/q08.txt
+++ b/test/regress/expect/tpch1/q08.txt
@@ -35,42 +35,42 @@ group by
 	o_year
 order by
 	o_year
-Total cost: 41660333.1
-PhysicOrder  (inccost=41660333.1, cost=0.1, rows=1)
+Total cost: 34516292.1
+PhysicOrder  (inccost=34516292.1, cost=0.1, rows=1)
     Output: o_year[0],{sum(case with 1)/sum(volume)(as mkt_share)}[1]
     Order by: o_year[0]
-    -> PhysicHashAgg  (inccost=41660333, cost=2475, rows=1)
+    -> PhysicHashAgg  (inccost=34516292, cost=4, rows=1)
         Output: {o_year}[0],{sum(case with 1)}[1]/{sum(volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(volume[5])
         Group by: o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=41657858, cost=2473, rows=2473)
+        -> PhysicFromQuery <all_nations> (inccost=34516288, cost=2, rows=2)
             Output: o_year[0],case with 1,nation[2]='BRAZIL',nation[2],'BRAZIL',volume[1],0
-            -> PhysicHashJoin  (inccost=41655385, cost=746485, rows=2473)
+            -> PhysicHashJoin  (inccost=34516286, cost=547636, rows=2)
                 Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3]
                 Filter: p_partkey[0]=l_partkey[4]
-                -> PhysicScanTable part (inccost=200000, cost=200000, rows=666)
+                -> PhysicScanTable part (inccost=200000, cost=200000, rows=1)
                     Output: p_partkey[0]
                     Filter: p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=40708900, cost=4456082, rows=742680)
+                -> PhysicHashJoin  (inccost=33768650, cost=3285797, rows=547632)
                     Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3],l_partkey[4]
                     Filter: n_regionkey[5]=r_regionkey[0]
                     -> PhysicScanTable region (inccost=5, cost=5, rows=1)
                         Output: r_regionkey[0]
                         Filter: r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=36252813, cost=7426850, rows=3713400)
+                    -> PhysicHashJoin  (inccost=30482848, cost=5476376, rows=2738163)
                         Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],n_name (as nation)[0],l_partkey[4],n_regionkey[5]
                         Filter: s_nationkey[6]=n_nationkey[1]
                         -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25)
                             Output: n_name (as nation)[1],n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=28825938, cost=7446798, rows=3713399)
+                        -> PhysicHashJoin  (inccost=25006447, cost=5496324, rows=2738162)
                             Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[5],s_nationkey[0]
                             Filter: s_suppkey[1]=l_suppkey[6]
                             -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
                                 Output: s_nationkey[3],s_suppkey[0]
-                            -> PhysicHashJoin  (inccost=21369140, cost=11570938, rows=3713399)
+                            -> PhysicHashJoin  (inccost=19500123, cost=10108181, rows=2738162)
                                 Output: {year(o_orderdate)}[0],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[1],l_suppkey[5]
                                 Filter: l_orderkey[6]=o_orderkey[2]
-                                -> PhysicHashJoin  (inccost=3796987, cost=1846912, rows=928162)
+                                -> PhysicHashJoin  (inccost=3390727, cost=1440652, rows=684402)
                                     Output: {year(o_orderdate)}[2],n_regionkey[0],o_orderkey[3]
                                     Filter: o_custkey[4]=c_custkey[1]
                                     -> PhysicHashJoin  (inccost=450075, cost=300050, rows=150000)
@@ -80,7 +80,7 @@ PhysicOrder  (inccost=41660333.1, cost=0.1, rows=1)
                                             Output: n_regionkey[2],n_nationkey[0]
                                         -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                                             Output: c_custkey[0],c_nationkey[3]
-                                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=618750)
+                                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=456250)
                                         Output: year(o_orderdate[4]),o_orderkey[0],o_custkey[1]
                                         Filter: o_orderdate[4]>='1995-01-01' and o_orderdate[4]<='1996-12-31'
                                 -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=6001215)

--- a/test/regress/expect/tpch1/q10.txt
+++ b/test/regress/expect/tpch1/q10.txt
@@ -30,32 +30,32 @@ group by
 order by
 	revenue desc
 limit 20
-Total cost: 19527058.97
-PhysicLimit (20) (inccost=19527058.97, cost=20, rows=20)
+Total cost: 11008899.44
+PhysicLimit (20) (inccost=11008899.44, cost=20, rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=19527038.97, cost=6504328.97, rows=492483)
+    -> PhysicOrder  (inccost=11008879.44, cost=950731.44, rows=83187)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*1-l_discount)}[2]
-        -> PhysicHashAgg  (inccost=13022710, cost=1477449, rows=492483)
+        -> PhysicHashAgg  (inccost=10058148, cost=249561, rows=83187)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicHashJoin  (inccost=11545261, cost=1120792, rows=492483)
-                Output: c_custkey[0],c_name[1],c_acctbal[2],n_name[3],c_address[4],c_phone[5],c_comment[6],{l_extendedprice*1-l_discount}[8],l_extendedprice[9],{1-l_discount}[10],1,l_discount[11]
-                Filter: c_custkey[0]=o_custkey[12]
-                -> PhysicHashJoin  (inccost=450075, cost=300050, rows=150000)
-                    Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{1}[1]
-                    Filter: c_nationkey[9]=n_nationkey[2]
-                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
-                        Output: n_name[1],1,n_nationkey[0]
+            -> PhysicHashJoin  (inccost=9808587, cost=166424, rows=83187)
+                Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
+                Filter: c_nationkey[13]=n_nationkey[2]
+                -> PhysicScanTable nation (inccost=25, cost=25, rows=25)
+                    Output: n_name[1],1,n_nationkey[0]
+                -> PhysicHashJoin  (inccost=9642138, cost=344099, rows=83187)
+                    Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],c_nationkey[11]
+                    Filter: c_custkey[5]=o_custkey[4]
+                    -> PhysicHashJoin  (inccost=9148039, cost=1646824, rows=55456)
+                        Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
+                        Filter: l_orderkey[6]=o_orderkey[1]
+                        -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=56249)
+                            Output: o_custkey[1],o_orderkey[0]
+                            Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
+                        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1478870)
+                            Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
+                            Filter: l_returnflag[8]='R'
                     -> PhysicScanTable customer (inccost=150000, cost=150000, rows=150000)
                         Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
-                -> PhysicHashJoin  (inccost=9974394, cost=2473179, rows=328309)
-                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
-                    Filter: l_orderkey[6]=o_orderkey[1]
-                    -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=333000)
-                        Output: o_custkey[1],o_orderkey[0]
-                        Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1478870)
-                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
-                        Filter: l_returnflag[8]='R'

--- a/test/regress/expect/tpch1/q12.txt
+++ b/test/regress/expect/tpch1/q12.txt
@@ -26,18 +26,18 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 11105051.32
-PhysicOrder  (inccost=11105051.32, cost=14.32, rows=7)
+Total cost: 10041939.32
+PhysicOrder  (inccost=10041939.32, cost=14.32, rows=7)
     Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=11105037, cost=525966, rows=7)
+    -> PhysicHashAgg  (inccost=10041925, cost=260188, rows=7)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicHashJoin  (inccost=10579071, cost=3077856, rows=525952)
+        -> PhysicHashJoin  (inccost=9781737, cost=2280522, rows=260174)
             Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
             Filter: o_orderkey[15]=l_orderkey[5]
-            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=525952)
+            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=260174)
                 Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                 Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
             -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)

--- a/test/regress/expect/tpch1/q14.txt
+++ b/test/regress/expect/tpch1/q14.txt
@@ -11,15 +11,15 @@ where
 	l_partkey = p_partkey
 	and l_shipdate >= date '1995-09-01'
 	and l_shipdate < date '1995-09-01' + interval '1' month
-Total cost: 11170541
-PhysicHashAgg  (inccost=11170541, cost=1523110, rows=1)
+Total cost: 6701277
+PhysicHashAgg  (inccost=6701277, cost=75017, rows=1)
     Output: 100*{sum(case with 1)}[0]/{sum(l_extendedprice*1-l_discount)}[1](as promo_revenue)
     Aggregates: sum(case with 1), sum(l_extendedprice[5]*1-l_discount[8])
-    -> PhysicHashJoin  (inccost=9647431, cost=3446216, rows=1523108)
-        Output: case with 1,{p_typelike'PROMO%'}[1],p_type[0],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[8],l_extendedprice[6],{1-l_discount}[9],{1}[3],l_discount[7],{0}[4]
-        Filter: l_partkey[10]=p_partkey[5]
-        -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000)
-            Output: p_type[4],p_type[4]like'PROMO%','PROMO%',1,0,p_partkey[0]
-        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1523108)
-            Output: l_extendedprice[5],l_discount[6],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],l_partkey[1]
+    -> PhysicHashJoin  (inccost=6626260, cost=425045, rows=75015)
+        Output: case with 1,{p_typelike'PROMO%'}[9],p_type[8],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[3],l_extendedprice[0],{1-l_discount}[4],{1}[5],l_discount[1],{0}[6]
+        Filter: l_partkey[7]=p_partkey[10]
+        -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=75015)
+            Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,0,l_partkey[1]
             Filter: l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM'
+        -> PhysicScanTable part (inccost=200000, cost=200000, rows=200000)
+            Output: p_type[4],p_type[4]like'PROMO%',p_partkey[0]

--- a/test/regress/expect/tpch1/q15.txt
+++ b/test/regress/expect/tpch1/q15.txt
@@ -28,34 +28,34 @@ where
 		from
 			revenue0
 	)
-Total cost: 7628726
-PhysicFilter  (inccost=7628726, cost=10000, rows=10000)
+Total cost: 6314060
+PhysicFilter  (inccost=6314060, cost=10000, rows=10000)
     Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
     Filter: total_revenue[4]=@1
     <ScalarSubqueryExpr> cached 1
-        -> PhysicHashAgg  (inccost=7578728, cost=10002, rows=1)
+        -> PhysicHashAgg  (inccost=6264062, cost=10002, rows=1)
             Output: {max(total_revenue)}[0]
             Aggregates: max(total_revenue[0])
-            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=7568726, cost=10000, rows=10000)
+            -> PhysicFromQuery <revenue0 as revenue0__1> (inccost=6254060, cost=10000, rows=10000)
                 Output: total_revenue[1]
-                -> PhysicHashAgg  (inccost=7558726, cost=1557511, rows=10000)
+                -> PhysicHashAgg  (inccost=6244060, cost=242845, rows=10000)
                     Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
                     Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
                     Group by: l_suppkey[0]
-                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1537511)
+                    -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=222845)
                         Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
                         Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'
-    -> PhysicHashJoin  (inccost=7618726, cost=40000, rows=10000)
+    -> PhysicHashJoin  (inccost=6304060, cost=40000, rows=10000)
         Output: s_suppkey[0],s_name[1],s_address[2],s_phone[3],total_revenue[4]
         Filter: s_suppkey[0]=supplier_no[5]
         -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)
             Output: s_suppkey[0],s_name[1],s_address[2],s_phone[4]
-        -> PhysicFromQuery <revenue0> (inccost=7568726, cost=10000, rows=10000)
+        -> PhysicFromQuery <revenue0> (inccost=6254060, cost=10000, rows=10000)
             Output: total_revenue[1],supplier_no[0]
-            -> PhysicHashAgg  (inccost=7558726, cost=1557511, rows=10000)
+            -> PhysicHashAgg  (inccost=6244060, cost=242845, rows=10000)
                 Output: {l_suppkey}[0],{sum(l_extendedprice*1-l_discount)}[1]
                 Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
                 Group by: l_suppkey[0]
-                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1537511)
+                -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=222845)
                     Output: l_suppkey (as supplier_no)[2],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6]
                     Filter: l_shipdate[10]>='1996-01-01' and l_shipdate[10]<'3/31/1996 12:00:00 AM'

--- a/test/regress/expect/tpch1/q20.txt
+++ b/test/regress/expect/tpch1/q20.txt
@@ -49,10 +49,10 @@ PhysicOrder  (inccost=22863.58, cost=2436.58, rows=400)
             Output: s_name[1],s_address[2],s_nationkey[3]
             Filter: s_suppkey[0] in @1
             <InSubqueryExpr> cached 1
-                -> PhysicFilter  (inccost=15762573, cost=735, rows=735)
+                -> PhysicFilter  (inccost=12042679, cost=364, rows=364)
                     Output: ps_suppkey[0]
                     Filter: ps_availqty[1]>0.5*{sum(l_quantity)}[2]
-                    -> PhysicHashJoin Left (inccost=15761838, cost=3440707, rows=735)
+                    -> PhysicHashJoin Left (inccost=12042315, cost=2510548, rows=364)
                         Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
                         Filter: l_partkey[4]=ps_partkey[2] and l_suppkey[5]=ps_suppkey[0]
                         -> PhysicScanTable partsupp (inccost=800000, cost=800000, rows=800000)
@@ -62,10 +62,10 @@ PhysicOrder  (inccost=22863.58, cost=2436.58, rows=400)
                                 -> PhysicScanTable part (inccost=200000, cost=200000, rows=64)
                                     Output: p_partkey[0]
                                     Filter: p_name[1]like'forest%'
-                        -> PhysicHashAgg  (inccost=11521131, cost=5519916, rows=1839972)
+                        -> PhysicHashAgg  (inccost=8731767, cost=2730552, rows=910184)
                             Output: {sum(l_quantity)}[2],{l_partkey}[0],{l_suppkey}[1]
                             Aggregates: sum(l_quantity[2])
                             Group by: l_partkey[0], l_suppkey[1]
-                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=1839972)
+                            -> PhysicScanTable lineitem (inccost=6001215, cost=6001215, rows=910184)
                                 Output: l_partkey[1],l_suppkey[2],l_quantity[4]
                                 Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM'

--- a/test/regress/expect/tpch1/q22.txt
+++ b/test/regress/expect/tpch1/q22.txt
@@ -55,10 +55,10 @@ PhysicOrder  (inccost=225008400272.1, cost=0.1, rows=1)
                         Output: substring(c_phone[4],1,2),c_acctbal[5],c_custkey[0]
                         Filter: substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> ) and c_acctbal[5]>@1
                         <ScalarSubqueryExpr> cached 1
-                            -> PhysicHashAgg  (inccost=286502, cost=136502, rows=1)
+                            -> PhysicHashAgg  (inccost=287801, cost=137801, rows=1)
                                 Output: {avg(c_acctbal)}[0]
                                 Aggregates: avg(c_acctbal[0])
-                                -> PhysicScanTable customer as customer__1 (inccost=150000, cost=150000, rows=136500)
+                                -> PhysicScanTable customer as customer__1 (inccost=150000, cost=150000, rows=137799)
                                     Output: c_acctbal[5]
                                     Filter: c_acctbal[5]>0 and substring(c_phone[4],1,2) in ('13','31','23', ... <Total: 7> )
                     -> PhysicScanTable orders (inccost=1500000, cost=1500000, rows=1500000)


### PR DESCRIPTION
This branch deal with the collection of statistics and cardinality estimation. The changes are mainly in three parts, the fourth part is intended but not successful.

1. Implemented CE for OR
Previously, only expressions connected by AND can be recognized by CE process, the expressions are parsed into andlists. Now, orlist is added alongside of andlist, splitting the whole binary expression into tree of andlist and orlist, and the selectivity is estimated accordingly.
For A and B : selectivity = sel(A) * sel(B)
For A or B : selectivity = sel(A) + sel(B) - sel(A)*sel(B)

2. Implemented grouping of same column filters
Under the same level of and/or list, the expressions on the same column is been considered together to produce better result. Only simple expressions of =/</>/<=/>= are included in this process.
For A and B : selectivity = 1 - (1 - sel(A)) - (1 - sel(B))
For A or B : selectivity = sel(A) + sel(B)
This is based on assumption of numerical value and reasonable expressions. For and situation, it is assumed that each expression eliminates some part of the data, and the eliminated parts does not overlap (otherwise the two should be written as one). For or, it is assumed that expression is not overlapping. 

3. Rewrite histogram and MCV
The original column stat is either MCV or histogram. There were some minor issue concerning </<= and >/>= when the cardinality for = is significant.
To improve the estimation accuracy, the method in PostgreSQL is applied. [link](https://www.postgresql.org/docs/12/row-estimation-examples.html)
MCV is always collected except for the unique case, and histogram is also collected even when MCV is collected. Histogram is only considering the part where MCV is not covering. 
1) For = expression, only MCV is used: when the val is in MCV, it is trivial; when not in MCV, the estimation is based on the assumption that all the other values have similar frequency.
2) For inequalities, both stats are used. Scan through MCV to find the sum of frequencies for satisfying values, then use the histogram to find the placement among bins.

(not actual change)
 4. Update join estimation
The method in PostgreSQL is that CE of join is:
card(left) * card(right) / max( distinct(left_col.orig), distinct(right_col.orig) )
As in our previous implementation it was min. Changing this cause infinite recursion problem.