### PR TITLE
Modify redistribution execution

### DIFF
--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1879,12 +1879,16 @@ namespace qpmodel.physic
             var context = context_ as DistributedContext;
             int dop = context.option_.optimize_.query_dop_;
 
+            var distributeby = (logic_ as LogicRedistribute).distributeby_;
+
             string s = child_().Exec(r =>
             {
                 string srccode = null;
                 if (!context.option_.optimize_.use_codegen_)
                 {
-                    var sendtoMachine = r[0].GetHashCode() % dop;
+                    // hash by distribution keys
+                    var key = KeyList.ComputeKeys(context_, distributeby, r);
+                    var sendtoMachine = key.GetHashCode() % dop;
                     upChannels_[sendtoMachine].Send(r);
 
                     var tid = Thread.CurrentThread.ManagedThreadId;

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2090,6 +2090,18 @@ namespace qpmodel.unittest
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
             Assert.AreEqual(6, TU.CountStr(phyplan, "Redistribute"));
             Assert.AreEqual(1, TU.CountStr(phyplan, "70 threads"));
+
+            // ensure redistribution can shuffle by expression
+            sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";
+            TU.ExecuteSQL(sql, "1,2", out phyplan);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+
+            // no output if by previous r[0] method for redistribution
+            sql = "select d2, a1 from ad, dd where d3=a1 order by d2;";
+            TU.ExecuteSQL(sql, "1,2", out phyplan);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
         }
     }
 


### PR DESCRIPTION
Make redistribution to distribute by the target expressions.

Previously, redistribution automatically redistribute by the first expression from child output (r[0]). 
Now the distributeby expression list is extracted from parent join logic node and record in logic redistribute node. This information is later passed to physic node execution. Redistribution is for list of distribution.