### PR TITLE
add streamagg codegen support

### DIFF
--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1092,6 +1092,9 @@ namespace qpmodel.physic
                     buildcode += $@"
                         var keys = KeyList.ComputeKeys(context, {_logic_}.groupby_, {lrow});";
                     buildcode += $@"
+                        if (context.stop_)
+                            return;
+
                         if (curGroupKey{_} != null && keys.Equals(curGroupKey{_}))
                         {{
                             for (int i = 0; i < {aggrcore.Count}; i++)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1099,7 +1099,7 @@ namespace qpmodel.physic
                     {
                         // output current grouped row if any
                         if (curGroupKey != null)
-                            FinalizeAGroupRow(context, keys, curGroupRow, callback);
+                            FinalizeAGroupRow(context, curGroupKey, curGroupRow, callback);
 
                         // start a new grouped row
                         curGroupRow = AggrCoreToRow(l);

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1116,6 +1116,9 @@ namespace qpmodel.physic
                 }
                 else
                 {
+                    if (context.stop_)
+                        return null;
+
                     var keys = KeyList.ComputeKeys(context, logic.groupby_, l);
                     if (curGroupKey != null && keys.Equals(curGroupKey))
                     {
@@ -1172,6 +1175,8 @@ namespace qpmodel.physic
                     if (row != null)
                         callback(row);
                 }
+                // when there are still remaining output
+                // and output rows is not beyond limit
                 if (curGroupKey != null && !context.stop_)
                     FinalizeAGroupRow(context, curGroupKey, curGroupRow, callback);
             }

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1068,7 +1068,9 @@ namespace qpmodel.physic
             base.Open(context);
             if (context.option_.optimize_.use_codegen_)
             {
-                context.code_ += $@"";
+                context.code_ += $@"var aggrcore{_} = {_logic_}.aggrFns_;
+                    KeyList curGroupKey{_} = null;
+                    Row curGroupRow{_} = null;";
             }
         }
 
@@ -1084,7 +1086,35 @@ namespace qpmodel.physic
             string s = child_().Exec(l =>
             {
                 string buildcode = null;
-                if (!context.option_.optimize_.use_codegen_)
+                if (context.option_.optimize_.use_codegen_)
+                {
+                    var lrow = $"r{child_()._}";
+                    buildcode += $@"
+                        var keys = KeyList.ComputeKeys(context, {_logic_}.groupby_, {lrow});";
+                    buildcode += $@"
+                        if (curGroupKey{_} != null && keys.Equals(curGroupKey{_}))
+                        {{
+                            for (int i = 0; i < {aggrcore.Count}; i++)
+                            {{
+                                var old = curGroupRow{_}[i];
+                                curGroupRow{_}[i] = aggrcore{_}[i].Accum(context, old, {lrow});
+                            }}
+                        }}
+                        else
+                        {{
+                            if (curGroupKey{_} != null)
+                            {{
+                                var keys{_} = curGroupKey{_};
+                                Row aggvals{_} = curGroupRow{_};
+                                {FinalizeAGroupRow(context, null, null, callback)}
+                            }}
+                            curGroupRow{_} = {_physic_}.AggrCoreToRow({lrow});
+                            curGroupKey{_} = keys;
+                            for (int i = 0; i < {aggrcore.Count}; i++)
+                                curGroupRow{_}[i] = aggrcore{_}[i].Init(context, {lrow});
+                        }}";
+                }
+                else
                 {
                     var keys = KeyList.ComputeKeys(context, logic.groupby_, l);
                     if (curGroupKey != null && keys.Equals(curGroupKey))
@@ -1113,7 +1143,28 @@ namespace qpmodel.physic
             });
 
             // special handling for emtpy resultset and last row
-            if (!context.option_.optimize_.use_codegen_)
+            if (context.option_.optimize_.use_codegen_)
+            {
+                if (logic.groupby_ is null)
+                    s += $@"
+                    if (curGroupRow{_} is null)
+                    {{
+                        Row r{_} = {_physic_}.HandleEmptyResult(context);
+                        if (r{_} != null)
+                        {{
+                            {callback(null)}
+                        }}
+                    }}
+                    ";
+                s += $@"
+                if (curGroupKey{_} != null && !context.stop_)
+                {{
+                    var keys{_} = curGroupKey{_};
+                    Row aggvals{_} = curGroupRow{_};
+                    {FinalizeAGroupRow(context, null, null, callback)}
+                }}";
+            }
+            else
             {
                 if (logic.groupby_ is null && curGroupRow is null)
                 {
@@ -1121,7 +1172,7 @@ namespace qpmodel.physic
                     if (row != null)
                         callback(row);
                 }
-                if (curGroupKey != null)
+                if (curGroupKey != null && !context.stop_)
                     FinalizeAGroupRow(context, curGroupKey, curGroupRow, callback);
             }
 

--- a/qpmodel/RulesTrans.cs
+++ b/qpmodel/RulesTrans.cs
@@ -52,7 +52,6 @@ namespace qpmodel.optimizer
             new ScanFile2ScanFile(),
             new Filter2Filter(),
             new Agg2HashAgg(),
-            new Agg2StreamAgg(),
             new Order2Sort(),
             new From2From(),
             new Limit2Limit(),

--- a/qpmodel/RulesTrans.cs
+++ b/qpmodel/RulesTrans.cs
@@ -52,6 +52,7 @@ namespace qpmodel.optimizer
             new ScanFile2ScanFile(),
             new Filter2Filter(),
             new Agg2HashAgg(),
+            new Agg2StreamAgg(),
             new Order2Sort(),
             new From2From(),
             new Limit2Limit(),

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -187,7 +187,13 @@ namespace qpmodel.unittest
             option.optimize_.enable_subquery_unnest_ = false;
             option.optimize_.use_codegen_ = true;
 
+            option.optimize_.enable_streamagg_ = true;
             TU.ExecuteSQL(sql, "4,1;6,4", out string phyplan, option);
+
+            option.optimize_.enable_streamagg_ = false;
+            sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2 order by a2 desc;";
+            TU.ExecuteSQL(sql, "6,4;4,1", out phyplan, option);
+
             sql = "select a2*2, count(a1) from a, b, c where a1=b1 and a2=c2 group by a2 limit 2;";
             TU.ExecuteSQL(sql, "2,1;4,1", out phyplan, option);
 


### PR DESCRIPTION
This patch completed codegen for stream aggregate and resolved the conflict between limit and stream aggregate.
Since hash aggregate only have one result outlet (FinalizeAGroupRow), a generic stop can work. However, stream aggregate has two result outlet, the second outlet may conflict with limit node because stop is not triggered.