### PR TITLE
property enforcement with physical order 

### DIFF
--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -595,7 +595,6 @@ namespace qpmodel.optimizer
                 // calculate the min member for property requirement
                 if (required != null)
                     GetPropertyMinCostTuple(required, supplied);
-
             }
             Debug.Assert(!double.IsNaN(minIncCost_));
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -506,7 +506,8 @@ namespace qpmodel.optimizer
                 // cost1 require subproperty on children
                 // either propagated from required or required by physic node
                 var subprop = physic.RequiredProperty() ?? physic.PropagatedProperty(required)[i];
-                propcost += childgroup.minMember_[subprop].Item2;
+                if (subprop != null)
+                    propcost += childgroup.minMember_[subprop].Item2;
                 propchildprop[i] = subprop;
             }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -717,9 +717,9 @@ namespace qpmodel.unittest
             Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
             Assert.AreEqual("0;1;2", string.Join(";", result));
             mstr = stmt.optimizer_.PrintMemo();
-            Assert.AreEqual(7, TU.CountStr(mstr, "property"));
+            Assert.AreEqual(8, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
-                new List<string> { "PhysicStreamAgg", "PhysicOrder", "PhysicNLJoin" }));
+                new List<string> { "PhysicStreamAgg", "PhysicNLJoin", "PhysicOrder" }));
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -119,6 +119,34 @@ namespace qpmodel.unittest
             var count = CountStr(text, pattern);
             Assert.AreEqual(expected, count);
         }
+
+        public static bool CheckPlanOrder(PhysicNode physic, List<string> patternlist)
+        {
+            bool FindInLevel(List<PhysicNode> curlevel, string pattern, out List<PhysicNode> nextlevel)
+            {
+                nextlevel = new List<PhysicNode>();
+                bool output = false;
+                foreach (var node in curlevel)
+                {
+                    if (node.GetType().ToString() == "qpmodel.physic."+pattern) output = true;
+                    nextlevel.AddRange(node.children_);
+                }
+                return output;
+            }
+
+            Assert.IsNotNull(physic);
+            List<PhysicNode> curlevel = new List<PhysicNode> { physic };
+            foreach (var pattern in patternlist)
+            {
+                List<PhysicNode> nextlevel;
+                while ( !FindInLevel(curlevel, pattern, out nextlevel) )
+                {
+                    curlevel = nextlevel;
+                    if (nextlevel.Count == 0) return false;
+                }
+            }
+            return true;
+        }
     }
 
     [TestClass]
@@ -652,6 +680,47 @@ namespace qpmodel.unittest
             Assert.AreEqual(2, TU.CountStr(phyplan, "HashJoin"));
 
             Assert.IsTrue(option.optimize_.use_memo_);
+        }
+
+        [TestMethod]
+        public void TestPropertyEnforcement()
+        {
+            QueryOption option = new QueryOption();
+            option.optimize_.use_memo_ = true;
+            option.optimize_.enable_subquery_unnest_ = true;
+            option.optimize_.enable_streamagg_ = true;
+            
+            string sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2;";
+            TU.ExecuteSQL(sql, "4,1;6,4", out string phyplan, option);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicOrder"));
+
+            sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2 order by a2;";
+            TU.ExecuteSQL(sql, "4,1;6,4", out phyplan, option);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicOrder"));
+
+            var result = TU.ExecuteSQL(sql, out SQLStatement stmt, out _, option);
+            var memo = stmt.optimizer_.memoset_[0];
+            memo.CalcStats(out int tlogics, out int tphysics);
+            Assert.AreEqual(8, memo.cgroups_.Count);
+            Assert.AreEqual(16, tlogics); Assert.AreEqual(17, tphysics);
+            Assert.AreEqual("4,1;6,4", string.Join(";", result));
+            var mstr = stmt.optimizer_.PrintMemo();
+            Assert.IsTrue(mstr.Contains("Summary: 16,17"));
+
+            sql = "select a1 from a, b where a1 <= b1 group by a1 order by a1";
+            result = TU.ExecuteSQL(sql, out stmt, out phyplan, option);
+            memo = stmt.optimizer_.memoset_[0];
+            memo.CalcStats(out tlogics, out tphysics);
+            Assert.AreEqual(4, memo.cgroups_.Count);
+            Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
+            Assert.AreEqual("0;1;2", string.Join(";", result));
+            mstr = stmt.optimizer_.PrintMemo();
+            Assert.AreEqual(7, TU.CountStr(mstr, "property"));
+            Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
+                new List<string> { "PhysicStreamAgg", "PhysicOrder", "PhysicNLJoin" }));
+            
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -720,7 +720,6 @@ namespace qpmodel.unittest
             Assert.AreEqual(7, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
                 new List<string> { "PhysicStreamAgg", "PhysicOrder", "PhysicNLJoin" }));
-            
         }
     }
 


### PR DESCRIPTION
Updated from #159, some minor modifications are made.

The major change is making the property enforcement part to follow the original logic of finding the minimum cost member. The original way was member being looped through and inclusive cost for physical member is computed by summing its cost with the cost of all the members. The minimum cost and the corresponding member is recorded for each group. This enabled copy out tree to acquire the minimum cost member from top to down.
However, with property requirement added into the process, the property required on this group and the property required on the child groups need to be taken into consideration. Meaning that a single cost and member is no long sufficient. A dictionary is attached to the group, recording the different cost/member for each property requirement.
The calculation is trivial when property requirement on current group is null, we simply look for the minimum inclusive cost member. Thus, here we focus on not null property requirement.

When there are required property, there are three mutually exclusive cases for any member:
1) property directly supplied by the member
2) property is able to propagate to child
3) property is neither supplied nor propagated

Another attribute of the member is whether there is property required directly by the member. We assume that if the member has property requirement, then it cannot have the ability to propagate property.
With this in consideration, there are two situation where some property is required on children of the member:
property is propagated or property is required by the member.

Therefore, two (at most) costs are computed for each member of the group:
Cost0: no property on children
Cost1: property requirement on children

Also, two lists are maintained for the group:
List0: any member (no property requirement)
List1: members that the required property can be supplied (either through propagation or direct supply)

Combining property supply and property required by this current member, there are a total of 5 cases:
1.1) property directly supplied by member/ no property required by member--> add cost0 to both list0 and list1
1.2) property directly supplied by member/ there is property required by member--> add cost1 to both list0 and list1
2) property able to propagate to child--> add cost0 to list 0 and add cost1 to list1
3.1) property is neither supplied nor propagated/ no property required by member--> add cost0 to list0
3.2) property is neither supplied nor propagated/ there is property required by member--> add cost1 to list0
These 5 cases can serve as a partition for all the members, mutually exclusive while covering.

After members are looped through to get list0 and list1, find the min inclusive cost member for different property requirement and record in the dictionary. For no requirement, simply find the minimum cost in list0. For some property requirement, take the no requirement minimum, enforce the property and use it as a starting point. Loop through list1 and compare to get the minimum cost/member that satisfy the required property. Also record this in the dictionary.

The property requirement for children is recorded as an attribute in each member. This is used when copying out the physical plan. With this information, we know which member from the dictionary should be used.