### PR TITLE
Fix inconsistent cost estimation

### DIFF
--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -140,10 +140,18 @@ namespace qpmodel.physic
         }
 
         #region optimizer
-        public ulong Card() => logic_.Card();
-        public double Cost()
+        public ulong Card()
         {
-            if (double.IsNaN(cost_))
+            if (this is PhysicMemoRef pmr && pmr.Group().minMember_ != null)
+                return pmr.Group().minMember_.physic_.logic_.Card();
+            return logic_.Card();
+        }
+        public double Cost(bool findopt = false)
+        {
+            // force update when finding min cost member
+            if (findopt)
+                cost_ = EstimateCost();
+            else if (double.IsNaN(cost_))
                 cost_ = EstimateCost();
             Debug.Assert(cost_ >= 0 || cost_ is double.NaN);
             return cost_;

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -385,13 +385,14 @@ namespace qpmodel.optimizer
                     var cost = double.MaxValue;
                     if (physic != null)
                     {
-                        cost = physic.Cost();
+                        cost = 0;
                         foreach (var child in physic.children_)
                         {
                             var childgroup = (child as PhysicMemoRef).Group();
                             childgroup.CalculateMinInclusiveCostMember();
                             cost += childgroup.minIncCost_;
                         }
+                        cost += physic.Cost(true);
                     }
                     incCost.Add(cost);
                 }


### PR DESCRIPTION
This commit targets at #122 

The reason for the inconsistency is that when subquery is present, different join plan may result in different cardinality estimation, current method considers only the default logic plan, and may lead to incorrect cost estimation.
This fix force the cost of a physical node to be updated during the process of finding min cost member, and the cardinality is set as that of the minmember of the group (if availble).

The result of the query mentioned in #122 after this update is
```
    -> PhysicHashAgg 1311_1597  (inccost=47137, cost=6007, rows=1, memory=8) (actual rows=1500)
        Output: {l_orderkey}[0]
        Group by: l_orderkey[0]
        -> PhysicHashJoin 1420_1599  (inccost=41130, cost=15010, rows=6005, memory=12000) (actual rows=6005)
            Output: l_orderkey[1]
            Filter: l_orderkey[1]=o_orderkey[0]
```
Now the CE for the hash join is correctly passed to the cost estimation of hash aggregation.