### PR TITLE
Enable memo for insert-select statement (#121)

### DIFF
--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -718,7 +718,7 @@ namespace qpmodel.optimizer
             copyoutCounter_ = 0;
 
             PhysicNode selectplan = CopyOutOptimalPlan(select_);
-            return topstmt_.MemoOpt(selectplan);
+            return topstmt_.InstallSelectPlan(selectplan);
         }
 
         public string PrintMemo()

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -626,6 +626,7 @@ namespace qpmodel.optimizer
     {
         public List<Memo> memoset_ = new List<Memo>();
         public SQLStatement topstmt_;
+        public SelectStmt select_;
         public int copyoutCounter_ = 0;
 
         public void InitRootPlan(SQLStatement stmt)
@@ -633,15 +634,16 @@ namespace qpmodel.optimizer
             // call once
             Rule.Init(stmt.queryOpt_);
             topstmt_ = stmt;
+            select_ = stmt.ExtractSelect();
             memoset_.Clear();
         }
 
         public void OptimizeRootPlan(SQLStatement stmt, PhysicProperty required, bool enqueueit = true)
         {
-            var select = stmt as SelectStmt;
+            var select = stmt.ExtractSelect();
 
             // each statement sitting in a new memo
-            var memo = new Memo(stmt);
+            var memo = new Memo(select);
             if (enqueueit)
             {
                 memoset_.Add(memo);
@@ -714,7 +716,9 @@ namespace qpmodel.optimizer
         public PhysicNode CopyOutOptimalPlan()
         {
             copyoutCounter_ = 0;
-            return CopyOutOptimalPlan(topstmt_);
+
+            PhysicNode selectplan = CopyOutOptimalPlan(select_);
+            return topstmt_.MemoOpt(selectplan);
         }
 
         public string PrintMemo()

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -69,6 +69,8 @@ namespace qpmodel.logic
         public virtual BindContext Bind(BindContext parent) => null;
         public virtual LogicNode SubstitutionOptimize() => logicPlan_;
         public virtual LogicNode CreatePlan() => logicPlan_;
+        public virtual SelectStmt ExtractSelect() => null;
+        public virtual PhysicNode MemoOpt(PhysicNode select) => null;
 
         public ExecContext CreateExecContext()
         {
@@ -815,6 +817,9 @@ namespace qpmodel.logic
                 v.query_.OpenSubQueries(context);
             context.option_.PopCodeGen();
         }
+
+        public override SelectStmt ExtractSelect() => this;
+        public override PhysicNode MemoOpt(PhysicNode select) => select;
     }
 
     public class DataSet

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -70,7 +70,7 @@ namespace qpmodel.logic
         public virtual LogicNode SubstitutionOptimize() => logicPlan_;
         public virtual LogicNode CreatePlan() => logicPlan_;
         public virtual SelectStmt ExtractSelect() => null;
-        public virtual PhysicNode MemoOpt(PhysicNode select) => null;
+        public virtual PhysicNode InstallSelectPlan(PhysicNode select) => null;
 
         public ExecContext CreateExecContext()
         {
@@ -819,7 +819,7 @@ namespace qpmodel.logic
         }
 
         public override SelectStmt ExtractSelect() => this;
-        public override PhysicNode MemoOpt(PhysicNode select) => select;
+        public override PhysicNode InstallSelectPlan(PhysicNode select) => select;
     }
 
     public class DataSet

--- a/qpmodel/stmtDML.cs
+++ b/qpmodel/stmtDML.cs
@@ -192,7 +192,8 @@ namespace qpmodel.dml
 
         public override LogicNode CreatePlan()
         {
-            queryOpt_.optimize_.use_memo_ = false;
+            if (select_ is null)
+                queryOpt_.optimize_.use_memo_ = false;
             logicPlan_ = select_ is null ?
                 new LogicInsert(targetref_, new LogicResult(vals_)) :
                 new LogicInsert(targetref_, select_.CreatePlan());
@@ -207,6 +208,17 @@ namespace qpmodel.dml
             if (select_ != null)
                 select_.logicPlan_.ResolveColumnOrdinal(select_.selection_, false);
             return logicPlan_;
+        }
+
+        public override SelectStmt ExtractSelect() => select_;
+        public override PhysicNode MemoOpt(PhysicNode select)
+        {
+            var node = physicPlan_;
+            while (!(node is PhysicInsert))
+                node = node.child_();
+            Debug.Assert(node.child_() is PhysicProfiling);
+            node.children_[0] = select;
+            return physicPlan_;
         }
     }
 

--- a/qpmodel/stmtDML.cs
+++ b/qpmodel/stmtDML.cs
@@ -211,7 +211,7 @@ namespace qpmodel.dml
         }
 
         public override SelectStmt ExtractSelect() => select_;
-        public override PhysicNode MemoOpt(PhysicNode select)
+        public override PhysicNode InstallSelectPlan(PhysicNode select)
         {
             var node = physicPlan_;
             while (!(node is PhysicInsert))


### PR DESCRIPTION
Previously all insert statements have use_memo_ disabled. (#121 )
Now insertion with select statement can utilize memo, 
it is done by extracting the select part and use memo only for that.