### PR TITLE
fix stream aggregation key value

### DIFF
--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1099,7 +1099,7 @@ namespace qpmodel.physic
                     {
                         // output current grouped row if any
                         if (curGroupKey != null)
-                            FinalizeAGroupRow(context, keys, curGroupRow, callback);
+                            FinalizeAGroupRow(context, curGroupKey, curGroupRow, callback);
 
                         // start a new grouped row
                         curGroupRow = AggrCoreToRow(l);


### PR DESCRIPTION
Previously the FinalizeAGroupRow takes in the key from the new line instead of the previous key.
This patch change the key to the correct value.