### PR TITLE
Remove unnecessary redistribution node

### DIFF
--- a/qpmodel/DataType.cs
+++ b/qpmodel/DataType.cs
@@ -260,6 +260,7 @@ namespace qpmodel.expr
             tableSample_ = tableSample;
         }
 
+        public bool IsDopMatch(QueryOption option) => Table().distributions_.Count == option.optimize_.query_dop_;
         public bool IsDistributed() => Table().distributedBy_ != null;
         public bool IsDistributionMatch(List<Expr> keys, QueryOption option)
         {
@@ -268,7 +269,7 @@ namespace qpmodel.expr
                 return true;
             else
             {
-                Debug.Assert(Table().distributions_.Count == option.optimize_.query_dop_);
+                Debug.Assert(IsDopMatch(option));
                 // table distribution is by one column, check match
                 if (keys.Count == 1 && keys[0] is ColExpr key)
                     if (key.colName_ == Table().distributedBy_.name_)

--- a/qpmodel/DataType.cs
+++ b/qpmodel/DataType.cs
@@ -261,6 +261,20 @@ namespace qpmodel.expr
         }
 
         public bool IsDistributed() => Table().distributedBy_ != null;
+        public bool IsDistributionMatch(List<Expr> keys)
+        {
+            // check if the list of expressions match
+            // the distribution of this table
+            if (!IsDistributed())
+                return true;
+            else
+            {
+                if (keys.Count == 1 && keys[0] is ColExpr key)
+                    if (key.colName_ == Table().distributedBy_.name_)
+                        return true;
+            }
+            return false;
+        }
         public TableDef Table() => Catalog.systable_.Table(relname_);
 
         public override string ToString()

--- a/qpmodel/DataType.cs
+++ b/qpmodel/DataType.cs
@@ -263,20 +263,19 @@ namespace qpmodel.expr
         public bool IsDistributed() => Table().distributedBy_ != null;
         public bool IsDistributionMatch(List<Expr> keys, QueryOption option)
         {
-            // check if the list of expressions match
-            // the distribution of this table
+            // only check match when it is distributed deployment
             if (!IsDistributed())
                 return true;
             else
             {
-                // check if number of partitions agree
-                if (option.optimize_.query_dop_ == Table().distributions_.Count)
-                    // table distribution is by one column, check match
-                    if (keys.Count == 1 && keys[0] is ColExpr key)
-                        if (key.colName_ == Table().distributedBy_.name_)
-                            return true;
+                Debug.Assert(Table().distributions_.Count == option.optimize_.query_dop_);
+                // table distribution is by one column, check match
+                if (keys.Count == 1 && keys[0] is ColExpr key)
+                    if (key.colName_ == Table().distributedBy_.name_)
+                        return true;
+
+                return false;
             }
-            return false;
         }
         public TableDef Table() => Catalog.systable_.Table(relname_);
 

--- a/qpmodel/DataType.cs
+++ b/qpmodel/DataType.cs
@@ -261,7 +261,7 @@ namespace qpmodel.expr
         }
 
         public bool IsDistributed() => Table().distributedBy_ != null;
-        public bool IsDistributionMatch(List<Expr> keys)
+        public bool IsDistributionMatch(List<Expr> keys, QueryOption option)
         {
             // check if the list of expressions match
             // the distribution of this table
@@ -269,9 +269,12 @@ namespace qpmodel.expr
                 return true;
             else
             {
-                if (keys.Count == 1 && keys[0] is ColExpr key)
-                    if (key.colName_ == Table().distributedBy_.name_)
-                        return true;
+                // check if number of partitions agree
+                if (option.optimize_.query_dop_ == Table().distributions_.Count)
+                    // table distribution is by one column, check match
+                    if (keys.Count == 1 && keys[0] is ColExpr key)
+                        if (key.colName_ == Table().distributedBy_.name_)
+                            return true;
             }
             return false;
         }

--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -517,10 +517,9 @@ namespace qpmodel.logic
                 tableContained_ = SetOp.Union(l.tableContained_, r.tableContained_);
             }
         }
-        public LogicJoin(LogicNode l, LogicNode r, Expr filter, bool createkey = true) : this(l, r)
+        public LogicJoin(LogicNode l, LogicNode r, Expr filter) : this(l, r)
         {
             filter_ = filter;
-            if (createkey) CreateKeyList(false);
         }
 
         public bool IsInnerJoin() => type_ == JoinType.Inner && !(this is LogicMarkJoin);

--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -96,11 +96,11 @@ namespace qpmodel.logic
                 case LogicJoin lj:
                     LogicNode leftshuffle, rightshuffle;
                     // when distribution match join keys, redistribution is not necessary
-                    if (lchild_() is LogicScanTable ls && ls.tabref_.IsDistributionMatch(lj.leftKeys_))
+                    if (lchild_() is LogicScanTable ls && ls.tabref_.IsDistributionMatch(lj.leftKeys_, option))
                         leftshuffle = lchild_();
                     else
                         leftshuffle = new LogicRedistribute(lchild_().MarkExchange(option), lj.leftKeys_);
-                    if (rchild_() is LogicScanTable rs && rs.tabref_.IsDistributionMatch(lj.rightKeys_))
+                    if (rchild_() is LogicScanTable rs && rs.tabref_.IsDistributionMatch(lj.rightKeys_, option))
                         rightshuffle = rchild_();
                     else
                         rightshuffle = new LogicRedistribute(rchild_().MarkExchange(option), lj.rightKeys_);

--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -96,11 +96,11 @@ namespace qpmodel.logic
                 case LogicJoin lj:
                     LogicNode leftshuffle, rightshuffle;
                     // when distribution match join keys, redistribution is not necessary
-                    if (lchild_() is LogicScanTable ls && !ls.tabref_.IsDistributionMatch(lj.leftKeys_))
+                    if (lchild_() is LogicScanTable ls && ls.tabref_.IsDistributionMatch(lj.leftKeys_))
                         leftshuffle = lchild_();
                     else
                         leftshuffle = new LogicRedistribute(lchild_().MarkExchange(option), lj.leftKeys_);
-                    if (rchild_() is LogicScanTable rs && !rs.tabref_.IsDistributionMatch(lj.rightKeys_))
+                    if (rchild_() is LogicScanTable rs && rs.tabref_.IsDistributionMatch(lj.rightKeys_))
                         rightshuffle = rchild_();
                     else
                         rightshuffle = new LogicRedistribute(rchild_().MarkExchange(option), lj.rightKeys_);

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1432,8 +1432,6 @@ namespace qpmodel.physic
         {
             var table = (logic_ as LogicInsert).targetref_.Table();
             var dop = context_.option_.optimize_.query_dop_;
-            if (table.distributedBy_ != null)
-                Debug.Assert(dop == table.distributions_.Count);
 
             child_().Exec(l =>
             {

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1879,12 +1879,16 @@ namespace qpmodel.physic
             var context = context_ as DistributedContext;
             int dop = context.option_.optimize_.query_dop_;
 
+            var distributeby = (logic_ as LogicRedistribute).distributeby_;
+
             string s = child_().Exec(r =>
             {
                 string srccode = null;
                 if (!context.option_.optimize_.use_codegen_)
                 {
-                    var sendtoMachine = r[0].GetHashCode() % dop;
+                    // hash by distribution keys
+                    var key = KeyList.ComputeKeys(context_, distributeby, r);
+                    var sendtoMachine = key.GetHashCode() % dop;
                     upChannels_[sendtoMachine].Send(r);
 
                     var tid = Thread.CurrentThread.ManagedThreadId;

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1431,11 +1431,13 @@ namespace qpmodel.physic
 
         public override string Exec(Func<Row, string> callback)
         {
+            var table = (logic_ as LogicInsert).targetref_.Table();
             var dop = context_.option_.optimize_.query_dop_;
+            if (table.distributedBy_ != null)
+                Debug.Assert(dop == table.distributions_.Count);
 
             child_().Exec(l =>
             {
-                var table = (logic_ as LogicInsert).targetref_.Table();
                 int partid = 0;
                 // insert data row according to distribution column
                 if (table.distributedBy_ != null)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1431,12 +1431,18 @@ namespace qpmodel.physic
 
         public override string Exec(Func<Row, string> callback)
         {
+            var dop = context_.option_.optimize_.query_dop_;
+
             child_().Exec(l =>
             {
                 var table = (logic_ as LogicInsert).targetref_.Table();
                 int partid = 0;
+                // insert data row according to distribution column
                 if (table.distributedBy_ != null)
-                    partid = 0;
+                {
+                    var distrord = table.distributedBy_.ordinal_;
+                    partid = l[distrord].GetHashCode() % dop;
+                }
                 table.distributions_[partid].heap_.Add(l);
                 return null;
             });

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -639,7 +639,6 @@ namespace qpmodel.physic
         public override List<PhysicProperty> PropagatedProperty(PhysicProperty property)
         {
             var logic = logic_ as LogicJoin;
-            logic.CreateKeyList(false); // ensure existence of left/right keys
 
             if (property != null && property is SortOrderProperty sort)
                 if (IsExprMatch(sort, logic.leftKeys_))

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -866,7 +866,7 @@ namespace qpmodel.logic
 
         public DataSet join(DataSet other, string condition)
         {
-            logicPlan_ = new LogicJoin(logicPlan_, other.logicPlan_, parseExpr(condition), false);
+            logicPlan_ = new LogicJoin(logicPlan_, other.logicPlan_, parseExpr(condition));
             return this;
         }
 

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -866,7 +866,7 @@ namespace qpmodel.logic
 
         public DataSet join(DataSet other, string condition)
         {
-            logicPlan_ = new LogicJoin(logicPlan_, other.logicPlan_, parseExpr(condition));
+            logicPlan_ = new LogicJoin(logicPlan_, other.logicPlan_, parseExpr(condition), false);
             return this;
         }
 

--- a/qpmodel/stmtDML.cs
+++ b/qpmodel/stmtDML.cs
@@ -203,6 +203,7 @@ namespace qpmodel.dml
                 new LogicInsert(targetref_, new LogicResult(vals_)) :
                 new LogicInsert(targetref_, select_.CreatePlan());
             distributed_ = select_ is null ? false : select_.distributed_;
+            if (distributed_) Debug.Assert(targetref_.IsDopMatch(queryOpt_));
             return logicPlan_;
         }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2090,6 +2090,18 @@ namespace qpmodel.unittest
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
             Assert.AreEqual(6, TU.CountStr(phyplan, "Redistribute"));
             Assert.AreEqual(1, TU.CountStr(phyplan, "70 threads"));
+
+            // ensure redistribution can shuffle by expression
+            sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";
+            TU.ExecuteSQL(sql, "1,2", out phyplan);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+
+            // no output if by previous r[0] method for redistribution
+            sql = "select d2, a1 from ad, dd where d3=a1 order by d2;";
+            TU.ExecuteSQL(sql, "1,2", out phyplan);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2109,14 +2109,6 @@ namespace qpmodel.unittest
             TU.ExecuteSQL(sql, "1,3", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
             Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
-
-            // check redistribution for different partition number
-            var option = new QueryOption();
-            option.optimize_.query_dop_ = 3;
-            sql = "select a1,b1 from ad, b where a1=b1 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan, option);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2109,6 +2109,14 @@ namespace qpmodel.unittest
             TU.ExecuteSQL(sql, "1,3", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
             Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+
+            // check redistribution for different partition number
+            var option = new QueryOption();
+            option.optimize_.query_dop_ = 3;
+            sql = "select a1,b1 from ad, b where a1=b1 order by a1;";
+            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan, option);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
         }
     }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2076,11 +2076,11 @@ namespace qpmodel.unittest
             var sql = "select a1,b1 from ad, b where a1=b1 order by a1;";
             TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+            Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
             sql = "select a1,b1 from ad, bd where a1=b1 order by a1;";
             TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+            Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
             sql = "select a2,b2,c2 from ad, bd, cd where a2=b2 and c2 = b2 order by c2";
             TU.ExecuteSQL(sql, "1,1,1;2,2,2;3,3,3", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
@@ -2100,6 +2100,10 @@ namespace qpmodel.unittest
             // no output if by previous r[0] method for redistribution
             sql = "select d2, a1 from ad, dd where d3=a1 order by d2;";
             TU.ExecuteSQL(sql, "1,2", out phyplan);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+            sql = "select d2, a2 from ad, dd where d4=a2 order by d2;";
+            TU.ExecuteSQL(sql, "1,3", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
             Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
         }


### PR DESCRIPTION
Previously join force redistribution on top of table scan for distributed table, but it is not necessary when the key match the distribution.
Now the match is checked, only when the data distribution does not agree with the join keys, a redistribution node is added. 

Also, data insertion is modified. Previously, even for distributed table all the rows are added onto the first partition (0), but with distributed table scan all have redistribution node on top, it is still working. Now redistribution may not be present, the original insertion must follow the distributed column.

Additional unittest is added to verify the change. 