### PR TITLE
Fix property enforcement cost calculation

### DIFF
--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -163,7 +163,7 @@ namespace qpmodel.physic
             children_.ForEach(x =>
             {
                 if (x is PhysicMemoRef xp)
-                    incCost += xp.Group().minMember_[new PhysicProperty()].cost;
+                    incCost += xp.Group().nullPropertyMinIncCost;
                 else
                     incCost += x.InclusiveCost();
             });

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -195,10 +195,10 @@ namespace qpmodel.physic
         //
         // what property current node requires to implment it
         //      for example, StreamAgg requires Sort on grouping keys
-        public virtual PhysicProperty RequiredProperty() => null;
+        public virtual PhysicProperty RequiredProperty() => new PhysicProperty();
         // what property current node can supply
         //      for example, StreamAgg can supply Sort on grouping keys
-        public virtual PhysicProperty SuppiedProperty() => null;
+        public virtual PhysicProperty SuppiedProperty() => new PhysicProperty();
         // requirements of each children node if propogate the property
         //      for example, NLJ sort order requires outer node the same order
         public virtual List<PhysicProperty> PropagatedProperty(PhysicProperty property)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -163,7 +163,7 @@ namespace qpmodel.physic
             children_.ForEach(x =>
             {
                 if (x is PhysicMemoRef xp)
-                    incCost += xp.Group().minIncCost_;
+                    incCost += xp.Group().minMember_[new PhysicProperty()].cost;
                 else
                     incCost += x.InclusiveCost();
             });

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -595,7 +595,6 @@ namespace qpmodel.optimizer
                 // calculate the min member for property requirement
                 if (required != null)
                     GetPropertyMinCostTuple(required, supplied);
-
             }
             Debug.Assert(!double.IsNaN(minIncCost_));
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -309,7 +309,6 @@ namespace qpmodel.optimizer
             get { return minMember_[PhysicProperty.nullprop].cost; }
         }
 
-
         // debug info
         internal Memo memo_;
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -506,7 +506,8 @@ namespace qpmodel.optimizer
                 // cost1 require subproperty on children
                 // either propagated from required or required by physic node
                 var subprop = physic.RequiredProperty() ?? physic.PropagatedProperty(required)[i];
-                propcost += childgroup.minMember_[subprop].Item2;
+                if (subprop != null)
+                    propcost += childgroup.minMember_[subprop].Item2;
                 propchildprop[i] = subprop;
             }
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -433,12 +433,6 @@ namespace qpmodel.optimizer
             explored_ = true;
         }
 
-        // propagate the property requirement from the top
-        public void PropagateProperty(PhysicProperty property)
-        {
-            return;
-        }
-
         // scan through the member list and return the least inclusive cost member
         //  since this procedure is for leaf nodes only, inclsuve cost equals cost
         //

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -717,9 +717,9 @@ namespace qpmodel.unittest
             Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
             Assert.AreEqual("0;1;2", string.Join(";", result));
             mstr = stmt.optimizer_.PrintMemo();
-            Assert.AreEqual(7, TU.CountStr(mstr, "property"));
+            Assert.AreEqual(8, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
-                new List<string> { "PhysicStreamAgg", "PhysicOrder", "PhysicNLJoin" }));
+                new List<string> { "PhysicStreamAgg", "PhysicNLJoin", "PhysicOrder" }));
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -707,13 +707,13 @@ namespace qpmodel.unittest
             var mstr = stmt.optimizer_.PrintMemo();
             Assert.IsTrue(mstr.Contains("Summary: 16,17"));
 
-            sql = "select a1 from a, b where a1 <= b1 group by a1 order by a1";
+            sql = "select a1 from a, b where a1 <= b1 and a2 = 2 group by a1 order by a1";
             result = TU.ExecuteSQL(sql, out stmt, out phyplan, option);
             memo = stmt.optimizer_.memoset_[0];
             memo.CalcStats(out tlogics, out tphysics);
             Assert.AreEqual(4, memo.cgroups_.Count);
             Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
-            Assert.AreEqual("0;1;2", string.Join(";", result));
+            Assert.AreEqual("1", string.Join(";", result));
             mstr = stmt.optimizer_.PrintMemo();
             Assert.AreEqual(8, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -119,6 +119,34 @@ namespace qpmodel.unittest
             var count = CountStr(text, pattern);
             Assert.AreEqual(expected, count);
         }
+
+        public static bool CheckPlanOrder(PhysicNode physic, List<string> patternlist)
+        {
+            bool FindInLevel(List<PhysicNode> curlevel, string pattern, out List<PhysicNode> nextlevel)
+            {
+                nextlevel = new List<PhysicNode>();
+                bool output = false;
+                foreach (var node in curlevel)
+                {
+                    if (node.GetType().ToString() == "qpmodel.physic."+pattern) output = true;
+                    nextlevel.AddRange(node.children_);
+                }
+                return output;
+            }
+
+            Assert.IsNotNull(physic);
+            List<PhysicNode> curlevel = new List<PhysicNode> { physic };
+            foreach (var pattern in patternlist)
+            {
+                List<PhysicNode> nextlevel;
+                while ( !FindInLevel(curlevel, pattern, out nextlevel) )
+                {
+                    curlevel = nextlevel;
+                    if (nextlevel.Count == 0) return false;
+                }
+            }
+            return true;
+        }
     }
 
     [TestClass]
@@ -652,6 +680,47 @@ namespace qpmodel.unittest
             Assert.AreEqual(2, TU.CountStr(phyplan, "HashJoin"));
 
             Assert.IsTrue(option.optimize_.use_memo_);
+        }
+
+        [TestMethod]
+        public void TestPropertyEnforcement()
+        {
+            QueryOption option = new QueryOption();
+            option.optimize_.use_memo_ = true;
+            option.optimize_.enable_subquery_unnest_ = true;
+            option.optimize_.enable_streamagg_ = true;
+            
+            string sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2;";
+            TU.ExecuteSQL(sql, "4,1;6,4", out string phyplan, option);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicOrder"));
+
+            sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2 order by a2;";
+            TU.ExecuteSQL(sql, "4,1;6,4", out phyplan, option);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicOrder"));
+
+            var result = TU.ExecuteSQL(sql, out SQLStatement stmt, out _, option);
+            var memo = stmt.optimizer_.memoset_[0];
+            memo.CalcStats(out int tlogics, out int tphysics);
+            Assert.AreEqual(8, memo.cgroups_.Count);
+            Assert.AreEqual(16, tlogics); Assert.AreEqual(17, tphysics);
+            Assert.AreEqual("4,1;6,4", string.Join(";", result));
+            var mstr = stmt.optimizer_.PrintMemo();
+            Assert.IsTrue(mstr.Contains("Summary: 16,17"));
+
+            sql = "select a1 from a, b where a1 <= b1 group by a1 order by a1";
+            result = TU.ExecuteSQL(sql, out stmt, out phyplan, option);
+            memo = stmt.optimizer_.memoset_[0];
+            memo.CalcStats(out tlogics, out tphysics);
+            Assert.AreEqual(4, memo.cgroups_.Count);
+            Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
+            Assert.AreEqual("0;1;2", string.Join(";", result));
+            mstr = stmt.optimizer_.PrintMemo();
+            Assert.AreEqual(7, TU.CountStr(mstr, "property"));
+            Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
+                new List<string> { "PhysicStreamAgg", "PhysicOrder", "PhysicNLJoin" }));
+            
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -720,7 +720,6 @@ namespace qpmodel.unittest
             Assert.AreEqual(7, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
                 new List<string> { "PhysicStreamAgg", "PhysicOrder", "PhysicNLJoin" }));
-            
         }
     }
 


### PR DESCRIPTION
1) Modify minIncCost of group:
    Change its name to nullPropertyMinIncCost to represent the real meaning, and only initialize the get method of that member.
2) Fix cost calculation error 
    This error was caused by member referring to the same object, so later changes in the object affect the used object. Problem solved by creating new object for member associated with cost1.
3) Modify unittest
    Adjust one of the property enforcement unittest to force the optimizer push order node below PNLJoin.
4) Change null property
    Create a static member in PhysicProperty to represent null property. This avoid multiple call of default property constructor.