### PR TITLE
Add property propagation in memo optimization

### DIFF
--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1062,11 +1062,15 @@ namespace qpmodel.physic
         public override string ToString() => $"PStreamAgg({child_()}: {Cost()})";
         public override PhysicProperty RequiredProperty()
         {
-            return new PhysicProperty((logic_ as LogicAgg).groupby_);
+            var exprlist = (logic_ as LogicAgg).groupby_;
+            if (exprlist is null) return null;
+            return new PhysicProperty(exprlist);
         }
         public override PhysicProperty SuppiedProperty()
         {
-            return new PhysicProperty((logic_ as LogicAgg).groupby_);
+            var exprlist = (logic_ as LogicAgg).groupby_;
+            if (exprlist is null) return null;
+            return new PhysicProperty(exprlist);
         }
         protected override double EstimateCost()
         {
@@ -1109,7 +1113,7 @@ namespace qpmodel.physic
                     {
                         // output current grouped row if any
                         if (curGroupKey != null)
-                            FinalizeAGroupRow(context, keys, curGroupRow, callback);
+                            FinalizeAGroupRow(context, curGroupKey, curGroupRow, callback);
 
                         // start a new grouped row
                         curGroupRow = AggrCoreToRow(l);

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -190,6 +190,9 @@ namespace qpmodel.physic
 
             return memory;
         }
+        public virtual PhysicProperty RequiredProperty() => null;
+        public virtual PhysicProperty SuppiedProperty() => null;
+        public virtual PhysicProperty PropagatedProperty() => null;
         #endregion
 
         public BitVector tableContained_ { get => logic_.tableContained_; }
@@ -1057,7 +1060,14 @@ namespace qpmodel.physic
     {
         public PhysicStreamAgg(LogicAgg logic, PhysicNode l) : base(logic, l) { }
         public override string ToString() => $"PStreamAgg({child_()}: {Cost()})";
-
+        public override PhysicProperty RequiredProperty()
+        {
+            return new PhysicProperty((logic_ as LogicAgg).groupby_);
+        }
+        public override PhysicProperty SuppiedProperty()
+        {
+            return new PhysicProperty((logic_ as LogicAgg).groupby_);
+        }
         protected override double EstimateCost()
         {
             return logic_.Card() * 2.0;

--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -56,6 +56,7 @@ namespace qpmodel.logic
             // optimizer controls
             public bool enable_hashjoin_ { get; set; } = true;
             public bool enable_nljoin_ { get; set; } = true;
+            public bool enable_streamagg_ { get; set; } = false;
             public bool enable_indexseek_ { get; set; } = true;
             public bool use_memo_ { get; set; } = true;
             public bool memo_disable_crossjoin_ { get; set; } = true;

--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -209,6 +209,7 @@ namespace qpmodel
                 Console.WriteLine(optplan.Explain(a.queryOpt_.explain_));
                 a.optimizer_ = new Optimizer(a);
                 a.optimizer_.ExploreRootPlan(a);
+                a.optimizer_.PropagateProperty();
                 phyplan = a.optimizer_.CopyOutOptimalPlan();
                 Console.WriteLine(a.optimizer_.PrintMemo());
                 Console.WriteLine("***************** Memo plan *************");

--- a/qpmodel/RulesTrans.cs
+++ b/qpmodel/RulesTrans.cs
@@ -76,6 +76,8 @@ namespace qpmodel.optimizer
                 ruleset_.RemoveAll(x => x is Scan2IndexSeek);
             if (!option.optimize_.enable_hashjoin_)
                 ruleset_.RemoveAll(x => x is Join2HashJoin);
+            if (!option.optimize_.enable_streamagg_)
+                ruleset_.RemoveAll(x => x is Agg2StreamAgg);
             if (!option.optimize_.enable_nljoin_)
                 ruleset_.RemoveAll(x => x is Join2NLJoin);
         }

--- a/qpmodel/RulesTrans.cs
+++ b/qpmodel/RulesTrans.cs
@@ -52,6 +52,7 @@ namespace qpmodel.optimizer
             new ScanFile2ScanFile(),
             new Filter2Filter(),
             new Agg2HashAgg(),
+            new Agg2StreamAgg(),
             new Order2Sort(),
             new From2From(),
             new Limit2Limit(),

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -590,7 +590,7 @@ namespace qpmodel.optimizer
             var queryOpt = memo_.stmt_.queryOpt_;
 
             // if user does not provides a physic node, get the lowest inclusive
-            // cost one from the member list. Either wya, always use a clone to
+            // cost one from the member list. Either way, always use a clone to
             // not change memo itself.
             //
             if (knownMinPhysic is null)
@@ -617,10 +617,9 @@ namespace qpmodel.optimizer
                     }
                     else
                     {
-                        // this shall not happen if without join resolver. With join resolver
-                        // the plan is already given, so 'v' is the known min physic node
-                        //
-                        Debug.Assert(queryOpt.optimize_.memo_use_joinorder_solver_);
+                        // this could be join solver or enforced node
+                        Debug.Assert(queryOpt.optimize_.memo_use_joinorder_solver_ ||
+                            phyClone is PhysicOrder);
                         phychild = CopyOutMinLogicPhysicPlan(v);
                     }
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -89,6 +89,7 @@ namespace qpmodel.optimizer
 
         public bool Equals(PhysicProperty other)
         {
+            if (other is null) return false;
             if (ordering_.Count != other.ordering_.Count) return false;
             if (distribution_.Count != other.distribution_.Count) return false;
             for (int i = 0; i < ordering_.Count; i++)
@@ -428,7 +429,8 @@ namespace qpmodel.optimizer
                     var group = (child as PhysicMemoRef).Group();
                     group.PropagateProperty(exprList_[i].physic_.RequiredProperty());
                 }
-                if (property != null && property.IsPropertySupplied(exprList_[i].physic_))
+                if (property != null && exprList_[i].physic_ != null &&
+                    property.IsPropertySupplied(exprList_[i].physic_))
                 {
                     propertyCandidates_[property].Add(i);
                 }

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -545,7 +545,6 @@ namespace qpmodel.optimizer
                     var childgroup = (child as PhysicMemoRef).Group();
                     childgroup.CalculateMinInclusiveCostMember(subproperty);
                     cost += childgroup.propertyOptimum_[subproperty].Value;
-
                 }
                 if (cost < propmincost)
                 {

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -106,6 +106,13 @@ namespace qpmodel.optimizer
         {
             return ordering_.ListHashCode();
         }
+        public override string ToString()
+        {
+            string s = "";
+            foreach (var o in ordering_)
+                s += o.Key.ToString();
+            return s;
+        }
     }
     public enum DistributionType { }
 
@@ -356,6 +363,13 @@ namespace qpmodel.optimizer
             CountMembers(out int clogics, out int cphysics);
             var str = $"{clogics}, {cphysics}, [{logicSign_}][{minIncCost_}]: ";
             str += string.Join(",", exprList_);
+
+            // add property member
+            List<string> l = new List<string>();
+            foreach (var pair in propertyOptimum_)
+                l.Add("property:" + pair.Key.ToString() + " member:" + pair.Value);
+            str += "\n\t";
+            str += string.Join(",", l);
             return str;
         }
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -364,12 +364,26 @@ namespace qpmodel.optimizer
             var str = $"{clogics}, {cphysics}, [{logicSign_}][{minIncCost_}]: ";
             str += string.Join(",", exprList_);
 
-            // add property member
-            List<string> l = new List<string>();
-            foreach (var pair in propertyOptimum_)
-                l.Add("property:" + pair.Key.ToString() + " member:" + pair.Value);
-            str += "\n\t";
-            str += string.Join(",", l);
+            // add property candidates
+            if (propertyCandidates_.Count > 0)
+            {
+                List<string> l = new List<string>();
+                foreach (var pair in propertyCandidates_)
+                    l.Add("property:" + pair.Key.ToString() + ", candidate:" + string.Join(",",pair.Value));
+                str += "\n\t";
+                str += string.Join("|", l);
+            }
+
+            // add property optimal member
+            if (propertyOptimum_.Count > 0)
+            {
+                List<string> l = new List<string>();
+                foreach (var pair in propertyOptimum_)
+                    l.Add("property:" + pair.Key.ToString() + ", member:" + pair.Value);
+                str += "\n\t";
+                str += string.Join("|", l);
+            }
+
             return str;
         }
 

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -99,6 +99,7 @@ namespace qpmodel.logic
             {
                 optimizer_ = new Optimizer(this);
                 optimizer_.ExploreRootPlan(this);
+                optimizer_.PropagateProperty();
                 physicPlan_ = optimizer_.CopyOutOptimalPlan();
             }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -617,6 +617,12 @@ namespace qpmodel.unittest
 
             Assert.IsTrue(option.optimize_.use_memo_);
         }
+
+        [TestMethod]
+        public void TestEnforcer()
+        {
+
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
This patch attempts to add a new property propagation step to the end the exploration. The groups are traversed from top to down and properties required by certain physical nodes are propagated to the child group. If a member in the child group can provided the property, it will be added to the candidate list.

The locate min cost member functions are changed to accommodate to property requirements. If the property requirement is null, then the min cost member is found and returned same as before. When a property requirement is present, the min cost member with additional enforcement node will be compared to all the other members that can provide that property. Then the optimal member will be found.

Since enforced node will be added onto the member physical node, the assumption that each member correspond to one layer of physical node is no longer valid. However, since bypass is created for join solver case, which will also work for enforced node case, minimal changes is required for copy out min logic physic plan function.