### PR TITLE
Add Code Coverage for Unit Tests

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,10 +25,10 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
 
     - name: Unit Test Cover
-      run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov 
+      run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
         /p:CoverletOutput='/home/runner/work/qpmodel/qpmodel/test/lcov.info'
     - name: Coveralls
       uses: coverallsapp/github-action@master
-      with: 
+      with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: "/home/runner/work/qpmodel/qpmodel/test/lcov.info"

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -23,3 +23,12 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+
+    - name: Unit Test Cover
+      run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov 
+        /p:CoverletOutput='/home/runner/work/qpmodel/qpmodel/test/lcov.info'
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with: 
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: "/home/runner/work/qpmodel/qpmodel/test/lcov.info"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Build Status](https://github.com/zhouqingqing/qpmodel/workflows/unittest/badge.svg)
 [![CodeFactor](https://www.codefactor.io/repository/github/zhouqingqing/qpmodel/badge)](https://www.codefactor.io/repository/github/zhouqingqing/qpmodel)
+[![Coverage Status](https://coveralls.io/repos/github/zhouqingqing/qpmodel/badge.svg?branch=master)](https://coveralls.io/github/zhouqingqing/qpmodel?branch=master)
 
 # A Relational Optimizer and Executor Modeling
 This project implements a relational optimizer and executor in c#. It is called "model" because it does not have all the details carved. The main target is the optimizer, and the purpose is to prepare for a more serious production implementation later. The executor part is needed for plan correctness verification with TPCH/DS end to end runnable. See github project "issues" for bugs and todo items.

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -22,6 +22,10 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0-preview.6.ga0e22ec622" >
+	    <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <ProjectReference Include="../psql/psql.csproj" />
     <ProjectReference Include="../qpmodel/qpmodel.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Use coverlet msbuild to produce code coverage report for unittest in LCOV format, 
then use Coveralls Github Action CL to sent to coveralls.io. 
Added code coverage badge to README: the current line coverage is 71%.
