### PR TITLE
Avoid creating SQLStatement twice for ExecSQLList()

### DIFF
--- a/qpmodel/Catalog.cs
+++ b/qpmodel/Catalog.cs
@@ -251,8 +251,7 @@ namespace qpmodel
                 @"create unique index dd1 on d(d1);",
                 @"create index dd2 on d(d2);",
             };
-            foreach (var sql in createindexes)
-                SQLStatement.ExecSQL(sql, out _, out _);
+            SQLStatement.ExecSQLList(string.Join("", createindexes));
 
             // analyze tables
             foreach (var v in tables)

--- a/qpmodel/Index.cs
+++ b/qpmodel/Index.cs
@@ -57,12 +57,12 @@ namespace qpmodel.index
             def_.table_ = target;
             select_ = RawParser.ParseSingleSqlStatement
                 ($"select sysrid_, {string.Join(",", columns)} from {def_.table_.relname_}") as SelectStmt;
-            // select_ is a different statement, binding their options
-            select_.queryOpt_ = queryOpt_;
         }
 
         public override BindContext Bind(BindContext parent)
         {
+            // select_ is a different statement, binding their options
+            select_.queryOpt_ = queryOpt_;
             return select_.Bind(parent);
         }
 

--- a/qpmodel/Index.cs
+++ b/qpmodel/Index.cs
@@ -57,12 +57,12 @@ namespace qpmodel.index
             def_.table_ = target;
             select_ = RawParser.ParseSingleSqlStatement
                 ($"select sysrid_, {string.Join(",", columns)} from {def_.table_.relname_}") as SelectStmt;
+            // select_ is a different statement, binding their options
+            select_.queryOpt_ = queryOpt_;
         }
 
         public override BindContext Bind(BindContext parent)
         {
-            // select_ is a different statement, binding their options
-            select_.queryOpt_ = queryOpt_;
             return select_.Bind(parent);
         }
 

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -133,21 +133,27 @@ namespace qpmodel.logic
             return finalplan.rows_;
         }
 
-        public static List<Row> ExecSQL(string sql, out SQLStatement stmt, out string physicplan, out string error, QueryOption option = null)
+        public static List<Row> ExecSQL (SQLStatement stmt, out string physicplan, QueryOption option = null)
         {
             var optCopy = option?.Clone();
+            if (option != null)
+                stmt.queryOpt_ = optCopy;
 
+            var result = stmt.Exec();
+            physicplan = "";
+            if (stmt.physicPlan_ != null)
+                physicplan = stmt.physicPlan_.Explain(option?.explain_ ?? stmt.queryOpt_.explain_);
+            return result;
+        }
+
+        public static List<Row> ExecSQL(string sql, out SQLStatement stmt, out string physicplan, out string error, QueryOption option = null)
+        {
             try
             {
                 stmt = RawParser.ParseSingleSqlStatement(sql);
-                if (option != null)
-                    stmt.queryOpt_ = optCopy;
-                var result = stmt.Exec();
-                physicplan = "";
-                if (stmt.physicPlan_ != null)
-                    physicplan = stmt.physicPlan_.Explain(option?.explain_ ?? stmt.queryOpt_.explain_);
+                var results = ExecSQL(stmt, out physicplan, option);
                 error = "";
-                return result;
+                return results;
             }
             catch (Exception e)
             {
@@ -211,7 +217,7 @@ namespace qpmodel.logic
             foreach (var v in list_)
             {
                 v.queryOpt_ = queryOpt_;
-                var rows = ExecSQL(v.text_, out string plan, out _, queryOpt_);
+                var rows = ExecSQL(v, out string plan, queryOpt_);
 
                 // format: <sql> <plan> <result>
                 result += v.text_ + "\n";

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -185,8 +185,7 @@ namespace qpmodel.logic
         public static string ExecSQLList(string sqls, QueryOption option = null)
         {
             StatementList stmts = RawParser.ParseSqlStatements(sqls);
-            if (option != null)
-                stmts.queryOpt_ = option;
+            stmts.queryOpt_ = option;
             return stmts.ExecList();
         }
     }
@@ -216,7 +215,6 @@ namespace qpmodel.logic
             string result = "";
             foreach (var v in list_)
             {
-                v.queryOpt_ = queryOpt_;
                 var rows = ExecSQL(v, out string plan, queryOpt_);
 
                 // format: <sql> <plan> <result>


### PR DESCRIPTION
This is for #120 

ExecSQLList() pass the statement text to ExecSQL, causing the statement object to be created twice.
The solution is creating an overload of ExecSQL for directly taking in statement object.
Adjustment to list execution is also made to avoid the default query option be falsely assigned to ExecSQL even when the option for the outer function is null.