### PR TITLE
Slightly change buildin test folder path

### DIFF
--- a/qpmodel/Catalog.cs
+++ b/qpmodel/Catalog.cs
@@ -237,8 +237,8 @@ namespace qpmodel
             SQLStatement.ExecSQLList(string.Join("", createtables));
 
             // load tables
-            var curdir = Directory.GetCurrentDirectory();
-            var folder = $@"{curdir}/../../../../data";
+            var appbin_dir = AppContext.BaseDirectory.Substring(0, AppContext.BaseDirectory.LastIndexOf("bin"));
+            var folder = $@"{appbin_dir}/../data";
             var tables = new List<string>() {"test", "a", "b", "c", "d", "r", "ad", "bd", "cd", "dd", "ast" };
             foreach (var v in tables)
             {


### PR DESCRIPTION
Don't assume the current folder is where the dll is located, since this is not
the case in vscode, and it throws a file not found exception.

Use a relatively absolute path by reference of AppContext.BaseDirectory.

---
test