### PR TITLE
Fix join CE with subquery as join children (#122)

### DIFF
--- a/qpmodel/LogicCard.cs
+++ b/qpmodel/LogicCard.cs
@@ -164,12 +164,12 @@ namespace qpmodel.logic
                     var tr = col.tabRef_;
 
                     if (tr is FromQueryRef fqr && fqr.MapOutputName(col.colName_) != null)
-                        tr = (fqr.MapOutputName(col.colName_) as ColExpr).tabRef_;
+                        if (fqr.MapOutputName(col.colName_) is ColExpr ce) tr = ce.tabRef_;
 
                     if (tr is BaseTableRef btr)
                     {
                         var stats = Catalog.sysstat_.GetColumnStat(btr.relname_, col.colName_);
-                        return stats.EstDistinct();
+                        return stats?.EstDistinct() ?? 0;
                     }
                     
                 }


### PR DESCRIPTION
This commit targets at #122 

Previously, when subquery is present, the cardinality estimation for different joining order may produce different results. This breaks the assumption that the members in the same memogroup should have the same output cardinality, and further lead to inconsistent cost estimation for parent groups.
The last fix (#124 ) focused on finding the cardinality of the min-cost member during cost calculation, instead of making sure that all cardinalities of the same group are the same. 
This fix targets at the cardinality estimation of join. Columns from subquery (FromQueryRef) are referenced back to column map, which contains reference to the original table, then the number of distinct values can in turn be extracted.

Subquery with join operation is also tested, and all unit tests are able to pass.