### PR TITLE
Changeset implementing SQL Analyze with Sampling

### DIFF
--- a/qpmodel/SQLParser.cs
+++ b/qpmodel/SQLParser.cs
@@ -517,8 +517,16 @@ namespace qpmodel.sqlparser
 
         public override object VisitAnalyze_stmt([NotNull] SQLiteParser.Analyze_stmtContext context)
         {
-            var tabref = new BaseTableRef(context.table_name().GetText());
-            return new AnalyzeStmt(tabref, GetRawText(context));
+            SelectStmt.TableSample sample = null;
+
+            if (context.tablesample_clause(0) != null)
+                sample = VisitTablesample_clause(context.tablesample_clause(0)) as SelectStmt.TableSample;
+
+            var tabref = new BaseTableRef(context.table_name().GetText(),
+                                          null,
+                                          sample);
+
+            return new AnalyzeStmt(tabref, GetRawText(context), sample);
         }
 
         public override object VisitDrop_table_stmt([NotNull] SQLiteParser.Drop_table_stmtContext context)

--- a/qpmodel/SQLite.g4
+++ b/qpmodel/SQLite.g4
@@ -66,7 +66,7 @@ sql_stmt
  ;
 
 analyze_stmt
- : K_ANALYZE table_name?
+ : K_ANALYZE table_name? (tablesample_clause)*
  ;
 
 create_index_stmt

--- a/qpmodel/Statis.cs
+++ b/qpmodel/Statis.cs
@@ -619,8 +619,12 @@ namespace qpmodel.stat
         {
             // its child is a [gather ontop] scan
             var child = child_();
-            Debug.Assert(child is LogicGather || child is LogicScanTable);
-            if (child is LogicGather)
+
+            Debug.Assert(child is LogicGather ||
+                         child is LogicScanTable  ||
+                         child is LogicSampleScan);
+
+            if (child is LogicGather || child is LogicSampleScan)
                 child = child.child_();
             return (child as LogicScanTable).tabref_;
         }

--- a/qpmodel/stmtDML.cs
+++ b/qpmodel/stmtDML.cs
@@ -97,11 +97,17 @@ namespace qpmodel.dml
         public readonly BaseTableRef targetref_;
         public readonly SelectStmt select_;
 
-        public AnalyzeStmt(BaseTableRef target, string text) : base(text)
+        public AnalyzeStmt(BaseTableRef target, string text,
+                           SelectStmt.TableSample ts) : base(text)
         {
             // SELECT statement is used so later optimizations can be kicked in easier
             targetref_ = target;
-            select_ = RawParser.ParseSingleSqlStatement($"select * from {target.relname_}") as SelectStmt;
+            string sql = $"select * from {target.relname_} ";
+
+            if (ts != null)
+                sql += $" tablesample row ({ts.rowcnt_})";
+
+            select_ = RawParser.ParseSingleSqlStatement(sql) as SelectStmt;
         }
 
         public override BindContext Bind(BindContext parent)

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -199,6 +199,9 @@ namespace qpmodel.unittest
         {
             var sql = "analyze a;";
             SQLStatement.ExecSQL(sql, out _, out _);
+
+            sql = "analyze a tablesample row (15)";
+            SQLStatement.ExecSQL(sql, out _, out _);
         }
     }
 


### PR DESCRIPTION
This changeset has the changes you requested. I took the option changes out of the method AnalyzeStmt. I had originally included them after errors showed up initially and failed to recheck if they were needed after those errors were fixed. Testing now shows that changing the options here is not needed.

TableSample is actually already passed to AnalyzeStmt as part of the parameter: 
     BaseTableRef target
but I added an additional parameter, 
     SelectStmt.TableSample ts
to AnalyzeStmt as requested. I can always remove this new parameter if you think the value should be picked up from "target" instead. 

++++++++++++++++++++++

This changeset allows an SQL analyze statement to gather table
statistics using either a full scan
     Analyze <table name>
 or with table sampling
     Analyze <table name> tablesample row (<num>)
 where "num" is the number of elements in the sample array.