### PR TITLE
[bug] race condition in emulated distributed execution #173

### DIFF
--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -509,6 +509,7 @@ namespace qpmodel.logic
         public List<Expr> leftKeys_ = new List<Expr>();
         public List<Expr> rightKeys_ = new List<Expr>();
         internal List<string> ops_ = new List<string>();
+        internal bool isRecreated_ = false;
 
         public override string ToString() => $"({lchild_()} {type_} {rchild_()})";
         public override string ExplainInlineDetails() { return type_ == JoinType.Inner ? "" : type_.ToString(); }
@@ -553,6 +554,25 @@ namespace qpmodel.logic
             filter_ = filter_.AddAndFilter(filter);
             CreateKeyList(false);
             return true;
+        }
+
+        internal void RecreateKeyList(bool canReUse)
+        {
+            if (isRecreated_)
+            {
+                return;
+            }
+
+            lock(this)
+            {
+                if (isRecreated_)
+                {
+                    return;
+                }
+
+                CreateKeyList(canReUse);
+                isRecreated_ = true;
+            }
         }
 
         internal void CreateKeyList(bool canReUse = true)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -740,7 +740,7 @@ namespace qpmodel.physic
             // because earlier optimization time keylist may have wrong bindings
             //
             var logic = logic_ as LogicJoin;
-            logic.CreateKeyList(false);
+            logic.RecreateKeyList(false);
             if (context.option_.optimize_.use_codegen_)
             {
                 context.code_ += $@"var hm{_} = new Dictionary<KeyList, List<TaggedRow>>();";

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2221,72 +2221,75 @@ namespace qpmodel.unittest
         public void Redistribute()
         {
             // needs order by to force result order
-            var phyplan = "";
-            var sql = "select a1,b1 from ad, b where a1=b1 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a1,b1 from ad, bd where a1=b1 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a2,b2,c2 from ad, bd, cd where a2=b2 and c2 = b2 order by c2";
-            TU.ExecuteSQL(sql, "1,1,1;2,2,2;3,3,3", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a2,b2,c2,d2 from ad, bd, cd, dd where a2=b2 and c2 = b2 and c2=d2 order by b2";
-            TU.ExecuteSQL(sql, "1,1,1,1;2,2,2,2;2,2,2,2;3,3,3,3", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(6, TU.CountStr(phyplan, "Redistribute"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "70 threads"));
+            for (int i = 0; i < 3; i++)
+            {
+                var phyplan = "";
+                var sql = "select a1,b1 from ad, b where a1=b1 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a1,b1 from ad, bd where a1=b1 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a2,b2,c2 from ad, bd, cd where a2=b2 and c2 = b2 order by c2";
+                TU.ExecuteSQL(sql, "1,1,1;2,2,2;3,3,3", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a2,b2,c2,d2 from ad, bd, cd, dd where a2=b2 and c2 = b2 and c2=d2 order by b2";
+                TU.ExecuteSQL(sql, "1,1,1,1;2,2,2,2;2,2,2,2;3,3,3,3", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(6, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "70 threads"));
 
-            // ensure redistribution can shuffle by expression
-            sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";
-            TU.ExecuteSQL(sql, "1,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                // ensure redistribution can shuffle by expression
+                sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";
+                TU.ExecuteSQL(sql, "1,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
 
-            // no output if by previous r[0] method for redistribution
-            sql = "select d2, a1 from ad, dd where d3=a1 order by d2;";
-            TU.ExecuteSQL(sql, "1,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select d2, a2 from ad, dd where d4=a2 order by d2;";
-            TU.ExecuteSQL(sql, "1,3", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                // no output if by previous r[0] method for redistribution
+                sql = "select d2, a1 from ad, dd where d3=a1 order by d2;";
+                TU.ExecuteSQL(sql, "1,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select d2, a2 from ad, dd where d4=a2 order by d2;";
+                TU.ExecuteSQL(sql, "1,3", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
 
-            // mixed with replicated table
-            sql = "select a1,b1 from ad, br where a1=b1 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a1,b1 from ad, br where a2=b2 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute")); // FIXME: redistribution is not needed if replica is on the build side
-            sql = "select a1,b1 from ar, br where a2=b2 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
+                // mixed with replicated table
+                sql = "select a1,b1 from ad, br where a1=b1 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a1,b1 from ad, br where a2=b2 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute")); // FIXME: redistribution is not needed if replica is on the build side
+                sql = "select a1,b1 from ar, br where a2=b2 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
 
-            // mixed with rounbrobin table
-            sql = "select a1,b1 from ad, brb where a1=b1 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a1,b1 from ad, brb where a2=b2 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a1,b1 from arb, brb where a2=b2 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
-            sql = "select a1,b1 from ar, brb where a2=b2 order by a1;";
-            TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+                // mixed with rounbrobin table
+                sql = "select a1,b1 from ad, brb where a1=b1 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a1,b1 from ad, brb where a2=b2 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a1,b1 from arb, brb where a2=b2 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                sql = "select a1,b1 from ar, brb where a2=b2 order by a1;";
+                TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+            }
         }
     }
 


### PR DESCRIPTION
loop @Redistribute() 3 times in UnitTest.
The @leftKeys_ and @rightKeys_ of @LogicJoin are changed in multi-thread.
Above lists must be changed only once. @PhysicHashJoin issues
RecreateKeyList() instead of CreateKeyList() to guarantee those keys are
changed only once.