### PR TITLE
fix race condition of distributed execution

### DIFF
--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -366,7 +366,9 @@ namespace qpmodel.logic
         // 2. compute children's output by requesting reqOutput from them
         // 3. find mapping from children's output
         //
-        // this parent class implments a default one for using first child output without any change
+        // this parent class implments a default one for using first child output without any change. You can
+        // also piggy back in this method to "finalize" your logic node.
+        //
         public virtual List<int> ResolveColumnOrdinal(in List<Expr> reqOutput, bool removeRedundant = true)
         {
             List<int> ordinals = new List<int>();
@@ -551,11 +553,11 @@ namespace qpmodel.logic
         public bool AddFilter(Expr filter)
         {
             filter_ = filter_.AddAndFilter(filter);
-            CreateKeyList(false);
+            CreateKeyList();
             return true;
         }
 
-        internal void CreateKeyList(bool canReUse = true)
+        internal void CreateKeyList()
         {
             void createOneKeyList(BinExpr fb)
             {
@@ -590,17 +592,9 @@ namespace qpmodel.logic
             }
 
             // reset the old values
-            if (!canReUse)
-            {
-                leftKeys_.Clear();
-                rightKeys_.Clear();
-                ops_.Clear();
-            }
-            else
-            {
-                if (leftKeys_.Count != 0)
-                    return;
-            }
+            leftKeys_.Clear();
+            rightKeys_.Clear();
+            ops_.Clear();
 
             // cross join does not have join filter
             if (filter_ != null)
@@ -666,6 +660,7 @@ namespace qpmodel.logic
             output_ = CloneFixColumnOrdinal(reqOutput, childrenout, removeRedundant);
 
             RefreshOutputRegisteration();
+            CreateKeyList();
             return ordinals;
         }
     }

--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -509,7 +509,6 @@ namespace qpmodel.logic
         public List<Expr> leftKeys_ = new List<Expr>();
         public List<Expr> rightKeys_ = new List<Expr>();
         internal List<string> ops_ = new List<string>();
-        internal bool isRecreated_ = false;
 
         public override string ToString() => $"({lchild_()} {type_} {rchild_()})";
         public override string ExplainInlineDetails() { return type_ == JoinType.Inner ? "" : type_.ToString(); }
@@ -554,25 +553,6 @@ namespace qpmodel.logic
             filter_ = filter_.AddAndFilter(filter);
             CreateKeyList(false);
             return true;
-        }
-
-        internal void RecreateKeyList(bool canReUse)
-        {
-            if (isRecreated_)
-            {
-                return;
-            }
-
-            lock(this)
-            {
-                if (isRecreated_)
-                {
-                    return;
-                }
-
-                CreateKeyList(canReUse);
-                isRecreated_ = true;
-            }
         }
 
         internal void CreateKeyList(bool canReUse = true)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -740,7 +740,6 @@ namespace qpmodel.physic
             // because earlier optimization time keylist may have wrong bindings
             //
             var logic = logic_ as LogicJoin;
-            logic.CreateKeyList(false);
             if (context.option_.optimize_.use_codegen_)
             {
                 context.code_ += $@"var hm{_} = new Dictionary<KeyList, List<TaggedRow>>();";
@@ -1780,7 +1779,6 @@ namespace qpmodel.physic
         public PhysicNode EmulateSerialization(PhysicNode node)
         {
             var newnode = node.Clone();
-            newnode.logic_ = node.logic_.Clone();
             return newnode;
         }
         public virtual string OpenConsumer(ExecContext context) => null;

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -365,7 +365,7 @@ namespace qpmodel.physic
                 {
                     context.code_ += $"if ({filter.ExecCode(context, $"r{_}")} is true)";
                 }
-                    
+
                 context.code_ += $@"
                     {{
                         {ExecProjectCode($"r{_}")}";
@@ -578,7 +578,7 @@ namespace qpmodel.physic
                         {
                             context.code_ += $"if ({filter.ExecCode(context, $"r{_}")} is true)";
                         }
-                            
+
                         context.code_ += $@"    
                             {{
                                 foundOneMatch{_} = true;";
@@ -740,7 +740,7 @@ namespace qpmodel.physic
             // because earlier optimization time keylist may have wrong bindings
             //
             var logic = logic_ as LogicJoin;
-            logic.RecreateKeyList(false);
+            logic.CreateKeyList(false);
             if (context.option_.optimize_.use_codegen_)
             {
                 context.code_ += $@"var hm{_} = new Dictionary<KeyList, List<TaggedRow>>();";
@@ -840,7 +840,7 @@ namespace qpmodel.physic
                     else
                     {{
                         // no match for antisemi";
-                    
+
                     if (antisemi)
                     {
                         context.code_ += $@"
@@ -848,7 +848,7 @@ namespace qpmodel.physic
                         {{
                             r{_} = new Row(null, r{_});
                             {ExecProjectCode($"r{_}")}";
-                        
+
                         // generate code to @context_code_ in callback
                         callback(null);
 
@@ -1124,7 +1124,7 @@ namespace qpmodel.physic
                     Row aggvals{_} = v{_}.Value;";
 
                 FinalizeAGroupRow(context, null, null, callback);
-                
+
                 context.code_ += $@"
                 }}";
             }
@@ -1212,7 +1212,7 @@ namespace qpmodel.physic
                             {{
                                 var keys{_} = curGroupKey{_};
                                 Row aggvals{_} = curGroupRow{_};";
-                    
+
                     FinalizeAGroupRow(context, null, null, callback);
 
                     context.code_ += $@"
@@ -1568,7 +1568,7 @@ namespace qpmodel.physic
             {
                 nloops_++;
             }
-                
+
             child_().Exec(l =>
             {
                 if (context.option_.optimize_.use_codegen_)
@@ -1773,6 +1773,16 @@ namespace qpmodel.physic
             }
         }
 
+        // this function emulates a full serialization of a given physic node for network
+        // transfer purpose, so it shall include every information we'd like the receiver
+        // have, including the physic node itself and its logic node and could be more.
+        //
+        public PhysicNode EmulateSerialization(PhysicNode node)
+        {
+            var newnode = node.Clone();
+            newnode.logic_ = node.logic_.Clone();
+            return newnode;
+        }
         public virtual string OpenConsumer(ExecContext context) => null;
         public virtual string OpenProducer(ExecContext context) => null;
         public override void Open(ExecContext econtext)
@@ -1790,14 +1800,14 @@ namespace qpmodel.physic
             }
         }
 
-        public virtual void ExecConsumer(Action<Row> callback) {}
-        public virtual void ExecProducer(Action<Row> callback) {}
+        public virtual void ExecConsumer(Action<Row> callback) { }
+        public virtual void ExecProducer(Action<Row> callback) { }
         public override void Exec(Action<Row> callback)
         {
             if (asConsumer_)
             {
                 ExecConsumer(callback);
-            } 
+            }
             else
             {
                 ExecProducer(callback);
@@ -1833,14 +1843,14 @@ namespace qpmodel.physic
 
             Debug.Assert(context.machines_ != null);
             List<Thread> workers = new List<Thread>();
-            foreach(var machineId in targets)
+            foreach (var machineId in targets)
             {
                 var planId = _;
                 var wo = new WorkerObject(Thread.CurrentThread.Name,
                                         context.machines_,
                                         machineId,
                                         planId,
-                                        this.Clone(),
+                                        EmulateSerialization(this),
                                         context.option_);
                 var thread = new Thread(new ThreadStart(wo.EntryPoint));
                 thread.Name = $"Gather_{planId}@{machineId}";
@@ -1928,7 +1938,7 @@ namespace qpmodel.physic
                                     context.machines_,
                                     machineId,
                                     planId,
-                                    this.Clone(),
+                                    EmulateSerialization(this),
                                     context.option_);
             var thread = new Thread(new ThreadStart(wo.EntryPoint));
             thread.Name = $"Redis_{planId}@{machineId}";


### PR DESCRIPTION
In the real execution, we  will have to serialize all information we want the receiver side to deserialize, including physic node an logic node and could be some more. So to emulate this behavior correctly, we shall either having one copy for each participanting thread or make sure their shared copy not change. We do the second way by moving CreateKeyList() to the last step in logic join creation, instead of every physic join doing that separately.