### PR TITLE
Refactor ruleset in optimizer

### DIFF
--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -56,6 +56,7 @@ namespace qpmodel.logic
             // optimizer controls
             public bool enable_hashjoin_ { get; set; } = true;
             public bool enable_nljoin_ { get; set; } = true;
+            public bool enable_streamagg_ { get; set; } = false;
             public bool enable_indexseek_ { get; set; } = true;
             public bool use_memo_ { get; set; } = true;
             public bool memo_disable_crossjoin_ { get; set; } = true;

--- a/qpmodel/RulesTrans.cs
+++ b/qpmodel/RulesTrans.cs
@@ -52,6 +52,7 @@ namespace qpmodel.optimizer
             new ScanFile2ScanFile(),
             new Filter2Filter(),
             new Agg2HashAgg(),
+            new Agg2StreamAgg(),
             new Order2Sort(),
             new From2From(),
             new Limit2Limit(),
@@ -69,14 +70,16 @@ namespace qpmodel.optimizer
         };
 
         // TBD: besides static controls, we can examine the plan and quick trim rules impossible to apply
-        public static void Init(QueryOption option)
+        public static void Init(ref List<Rule> ruleset, QueryOption option)
         {
             if (!option.optimize_.enable_indexseek_)
-                ruleset_.RemoveAll(x => x is Scan2IndexSeek);
+                ruleset.RemoveAll(x => x is Scan2IndexSeek);
             if (!option.optimize_.enable_hashjoin_)
-                ruleset_.RemoveAll(x => x is Join2HashJoin);
+                ruleset.RemoveAll(x => x is Join2HashJoin);
+            if (!option.optimize_.enable_streamagg_)
+                ruleset.RemoveAll(x => x is Agg2StreamAgg);
             if (!option.optimize_.enable_nljoin_)
-                ruleset_.RemoveAll(x => x is Join2NLJoin);
+                ruleset.RemoveAll(x => x is Join2NLJoin);
         }
 
         public abstract bool Appliable(CGroupMember expr);

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -157,7 +157,7 @@ namespace qpmodel.optimizer
         internal List<CGroupMember> ExploreMember(Memo memo)
         {
             var list = group_.exprList_;
-            foreach (var rule in Rule.ruleset_)
+            foreach (var rule in group_.memo_.optimizer_.ruleset_)
             {
                 if (rule.Appliable(this))
                 {
@@ -499,8 +499,13 @@ namespace qpmodel.optimizer
         public Dictionary<LogicSignature, CMemoGroup> cgroups_ = new Dictionary<LogicSignature, CMemoGroup>();
 
         public Stack<CMemoGroup> stack_ = new Stack<CMemoGroup>();
+        public Optimizer optimizer_;
 
-        public Memo(SQLStatement stmt) => stmt_ = stmt;
+        public Memo(SQLStatement stmt, Optimizer optimizer)
+        {
+            stmt_ = stmt;
+            optimizer_ = optimizer;
+        }
         public CMemoGroup LookupCGroup(LogicNode subtree)
         {
             if (subtree is LogicMemoRef sl)
@@ -655,11 +660,12 @@ namespace qpmodel.optimizer
         public List<Memo> memoset_ = new List<Memo>();
         public SQLStatement stmt_;
         public SelectStmt select_;
+        public List<Rule> ruleset_ = new List<Rule>(Rule.ruleset_);
 
         public Optimizer(SQLStatement stmt)
         {
             // call once
-            Rule.Init(stmt.queryOpt_);
+            Rule.Init(ref ruleset_, stmt.queryOpt_);
             stmt_ = stmt;
             select_ = stmt.ExtractSelect();
             memoset_.Clear();
@@ -670,7 +676,7 @@ namespace qpmodel.optimizer
             var select = stmt.ExtractSelect();
 
             // each statement sitting in a new memo
-            var memo = new Memo(select);
+            var memo = new Memo(select, this);
             if (enqueueit)
             {
                 memoset_.Add(memo);


### PR DESCRIPTION
Previously, ruleset is a global static list which any change by Init() from previous query will be inherited by later query, causing removed rules to not be recovered even if they are enabled.
Rulesets are now defined as an attribute for optimizer, copied from the original static Rule.ruleset_, each optimizer has a separate ruleset and changes in this query will not affect later queries.