### PR TITLE
New property enforcement framework

### DIFF
--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -301,7 +301,6 @@ namespace qpmodel.optimizer
     //
     public class CMemoGroup
     {
-        
         // insertion order in memo
         public int memoid_;
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -511,6 +511,7 @@ namespace qpmodel.optimizer
 
                 if (member.physic_.IsPropertySatisfied(required, out var childprops))
                 {
+                    member.propertypairs_.Add(required, childprops);
                     double cost = member.physic_.Cost();
                     if (!isleaf)
                     {

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -763,20 +763,20 @@ namespace qpmodel.unittest
             var memo = stmt.optimizer_.memoset_[0];
             memo.CalcStats(out int tlogics, out int tphysics);
             Assert.AreEqual(8, memo.cgroups_.Count);
-            Assert.AreEqual(16, tlogics); Assert.AreEqual(17, tphysics);
+            Assert.AreEqual(16, tlogics); Assert.AreEqual(20, tphysics);
             Assert.AreEqual("4,1;6,4", string.Join(";", result));
             var mstr = stmt.optimizer_.PrintMemo();
-            Assert.IsTrue(mstr.Contains("Summary: 16,17"));
+            Assert.IsTrue(mstr.Contains("Summary: 16,20"));
 
             sql = "select a1 from a, b where a1 <= b1 and a2 = 2 group by a1 order by a1";
             result = TU.ExecuteSQL(sql, out stmt, out phyplan, option);
             memo = stmt.optimizer_.memoset_[0];
             memo.CalcStats(out tlogics, out tphysics);
             Assert.AreEqual(4, memo.cgroups_.Count);
-            Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
+            Assert.AreEqual(5, tlogics); Assert.AreEqual(9, tphysics);
             Assert.AreEqual("1", string.Join(";", result));
             mstr = stmt.optimizer_.PrintMemo();
-            Assert.AreEqual(8, TU.CountStr(mstr, "property"));
+            Assert.AreEqual(7, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
                 new List<string> { "PhysicStreamAgg", "PhysicNLJoin", "PhysicOrder" }));
         }


### PR DESCRIPTION
This new version of property enforcement serves as the first step for adding distribution property into memo optimizer.

Previously, for each physical member, there are two costs: cost0 and cost1, which generally corresponds to null property supplied and property supplied. Property can be either directly supplied or supplied through propagation. This can work when only order is considered as property, meaning that a property can be either supplied or not. This binary determination results in the maximum of two different possibilities for each physical member (cost0 and cost1).
However, when distribution is added, property requirement can be partially supplied by a physical member, leading to more than two possible paths. This means the comparison between the inclusive cost of different enforcement nodes will become more complicated.

Given these circumstances, a list of pathways is maintained as an attribute for each member. This keep track of the different supported property and required property pairs of that particular node.
The new method includes enforcement nodes as members and they are created when certain requirement is passed to the group when calculating the min cost member. Hence, the calculation is no longer for each group, but for each group-property pair, and the optimal member for each pair can only be determined after all its child pairs are determined.

Another major change is on how to determine the relationship between physic node and property. The new physic node-property interface is no longer returning the required property, supplied property and propagated property individually, but doing it according to the requested property. If the requirement is satisfied, then the corresponding child requirements are returned. 
The property that are less strict is directly derived from the current requirement rather than suggested by possible supplied property of physic node. For each required property, if there is order part, then sorted node is added to the member list as enforcement node, (if there is distribution requirement, for singleton, gather is added, for hash distribution, redistribution is added since redistribution, similar to gather, does not need to know the distribution of the child.) In other word, property is always required, not supplied.
