### PR TITLE
Change error message for scalar subquery returning more than one row

### DIFF
--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -133,6 +133,11 @@ namespace qpmodel
 
             string sql = "";
 
+            if (args.Length != 0)
+            {
+                sql = args[0];
+            }
+
             if (false)
             {
                 JOBench.CreateTables();
@@ -165,7 +170,11 @@ namespace qpmodel
             }
 
         doit:
-            sql = "select * from a tablesample row (2)";
+
+            if (sql.Length == 0)
+            {
+                sql = "select * from a tablesample row (2);";
+            }
 
             var datetime = new DateTime();
             datetime = DateTime.Now;

--- a/qpmodel/subquery.cs
+++ b/qpmodel/subquery.cs
@@ -578,7 +578,7 @@ namespace qpmodel.logic
                         bool foundDups = foundOneMatch && filter != null;
 
                         if (foundDups)
-                            throw new SemanticExecutionException("more than one row matched");
+                            throw new SemanticExecutionException("subquery must return only one row");
                         foundOneMatch = true;
 
                         // there is at least one match, mark true

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -978,6 +978,9 @@ namespace qpmodel.unittest
             sql = "select a1,a1,a3,a3, (select * from b where b2=2) from a where a1>1"; // * handling
             result = ExecuteSQL(sql); Assert.IsNull(result);
             Assert.IsTrue(TU.error_.Contains("one"));
+            sql = "select * from a where a1 > (select b2 from b where a1<>b1)";
+            result = ExecuteSQL(sql); Assert.IsNull(result);
+            Assert.IsTrue(TU.error_.Contains("subquery must return only one row"));
 
             // subquery in selection
             sql = "select a1,a1,a3,a3, (select b3 from b where b2=2) from a where a1>1"; TU.ExecuteSQL(sql, "2,2,4,4,3");


### PR DESCRIPTION
…(issue 35, first item)

Main will take a properly SQL statement as argument and will execute it instead of the hard coded