### PR TITLE
Add order property enforcement in memo optimization

### DIFF
--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -65,6 +65,7 @@ namespace qpmodel.logic
         // it is possible to really have this value but ok to recompute
         protected LogicSignature logicSign_ = -1;
 
+        public virtual Property ConvertToRequirement() => null;
         public override string ExplainMoreDetails(int depth, ExplainOption option) => ExplainFilter(filter_, depth, option);
 
         public override string ExplainOutput(int depth, ExplainOption option)
@@ -1025,6 +1026,9 @@ namespace qpmodel.logic
             orders_ = orders;
             descends_ = descends;
         }
+
+        public override Property ConvertToRequirement()
+            => new SortOrderProperty(orders_, descends_);
 
         public override List<int> ResolveColumnOrdinal(in List<Expr> reqOutput, bool removeRedundant = true)
         {

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -168,7 +168,7 @@ namespace qpmodel.physic
                     incCost += x.InclusiveCost();
             });
 
-            Debug.Assert(incCost > Cost() || children_.Count == 0);
+            Debug.Assert(Double.IsNaN(incCost) || incCost > Cost() || children_.Count == 0);
             return incCost;
         }
 
@@ -190,6 +190,9 @@ namespace qpmodel.physic
 
             return memory;
         }
+        public virtual PhysicProperty RequiredProperty() => null;
+        public virtual PhysicProperty SuppiedProperty() => null;
+        public virtual PhysicProperty PropagatedProperty() => null;
         #endregion
 
         public BitVector tableContained_ { get => logic_.tableContained_; }
@@ -1057,7 +1060,18 @@ namespace qpmodel.physic
     {
         public PhysicStreamAgg(LogicAgg logic, PhysicNode l) : base(logic, l) { }
         public override string ToString() => $"PStreamAgg({child_()}: {Cost()})";
-
+        public override PhysicProperty RequiredProperty()
+        {
+            var exprlist = (logic_ as LogicAgg).groupby_;
+            if (exprlist is null) return null;
+            return new SortOrderProperty(exprlist);
+        }
+        public override PhysicProperty SuppiedProperty()
+        {
+            var exprlist = (logic_ as LogicAgg).groupby_;
+            if (exprlist is null) return null;
+            return new SortOrderProperty(exprlist);
+        }
         protected override double EstimateCost()
         {
             return logic_.Card() * 2.0;

--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -189,6 +189,7 @@ namespace qpmodel
             a.queryOpt_.explain_.show_id_ = true;
             a.queryOpt_.explain_.show_estCost_ = a.queryOpt_.optimize_.use_memo_;
             a.queryOpt_.explain_.mode_ = ExplainMode.full;
+            a.queryOpt_.optimize_.enable_streamagg_ = true;
 
             // -- Semantic analysis:
             //  - bind the query
@@ -209,6 +210,7 @@ namespace qpmodel
                 Console.WriteLine(optplan.Explain(a.queryOpt_.explain_));
                 a.optimizer_ = new Optimizer(a);
                 a.optimizer_.ExploreRootPlan(a);
+                a.optimizer_.PropagateProperty();
                 phyplan = a.optimizer_.CopyOutOptimalPlan();
                 Console.WriteLine(a.optimizer_.PrintMemo());
                 Console.WriteLine("***************** Memo plan *************");

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -99,6 +99,7 @@ namespace qpmodel.logic
             {
                 optimizer_ = new Optimizer(this);
                 optimizer_.ExploreRootPlan(this);
+                optimizer_.PropagateProperty();
                 physicPlan_ = optimizer_.CopyOutOptimalPlan();
             }
 


### PR DESCRIPTION
Migrated from #151 and cleaned, with additional unit test.

The three main parts are property propagation, property enforcement and property conversion. The property used here only refers to order property, distribution can be added to this framework.
Prior to exploration phase, top logic nodes that can be converted into property requirement is added into base requirement of the corresponding memo.
After exploration, a separate property propagation phase is added to find the candidate members of certain property in a memo group.
During the cost computation, property enforcement is added if there is a required property.

Unit test is added to cover the added code, with the exception of leaf group candidate. Since there is no current leaf physic node that supply order property.