### PR TITLE
Support ANTLR4 and auto generation csharp files

### DIFF
--- a/qpmodel/qpmodel.csproj
+++ b/qpmodel/qpmodel.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Antlr4UseCSharpGenerator>True</Antlr4UseCSharpGenerator>
     <OutputType>Exe</OutputType>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
@@ -39,10 +40,11 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Antlr4 Update="SQLite.g4">
+    <Antlr4 Include="SQLite.g4">
       <Generator>MSBuild:Compile</Generator>
       <CustomToolNamespace>qpmodel.sqlparser</CustomToolNamespace>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetLanguage>CSharp</TargetLanguage>
     </Antlr4>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The csharp support for ANTLR4 is still experimental and need to be enabled
manually with some properties in csproj file.

This patch prevent the occasionally wrong generated java files in obj folder.