### PR TITLE
property enforcement in memo optimization

### DIFF
--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -65,6 +65,7 @@ namespace qpmodel.logic
         // it is possible to really have this value but ok to recompute
         protected LogicSignature logicSign_ = -1;
 
+        public virtual Property TopDownRequirement() => null;
         public override string ExplainMoreDetails(int depth, ExplainOption option) => ExplainFilter(filter_, depth, option);
 
         public override string ExplainOutput(int depth, ExplainOption option)
@@ -1024,6 +1025,11 @@ namespace qpmodel.logic
             children_.Add(child);
             orders_ = orders;
             descends_ = descends;
+        }
+
+        public override Property TopDownRequirement()
+        {
+            return new PhysicProperty(orders_, descends_);
         }
 
         public override List<int> ResolveColumnOrdinal(in List<Expr> reqOutput, bool removeRedundant = true)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -65,7 +65,7 @@ namespace qpmodel.physic
         public override string ExplainOutput(int depth, ExplainOption option) => logic_.ExplainOutput(depth, option);
         public override string ExplainInlineDetails() => logic_.ExplainInlineDetails();
         public override string ExplainMoreDetails(int depth, ExplainOption option) => logic_.ExplainMoreDetails(depth, option);
-
+        
         public void ValidateThis()
         {
             VisitEach(x =>
@@ -161,7 +161,7 @@ namespace qpmodel.physic
             children_.ForEach(x =>
             {
                 if (x is PhysicMemoRef xp)
-                    incCost += xp.Group().minIncCost_;
+                    incCost += xp.Group().nullMinIncCost_;
                 else
                     incCost += x.InclusiveCost();
             });
@@ -188,6 +188,9 @@ namespace qpmodel.physic
 
             return memory;
         }
+        public virtual PhysicProperty RequiredProperty() => null;
+        public virtual PhysicProperty SuppiedProperty() => null;
+        public virtual PhysicProperty PropagatedProperty() => null;
         #endregion
 
         public BitVector tableContained_ { get => logic_.tableContained_; }
@@ -1059,6 +1062,20 @@ namespace qpmodel.physic
         protected override double EstimateCost()
         {
             return logic_.Card() * 2.0;
+        }
+        public override PhysicProperty RequiredProperty()
+        {
+            var collist = (logic_ as LogicAgg).groupby_;
+            if (collist.Count > 0)
+                return new PhysicProperty(collist);
+            return null;
+        }
+        public override PhysicProperty SuppiedProperty()
+        {
+            var collist = (logic_ as LogicAgg).groupby_;
+            if (collist.Count > 0)
+                return new PhysicProperty(collist);
+            return null;
         }
 
         public override void Open(ExecContext context)

--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -207,8 +207,8 @@ namespace qpmodel
                 Console.WriteLine("***************** optimized plan *************");
                 var optplan = a.SubstitutionOptimize();
                 Console.WriteLine(optplan.Explain(a.queryOpt_.explain_));
-                a.optimizer_.InitRootPlan(a);
-                a.optimizer_.OptimizeRootPlan(a, null);
+                a.optimizer_.Initialize(a);
+                a.optimizer_.ExploreRootPlan(a, null);
                 Console.WriteLine(a.optimizer_.PrintMemo());
                 phyplan = a.optimizer_.CopyOutOptimalPlan();
                 Console.WriteLine(a.optimizer_.PrintMemo());

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -97,8 +97,8 @@ namespace qpmodel.logic
 
             if (queryOpt_.optimize_.use_memo_)
             {
-                optimizer_.InitRootPlan(this);
-                optimizer_.OptimizeRootPlan(this, null);
+                optimizer_.Initialize(this);
+                optimizer_.ExploreRootPlan(this, null);
                 physicPlan_ = optimizer_.CopyOutOptimalPlan();
             }
 


### PR DESCRIPTION
Established the property enforcement process in optimization.
A property propagation step is created between exploration and cost calculation. In this step, properties are propagated from top to bottom, creating link between required properties and the group members that can supply them. Then the cost calculation determine the optimal case for each group under each required property. 
However, only exact match of the supplied property is considered in the model and partial property propagation is not implemented. This can be done through modification of the property method.
Properties are enforced on top of the original member (instead of down below in the previous implementation), the additional physical node will be the parent of the existing member that does not supply the property. This enables base requirement to be added.

Logic nodes on the top like ORDER is transformed into physical property to prevent corresponding groups to be create. For example, if an order node is on the top of the raw plan, it will be added to the base required property rather than a memo group. The new root group would be the first logic node that cannot be transformed into physical property.

All unittest pass.