### PR TITLE
Add distribution to physic property

### DIFF
--- a/qpmodel/DataType.cs
+++ b/qpmodel/DataType.cs
@@ -266,7 +266,7 @@ namespace qpmodel.expr
 
         public bool IsDopMatch(QueryOption option) => Table().distributions_.Count == option.optimize_.query_dop_;
         public bool IsDistributed() => Table().distMethod_ != TableDef.DistributionMethod.NonDistributed;
-        public bool IsDistributionMatch(List<Expr> keys, QueryOption option)
+        public bool IsDistributionMatch(List<Expr> keys, QueryOption option = null)
         {
             var method = Table().distMethod_;
 
@@ -275,7 +275,7 @@ namespace qpmodel.expr
                 return true;
             else
             {
-                Debug.Assert(IsDopMatch(option));
+                if (option != null) Debug.Assert(IsDopMatch(option));
 
                 // replicated always match
                 if (method == TableDef.DistributionMethod.Replicated)

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1028,9 +1028,14 @@ namespace qpmodel.physic
                 || required.IsDistributionSupplied(new DistributionProperty(logic.rightKeys_)))
             {
                 listchildprops.Add(new List<PhysicProperty> { new DistributionProperty(logic.leftKeys_), new DistributionProperty(logic.rightKeys_) });
-                listchildprops.Add(new List<PhysicProperty> { DistributionProperty.replicated, new DistributionProperty(logic.rightKeys_) });
                 listchildprops.Add(new List<PhysicProperty> { DistributionProperty.singleton, new DistributionProperty(logic.rightKeys_) });
                 listchildprops.Add(new List<PhysicProperty> { new DistributionProperty(logic.leftKeys_), DistributionProperty.singleton });
+                if (required.distribution_.disttype == DistributionType.Any)
+                {
+                    listchildprops.Add(new List<PhysicProperty> { DistributionProperty.replicated, PhysicProperty.nullprop });
+                    listchildprops.Add(new List<PhysicProperty> { DistributionProperty.singleton, new DistributionProperty(logic.rightKeys_) });
+                    listchildprops.Add(new List<PhysicProperty> { new DistributionProperty(logic.leftKeys_), DistributionProperty.singleton });
+                }
                 return true;
             }
             else

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -211,16 +211,9 @@ namespace qpmodel.physic
         {
             listchildprops = new List<List<PhysicProperty>>();
             listchildprops.Add(new List<PhysicProperty>());
-            // when there is no property requirement, it is always satisfied
-            if (required.Equals(PhysicProperty.nullprop))
-            {
-                for (int i = 0; i < children_.Count; i++)
-                    listchildprops[0].Add(PhysicProperty.nullprop);
-                return true;
-            }
             // the default is singleton with no order requirement
             // assume all the physic nodes can process singleton
-            else if (required.IsPropertySupplied(DistributionProperty.singleton))
+            if (required.IsPropertySupplied(DistributionProperty.singleton))
             {
                 for (int i = 0; i < children_.Count; i++)
                     listchildprops[0].Add(DistributionProperty.singleton);
@@ -1642,11 +1635,11 @@ namespace qpmodel.physic
                 {
                     int partid = 0;
                     if (table.distMethod_ == TableDef.DistributionMethod.Roundrobin)
-                        partid = Catalog.rand_.Next() % nparts;
+                        partid = Utils.mod(Catalog.rand_.Next(), nparts);
                     else if (table.distMethod_ == TableDef.DistributionMethod.Distributed)
                     {
                         var distrord = table.distributedBy_.ordinal_;
-                        partid = l[distrord].GetHashCode() % nparts;
+                        partid = Utils.mod(l[distrord].GetHashCode(), nparts);
                     }
                     table.distributions_[partid].heap_.Add(l);
                 }
@@ -2101,7 +2094,7 @@ namespace qpmodel.physic
                 {
                     // hash by distribution keys
                     var key = KeyList.ComputeKeys(context_, distributeby, r);
-                    var sendtoMachine = key.GetHashCode() % dop;
+                    var sendtoMachine = Utils.mod(key.GetHashCode(), dop);
                     upChannels_[sendtoMachine].Send(r);
 
 #if debug

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1140,6 +1140,7 @@ namespace qpmodel.physic
         public override bool IsPropertySatisfied(PhysicProperty required, out List<List<PhysicProperty>> listchildprops)
         {
             listchildprops = new List<List<PhysicProperty>>();
+            // hash agg can only support singleton with no order requirement by default
             if (required.Equals(DistributionProperty.singleton))
             {
                 listchildprops.Add(new List<PhysicProperty> { DistributionProperty.singleton });
@@ -1275,6 +1276,8 @@ namespace qpmodel.physic
             var exprlist = (logic_ as LogicAgg).groupby_;
             var prop = new SortOrderProperty(exprlist);
 
+            // stream agg can support certain order property
+            // but distribution must be singleton
             if (required.distribution_.disttype == DistributionType.Singleton
                 && required.IsPropertySupplied(prop))
             {

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1137,6 +1137,18 @@ namespace qpmodel.physic
             return (child_().Card() * 1.0) + (logic_.Card() * 2.0);
         }
 
+        public override bool IsPropertySatisfied(PhysicProperty required, out List<List<PhysicProperty>> listchildprops)
+        {
+            listchildprops = new List<List<PhysicProperty>>();
+            if (required.Equals(DistributionProperty.singleton))
+            {
+                listchildprops.Add(new List<PhysicProperty> { DistributionProperty.singleton });
+                return true;
+            }
+            listchildprops = null;
+            return false;
+        }
+
         public override void Open(ExecContext context)
         {
             base.Open(context);
@@ -1263,7 +1275,8 @@ namespace qpmodel.physic
             var exprlist = (logic_ as LogicAgg).groupby_;
             var prop = new SortOrderProperty(exprlist);
 
-            if (required.IsPropertySupplied(prop))
+            if (required.distribution_.disttype == DistributionType.Singleton
+                && required.IsPropertySupplied(prop))
             {
                 listchildprops.Add(new List<PhysicProperty> { prop });
                 return true;

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -806,7 +806,7 @@ namespace qpmodel.physic
             // because earlier optimization time keylist may have wrong bindings
             //
             var logic = logic_ as LogicJoin;
-            logic.CreateKeyList(false);
+            logic.RecreateKeyList(false);
             if (context.option_.optimize_.use_codegen_)
             {
                 context.code_ += $@"var hm{_} = new Dictionary<KeyList, List<TaggedRow>>();";

--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -59,6 +59,7 @@ namespace qpmodel.logic
             public bool enable_streamagg_ { get; set; } = false;
             public bool enable_indexseek_ { get; set; } = true;
             public bool use_memo_ { get; set; } = true;
+            public bool memo_use_remoteexchange_ { get; set; } = false;
             public bool memo_disable_crossjoin_ { get; set; } = true;
             public bool memo_use_joinorder_solver_ { get; set; } = false;   // make it true by default
 
@@ -445,7 +446,8 @@ namespace qpmodel.logic
                 distributed_ = true;
 
                 // FIXME: we have to disable memo optimization before property enforcement done
-                queryOpt_.optimize_.use_memo_ = false;
+                //queryOpt_.optimize_.use_memo_ = false;
+                queryOpt_.optimize_.memo_use_remoteexchange_ = true;
                 if (onlyreplicated)
                     root = new LogicGather(root, new List<int> { 0 });
                 else

--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -445,9 +445,10 @@ namespace qpmodel.logic
                 Debug.Assert(!distributed_);
                 distributed_ = true;
 
-                // FIXME: we have to disable memo optimization before property enforcement done
-                //queryOpt_.optimize_.use_memo_ = false;
+                // distributed table query can also use memo
+                // remote exchange is considered in memo optimization
                 queryOpt_.optimize_.memo_use_remoteexchange_ = true;
+
                 if (onlyreplicated)
                     root = new LogicGather(root, new List<int> { 0 });
                 else

--- a/qpmodel/Utils.cs
+++ b/qpmodel/Utils.cs
@@ -287,5 +287,6 @@ namespace qpmodel.utils
             }
         }
         public static string normalizeName(string name) => name.StartsWith('"') ? name : name.ToLower();
+        public static int mod(int a, int b) => (a % b + b) % b; // ensure positive
     }
 }

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -78,7 +78,7 @@ namespace qpmodel.optimizer
             switch (distribution_.disttype)
             {
                 case DistributionType.Any:
-                    return property.distribution_.disttype != DistributionType.Replicated;
+                    return property.distribution_.disttype == DistributionType.Distributed;
                 case DistributionType.Singleton:
                     return property.distribution_.disttype == DistributionType.Singleton;
                 // distribution expr list must match to be considered supplied

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -301,7 +301,6 @@ namespace qpmodel.optimizer
     //
     public class CMemoGroup
     {
-        
         // insertion order in memo
         public int memoid_;
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -56,6 +56,7 @@ namespace qpmodel.optimizer
 
         public bool IsPropertySupplied(PhysicProperty property)
         {
+            // property is considered supplied when both order and property is supplied
             if (IsOrderSupplied(property) && IsDistributionSupplied(property))
                 return true;
             return false;
@@ -80,6 +81,7 @@ namespace qpmodel.optimizer
                     return property.distribution_.disttype != DistributionType.Replicated;
                 case DistributionType.Singleton:
                     return property.distribution_.disttype == DistributionType.Singleton;
+                // distribution expr list must match to be considered supplied
                 case DistributionType.Distributed:
                     if (property.distribution_.disttype == DistributionType.Singleton)
                         return true;
@@ -94,6 +96,8 @@ namespace qpmodel.optimizer
                         return true;
                     }
                     return false;
+                // replicated can only be satisfied by replicated
+                // sin the gather node for that is different
                 case DistributionType.Replicated:
                     return property.distribution_.disttype == DistributionType.Replicated;
             }
@@ -103,6 +107,9 @@ namespace qpmodel.optimizer
 
         internal PhysicNode PropertyEnforcement(PhysicNode node, PhysicProperty nodeprop)
         {
+            // since the property tranformation process is
+            // one enforcement node, either the order is supplied
+            // or the distribution is supplied
             if (IsOrderSupplied(nodeprop))
                 return DistributionEnforcement(node, nodeprop);
             if (IsDistributionSupplied(nodeprop))
@@ -660,6 +667,9 @@ namespace qpmodel.optimizer
                     double cost = member.physic_.Cost();
                     if (!isleaf)
                     {
+                        // when the group is not leaf, it is possible
+                        // that there are more than one set of viable child properties,
+                        // need to find the best set
                         List<PhysicProperty> minchildprops = null;
                         var minchildcost = Double.MaxValue;
                         foreach (var childprops in listchildprops)

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -479,6 +479,7 @@ namespace qpmodel.optimizer
             {
                 var member = CalculateMinInclusiveCostMember(prop);
                 var enforcement = required.OrderEnforcement(member.physic_);
+                enforcement.children_ = new List<PhysicNode> { new PhysicMemoRef(new LogicMemoRef(this)) }; 
 
                 var newmember = new CGroupMember(enforcement, this);
                 if (!exprList_.Contains(newmember)) exprList_.Add(newmember);
@@ -490,12 +491,12 @@ namespace qpmodel.optimizer
 
                 // calculate the derived members from less strict property
                 // an important assumption here is that enforcement member does not change cardinality
-                (var childmember, var cost) = minMember_[prop];
+                (var _, var cost) = minMember_[prop];
                 cost += newmember.physic_.Cost();
                 if (cost < optinccost)
                 {
                     optinccost = cost;
-                    optmember = new CGroupMember(required.OrderEnforcement(childmember.physic_), this);
+                    optmember = newmember;
                 }
             }
 
@@ -577,9 +578,7 @@ namespace qpmodel.optimizer
                     {
                         // this shall not happen if without join resolver. With join resolver
                         // the plan is already given, so 'v' is the known min physic node
-                        // or the member is enforced an order node on top
-                        Debug.Assert(queryOpt.optimize_.memo_use_joinorder_solver_ ||
-                            phyClone is PhysicOrder);
+                        Debug.Assert(queryOpt.optimize_.memo_use_joinorder_solver_);
                         phychild = CopyOutMinLogicPhysicPlan(property, v);
                     }
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -511,6 +511,7 @@ namespace qpmodel.optimizer
 
                 if (member.physic_.IsPropertySatisfied(required, out var childprops))
                 {
+                    member.propertypairs_.Add(required, childprops);
                     double cost = member.physic_.Cost();
                     if (!isleaf)
                     {

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2238,12 +2238,12 @@ namespace qpmodel.unittest
             sql = "select a2,b2,c2 from ad, bd, cd where a2=b2 and c2 = b2 order by c2";
             TU.ExecuteSQL(sql, "1,1,1;2,2,2;3,3,3", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
+            Assert.AreEqual(3, TU.CountStr(phyplan, "Redistribute"));
             sql = "select a2,b2,c2,d2 from ad, bd, cd, dd where a2=b2 and c2 = b2 and c2=d2 order by b2";
             TU.ExecuteSQL(sql, "1,1,1,1;2,2,2,2;2,2,2,2;3,3,3,3", out phyplan);
             Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-            Assert.AreEqual(6, TU.CountStr(phyplan, "Redistribute"));
-            Assert.AreEqual(1, TU.CountStr(phyplan, "70 threads"));
+            Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
+            Assert.AreEqual(1, TU.CountStr(phyplan, "50 threads"));
 
             // ensure redistribution can shuffle by expression
             sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -754,6 +754,11 @@ namespace qpmodel.unittest
             Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));
             Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicOrder"));
 
+            sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2 order by count(a1) desc;";
+            TU.ExecuteSQL(sql, "6,4;4,1", out phyplan, option);
+            Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));
+            Assert.AreEqual(2, TU.CountStr(phyplan, "PhysicOrder"));
+
             sql = "select a2*2, count(a1) from a, b, c where a1>b1 and a2>c2 group by a2 order by a2;";
             TU.ExecuteSQL(sql, "4,1;6,4", out phyplan, option);
             Assert.AreEqual(1, TU.CountStr(phyplan, "PhysicStreamAgg"));

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -763,20 +763,20 @@ namespace qpmodel.unittest
             var memo = stmt.optimizer_.memoset_[0];
             memo.CalcStats(out int tlogics, out int tphysics);
             Assert.AreEqual(8, memo.cgroups_.Count);
-            Assert.AreEqual(16, tlogics); Assert.AreEqual(17, tphysics);
+            Assert.AreEqual(16, tlogics); Assert.AreEqual(20, tphysics);
             Assert.AreEqual("4,1;6,4", string.Join(";", result));
             var mstr = stmt.optimizer_.PrintMemo();
-            Assert.IsTrue(mstr.Contains("Summary: 16,17"));
+            Assert.IsTrue(mstr.Contains("Summary: 16,20"));
 
             sql = "select a1 from a, b where a1 <= b1 and a2 = 2 group by a1 order by a1";
             result = TU.ExecuteSQL(sql, out stmt, out phyplan, option);
             memo = stmt.optimizer_.memoset_[0];
             memo.CalcStats(out tlogics, out tphysics);
             Assert.AreEqual(4, memo.cgroups_.Count);
-            Assert.AreEqual(5, tlogics); Assert.AreEqual(6, tphysics);
+            Assert.AreEqual(5, tlogics); Assert.AreEqual(9, tphysics);
             Assert.AreEqual("1", string.Join(";", result));
             mstr = stmt.optimizer_.PrintMemo();
-            Assert.AreEqual(8, TU.CountStr(mstr, "property"));
+            Assert.AreEqual(7, TU.CountStr(mstr, "property"));
             Assert.IsTrue(TU.CheckPlanOrder(stmt.physicPlan_,
                 new List<string> { "PhysicStreamAgg", "PhysicNLJoin", "PhysicOrder" }));
         }

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2271,12 +2271,12 @@ namespace qpmodel.unittest
                 sql = "select a2,b2,c2 from ad, bd, cd where a2=b2 and c2 = b2 order by c2";
                 TU.ExecuteSQL(sql, "1,1,1;2,2,2;3,3,3", out phyplan);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(3, TU.CountStr(phyplan, "Redistribute"));
                 sql = "select a2,b2,c2,d2 from ad, bd, cd, dd where a2=b2 and c2 = b2 and c2=d2 order by b2";
                 TU.ExecuteSQL(sql, "1,1,1,1;2,2,2,2;2,2,2,2;3,3,3,3", out phyplan);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(6, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(1, TU.CountStr(phyplan, "70 threads"));
+                Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "50 threads"));
 
                 // ensure redistribution can shuffle by expression
                 sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2302,7 +2302,7 @@ namespace qpmodel.unittest
                 sql = "select a1,b1 from ad, br where a2=b2 order by a1;";
                 TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute")); // FIXME: redistribution is not needed if replica is on the build side
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute")); // FIXME: redistribution is not needed if replica is on the build side
                 sql = "select a1,b1 from ar, br where a2=b2 order by a1;";
                 TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
@@ -2324,7 +2324,7 @@ namespace qpmodel.unittest
                 sql = "select a1,b1 from ar, brb where a2=b2 order by a1;";
                 TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Redistribute"));
             }
         }
     }

--- a/test/regress/expect/tpch0001_d/q01.txt
+++ b/test/regress/expect/tpch0001_d/q01.txt
@@ -19,15 +19,15 @@ group by
 order by
 	l_returnflag,
 	l_linestatus
-Total cost: 12532.65, memory=1116
-PhysicOrder  (inccost=12532.65, cost=11.35, rows=6, memory=372) (actual rows=4)
+Total cost: 71071.35, memory=1116
+PhysicOrder  (inccost=71071.35, cost=11.35, rows=6, memory=372) (actual rows=4)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=12521.3, cost=5925, rows=6, memory=744) (actual rows=4)
+    -> PhysicHashAgg  (inccost=71060, cost=5925, rows=6, memory=744) (actual rows=4)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*1-l_discount[7]), sum(l_extendedprice[3]*1-l_discount[7]*1+l_tax[10]), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicGather 1 : 10 (inccost=6596.3, cost=591.3, rows=5913) (actual rows=5914)
+        -> PhysicGather 1 : 10 (inccost=65135, cost=59130, rows=5913) (actual rows=5914)
             Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
             -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5913) (actual rows=0)
                 Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]

--- a/test/regress/expect/tpch0001_d/q03.txt
+++ b/test/regress/expect/tpch0001_d/q03.txt
@@ -21,35 +21,35 @@ order by
 	revenue desc,
 	o_orderdate
 limit 10
-Total cost: 23009.8, memory=267728
-PhysicLimit (10) (inccost=23009.8, cost=10, rows=10) (actual rows=8)
+Total cost: 28022.9, memory=62600
+PhysicLimit (10) (inccost=28022.9, cost=10, rows=10) (actual rows=8)
     Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
-    -> PhysicOrder  (inccost=22999.8, cost=2851.9, rows=458, memory=10992) (actual rows=8)
+    -> PhysicOrder  (inccost=28012.9, cost=2851.9, rows=458, memory=10992) (actual rows=8)
         Output: l_orderkey[0],{sum(l_extendedprice*1-l_discount)}[1],o_orderdate[2],o_shippriority[3]
         Order by: {sum(l_extendedprice*1-l_discount)}[1], o_orderdate[2]
-        -> PhysicHashAgg  (inccost=20147.89, cost=1374, rows=458, memory=21984) (actual rows=8)
+        -> PhysicHashAgg  (inccost=25161, cost=1374, rows=458, memory=21984) (actual rows=8)
             Output: {l_orderkey}[0],{sum(l_extendedprice*1-l_discount)}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*1-l_discount[7])
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicGather 1 : 10 (inccost=18773.89, cost=45.8, rows=458) (actual rows=14)
+            -> PhysicGather 1 : 10 (inccost=23787, cost=4580, rows=458) (actual rows=14)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
-                -> PhysicHashJoin  (inccost=18728.09, cost=2097, rows=458, memory=464) (actual rows=0)
+                -> PhysicHashJoin  (inccost=19207, cost=2097, rows=458, memory=464) (actual rows=0)
                     Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
                     Filter: c_custkey[1]=o_custkey[9]
                     -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=0)
                         Output: 1,c_custkey[0]
                         Filter: c_mktsegment[6]='BUILDING'
-                    -> PhysicRedistribute  (inccost=16481.09, cost=158.1, rows=1581) (actual rows=0)
+                    -> PhysicRedistribute  (inccost=16960, cost=3162, rows=1581) (actual rows=0)
                         Output: l_orderkey[0],o_orderdate[1],o_shippriority[2],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7]
-                        -> PhysicHashJoin  (inccost=16323, cost=8818, rows=1581, memory=234288) (actual rows=0)
-                            Output: l_orderkey[0],o_orderdate[5],o_shippriority[6],{l_extendedprice*1-l_discount}[1],l_extendedprice[2],{1-l_discount}[3],l_discount[4],o_custkey[7]
-                            Filter: l_orderkey[0]=o_orderkey[8]
-                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3254) (actual rows=0)
-                                Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
-                                Filter: l_shipdate[10]>'1995-03-15'
+                        -> PhysicHashJoin  (inccost=13798, cost=6293, rows=1581, memory=29160) (actual rows=0)
+                            Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],l_discount[8],o_custkey[2]
+                            Filter: l_orderkey[4]=o_orderkey[3]
                             -> PhysicScanTable orders (inccost=1500, cost=1500, rows=729) (actual rows=0)
                                 Output: o_orderdate[4],o_shippriority[7],o_custkey[1],o_orderkey[0]
                                 Filter: o_orderdate[4]<'1995-03-15'
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3254) (actual rows=0)
+                                Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
+                                Filter: l_shipdate[10]>'1995-03-15'
 
 Emulated 10 machines distributed run with 20 threads
 1637,164224.9253,2/8/1995 12:00:00 AM,0

--- a/test/regress/expect/tpch0001_d/q05.txt
+++ b/test/regress/expect/tpch0001_d/q05.txt
@@ -22,29 +22,29 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 20525.97, memory=10303
-PhysicOrder  (inccost=20525.97, cost=82.97, rows=25, memory=825) (actual rows=0)
+Total cost: 20505.97, memory=10303
+PhysicOrder  (inccost=20505.97, cost=82.97, rows=25, memory=825) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
     Order by: {sum(l_extendedprice*1-l_discount)}[1]
-    -> PhysicHashAgg  (inccost=20443, cost=133, rows=25, memory=1650) (actual rows=0)
+    -> PhysicHashAgg  (inccost=20423, cost=133, rows=25, memory=1650) (actual rows=0)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicGather 1 : 10 (inccost=20310, cost=830, rows=83) (actual rows=0)
+        -> PhysicGather 1 : 10 (inccost=20290, cost=830, rows=83) (actual rows=0)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],1,l_discount[7]
-            -> PhysicHashJoin  (inccost=19480, cost=883, rows=83, memory=3600) (actual rows=0)
+            -> PhysicHashJoin  (inccost=19460, cost=883, rows=83, memory=3600) (actual rows=0)
                 Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],1,l_discount[7]
                 Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
                 -> PhysicRedistribute  (inccost=450, cost=300, rows=150) (actual rows=0)
                     Output: {1}[0],c_custkey[1],c_nationkey[2]
                     -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
                         Output: 1,c_custkey[0],c_nationkey[3]
-                -> PhysicHashJoin  (inccost=18147, cost=1360, rows=450, memory=330) (actual rows=0)
+                -> PhysicHashJoin  (inccost=18127, cost=1360, rows=450, memory=330) (actual rows=0)
                     Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[1]
                     Filter: l_suppkey[8]=s_suppkey[2]
-                    -> PhysicRedistribute  (inccost=127, cost=10, rows=5) (actual rows=0)
+                    -> PhysicRedistribute  (inccost=107, cost=10, rows=5) (actual rows=0)
                         Output: n_name[0],s_nationkey[1],s_suppkey[2]
-                        -> PhysicHashJoin  (inccost=117, cost=25, rows=5, memory=290) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=290) (actual rows=0)
                             Output: n_name[0],s_nationkey[2],s_suppkey[3]
                             Filter: s_nationkey[2]=n_nationkey[1]
                             -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=0)
@@ -55,10 +55,8 @@ PhysicOrder  (inccost=20525.97, cost=82.97, rows=25, memory=825) (actual rows=0)
                                     Filter: r_name[1]='ASIA'
                                 -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
                                     Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                            -> PhysicRedistribute  (inccost=30, cost=20, rows=10) (actual rows=0)
-                                Output: s_nationkey[0],s_suppkey[1]
-                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
-                                    Output: s_nationkey[3],s_suppkey[0]
+                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                Output: s_nationkey[3],s_suppkey[0]
                     -> PhysicRedistribute  (inccost=16660, cost=1800, rows=900) (actual rows=0)
                         Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4],l_suppkey[5]
                         -> PhysicHashJoin  (inccost=14860, cost=7355, rows=900, memory=3600) (actual rows=0)
@@ -70,6 +68,6 @@ PhysicOrder  (inccost=20525.97, cost=82.97, rows=25, memory=825) (actual rows=0)
                             -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                                 Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_suppkey[2],l_orderkey[0]
 
-Emulated 10 machines distributed run with 50 threads
+Emulated 10 machines distributed run with 40 threads
 
 

--- a/test/regress/expect/tpch0001_d/q05.txt
+++ b/test/regress/expect/tpch0001_d/q05.txt
@@ -22,56 +22,54 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 30704.27, memory=488293
-PhysicOrder  (inccost=30704.27, cost=82.97, rows=25, memory=825) (actual rows=0)
+Total cost: 20525.97, memory=10303
+PhysicOrder  (inccost=20525.97, cost=82.97, rows=25, memory=825) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
     Order by: {sum(l_extendedprice*1-l_discount)}[1]
-    -> PhysicHashAgg  (inccost=30621.3, cost=133, rows=25, memory=1650) (actual rows=0)
+    -> PhysicHashAgg  (inccost=20443, cost=133, rows=25, memory=1650) (actual rows=0)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicGather 1 : 10 (inccost=30488.3, cost=8.3, rows=83) (actual rows=0)
+        -> PhysicGather 1 : 10 (inccost=20310, cost=830, rows=83) (actual rows=0)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],1,l_discount[7]
-            -> PhysicHashJoin  (inccost=30480, cost=883, rows=83, memory=3600) (actual rows=0)
+            -> PhysicHashJoin  (inccost=19480, cost=883, rows=83, memory=3600) (actual rows=0)
                 Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],1,l_discount[7]
                 Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
-                -> PhysicRedistribute  (inccost=165, cost=15, rows=150) (actual rows=0)
+                -> PhysicRedistribute  (inccost=450, cost=300, rows=150) (actual rows=0)
                     Output: {1}[0],c_custkey[1],c_nationkey[2]
                     -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
                         Output: 1,c_custkey[0],c_nationkey[3]
-                -> PhysicRedistribute  (inccost=29432, cost=50, rows=500) (actual rows=0)
-                    Output: n_name[0],{l_extendedprice*1-l_discount}[1],l_extendedprice[2],{1-l_discount}[3],l_discount[4],o_custkey[5],s_nationkey[6]
-                    -> PhysicHashJoin  (inccost=29382, cost=3002, rows=500, memory=8) (actual rows=0)
-                        Output: n_name[1],{l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[6],s_nationkey[7]
-                        Filter: n_regionkey[8]=r_regionkey[0]
-                        -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
-                            Output: r_regionkey[0]
-                            Filter: r_name[1]='ASIA'
-                        -> PhysicRedistribute  (inccost=26375, cost=250, rows=2500) (actual rows=0)
-                            Output: n_name[0],{l_extendedprice*1-l_discount}[1],l_extendedprice[2],{1-l_discount}[3],l_discount[4],o_custkey[5],s_nationkey[6],n_regionkey[7]
-                            -> PhysicHashJoin  (inccost=26125, cost=3450, rows=2500, memory=1650) (actual rows=0)
-                                Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[8],n_regionkey[1]
-                                Filter: s_nationkey[8]=n_nationkey[2]
+                -> PhysicHashJoin  (inccost=18147, cost=1360, rows=450, memory=330) (actual rows=0)
+                    Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[1]
+                    Filter: l_suppkey[8]=s_suppkey[2]
+                    -> PhysicRedistribute  (inccost=127, cost=10, rows=5) (actual rows=0)
+                        Output: n_name[0],s_nationkey[1],s_suppkey[2]
+                        -> PhysicHashJoin  (inccost=117, cost=25, rows=5, memory=290) (actual rows=0)
+                            Output: n_name[0],s_nationkey[2],s_suppkey[3]
+                            Filter: s_nationkey[2]=n_nationkey[1]
+                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=0)
+                                Output: n_name[1],n_nationkey[2]
+                                Filter: n_regionkey[3]=r_regionkey[0]
+                                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                                    Output: r_regionkey[0]
+                                    Filter: r_name[1]='ASIA'
                                 -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
-                                    Output: n_name[1],n_regionkey[2],n_nationkey[0]
-                                -> PhysicRedistribute  (inccost=22650, cost=90, rows=900) (actual rows=0)
-                                    Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4],s_nationkey[5]
-                                    -> PhysicHashJoin  (inccost=22560, cost=1820, rows=900, memory=160) (actual rows=0)
-                                        Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[6],s_nationkey[0]
-                                        Filter: l_suppkey[7]=s_suppkey[1]
-                                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
-                                            Output: s_nationkey[3],s_suppkey[0]
-                                        -> PhysicRedistribute  (inccost=20730, cost=90, rows=900) (actual rows=0)
-                                            Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4],l_suppkey[5]
-                                            -> PhysicHashJoin  (inccost=20640, cost=13135, rows=900, memory=480400) (actual rows=0)
-                                                Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[6],l_suppkey[4]
-                                                Filter: l_orderkey[5]=o_orderkey[7]
-                                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
-                                                    Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_suppkey[2],l_orderkey[0]
-                                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=225) (actual rows=0)
-                                                    Output: o_custkey[1],o_orderkey[0]
-                                                    Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
+                                    Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                            -> PhysicRedistribute  (inccost=30, cost=20, rows=10) (actual rows=0)
+                                Output: s_nationkey[0],s_suppkey[1]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                    Output: s_nationkey[3],s_suppkey[0]
+                    -> PhysicRedistribute  (inccost=16660, cost=1800, rows=900) (actual rows=0)
+                        Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4],l_suppkey[5]
+                        -> PhysicHashJoin  (inccost=14860, cost=7355, rows=900, memory=3600) (actual rows=0)
+                            Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0],l_suppkey[6]
+                            Filter: l_orderkey[7]=o_orderkey[1]
+                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=225) (actual rows=0)
+                                Output: o_custkey[1],o_orderkey[0]
+                                Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_suppkey[2],l_orderkey[0]
 
-Emulated 10 machines distributed run with 60 threads
+Emulated 10 machines distributed run with 50 threads
 
 

--- a/test/regress/expect/tpch0001_d/q06.txt
+++ b/test/regress/expect/tpch0001_d/q06.txt
@@ -7,11 +7,11 @@ where
 	and l_shipdate < date '1994-01-01' + interval '1' year
 	and l_discount between .06 - 0.01  and .06 + 0.01
 	and l_quantity < 24
-Total cost: 6095, memory=16
-PhysicHashAgg  (inccost=6095, cost=82, rows=1, memory=16) (actual rows=1)
+Total cost: 6887, memory=16
+PhysicHashAgg  (inccost=6887, cost=82, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice*l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*l_discount[2])
-    -> PhysicGather 1 : 10 (inccost=6013, cost=8, rows=80) (actual rows=74)
+    -> PhysicGather 1 : 10 (inccost=6805, cost=800, rows=80) (actual rows=74)
         Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
         -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=80) (actual rows=0)
             Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]

--- a/test/regress/expect/tpch0001_d/q10.txt
+++ b/test/regress/expect/tpch0001_d/q10.txt
@@ -30,43 +30,41 @@ group by
 order by
 	revenue desc
 limit 20
-Total cost: 11814.98, memory=72302
-PhysicLimit (20) (inccost=11814.98, cost=20, rows=20) (actual rows=20)
+Total cost: 11634.98, memory=72302
+PhysicLimit (20) (inccost=11634.98, cost=20, rows=20) (actual rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=11794.98, cost=413.98, rows=90, memory=21780) (actual rows=20)
+    -> PhysicOrder  (inccost=11614.98, cost=413.98, rows=90, memory=21780) (actual rows=20)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*1-l_discount)}[2]
-        -> PhysicHashAgg  (inccost=11381, cost=270, rows=90, memory=43560) (actual rows=43)
+        -> PhysicHashAgg  (inccost=11201, cost=270, rows=90, memory=43560) (actual rows=43)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicGather 1 : 10 (inccost=11111, cost=900, rows=90) (actual rows=140)
+            -> PhysicGather 1 : 10 (inccost=10931, cost=900, rows=90) (actual rows=140)
                 Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
-                -> PhysicHashJoin  (inccost=10211, cost=230, rows=90, memory=1650) (actual rows=0)
+                -> PhysicHashJoin  (inccost=10031, cost=230, rows=90, memory=1650) (actual rows=0)
                     Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
                     Filter: c_nationkey[13]=n_nationkey[2]
                     -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
                         Output: n_name[1],1,n_nationkey[0]
-                    -> PhysicRedistribute  (inccost=9956, cost=180, rows=90) (actual rows=0)
-                        Output: c_custkey[0],c_name[1],c_acctbal[2],c_address[3],c_phone[4],c_comment[5],{l_extendedprice*1-l_discount}[6],l_extendedprice[7],{1-l_discount}[8],l_discount[9],c_nationkey[10]
-                        -> PhysicHashJoin  (inccost=9776, cost=360, rows=90, memory=4320) (actual rows=0)
-                            Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],c_nationkey[11]
-                            Filter: c_custkey[5]=o_custkey[4]
-                            -> PhysicRedistribute  (inccost=9266, cost=120, rows=60) (actual rows=0)
-                                Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4]
-                                -> PhysicHashJoin  (inccost=9146, cost=1641, rows=60, memory=992) (actual rows=0)
-                                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
-                                    Filter: l_orderkey[6]=o_orderkey[1]
-                                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=62) (actual rows=0)
-                                        Output: o_custkey[1],o_orderkey[0]
-                                        Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
-                                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=0)
-                                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
-                                        Filter: l_returnflag[8]='R'
-                            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
-                                Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
+                    -> PhysicHashJoin  (inccost=9776, cost=360, rows=90, memory=4320) (actual rows=0)
+                        Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],c_nationkey[11]
+                        Filter: c_custkey[5]=o_custkey[4]
+                        -> PhysicRedistribute  (inccost=9266, cost=120, rows=60) (actual rows=0)
+                            Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4]
+                            -> PhysicHashJoin  (inccost=9146, cost=1641, rows=60, memory=992) (actual rows=0)
+                                Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
+                                Filter: l_orderkey[6]=o_orderkey[1]
+                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=62) (actual rows=0)
+                                    Output: o_custkey[1],o_orderkey[0]
+                                    Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=0)
+                                    Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
+                                    Filter: l_returnflag[8]='R'
+                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
+                            Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
 
-Emulated 10 machines distributed run with 30 threads
+Emulated 10 machines distributed run with 20 threads
 121,Customer#000000121,282635.1719,6428.32,PERU,tv nCR2YKupGN73mQudO,27-411-990-2959,uriously stealthy ideas. carefully final courts use carefully
 124,Customer#000000124,222182.5188,1842.49,CHINA,aTbyVAW5tCd,v09O,28-183-750-7809,le fluffily even dependencies. quietly s
 106,Customer#000000106,190241.3334,3288.42,ARGENTINA,xGCOEAUjUNG,11-751-989-4627,lose slyly. ironic accounts along the evenly regular theodolites wake about the special, final gifts.

--- a/test/regress/expect/tpch0001_d/q10.txt
+++ b/test/regress/expect/tpch0001_d/q10.txt
@@ -30,45 +30,61 @@ group by
 order by
 	revenue desc
 limit 20
-Total cost: 15939.98, memory=235344
-PhysicLimit (20) (inccost=15939.98, cost=20, rows=20) (actual rows=3)
+Total cost: 11814.98, memory=72302
+PhysicLimit (20) (inccost=11814.98, cost=20, rows=20) (actual rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=15919.98, cost=413.98, rows=90, memory=21780) (actual rows=3)
+    -> PhysicOrder  (inccost=11794.98, cost=413.98, rows=90, memory=21780) (actual rows=20)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*1-l_discount)}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*1-l_discount)}[2]
-        -> PhysicHashAgg  (inccost=15506, cost=270, rows=90, memory=43560) (actual rows=3)
+        -> PhysicHashAgg  (inccost=11381, cost=270, rows=90, memory=43560) (actual rows=43)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicGather 1 : 10 (inccost=15236, cost=9, rows=90) (actual rows=8)
-                Output: c_custkey[0],c_name[1],c_acctbal[2],n_name[8],c_address[3],c_phone[4],c_comment[5],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],1,l_discount[12]
-                -> PhysicHashJoin  (inccost=15227, cost=1890, rows=90, memory=65100) (actual rows=0)
-                    Output: c_custkey[0],c_name[1],c_acctbal[2],n_name[8],c_address[3],c_phone[4],c_comment[5],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],1,l_discount[12]
-                    Filter: c_custkey[0]=o_custkey[13] and c_nationkey[7]=n_nationkey[14]
-                    -> PhysicRedistribute  (inccost=165, cost=15, rows=150) (actual rows=0)
-                        Output: c_custkey[0],c_name[1],c_acctbal[2],c_address[3],c_phone[4],c_comment[5],{1}[6],c_nationkey[7]
-                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
-                            Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],1,c_nationkey[3]
-                    -> PhysicRedistribute  (inccost=13172, cost=150, rows=1500) (actual rows=0)
-                        Output: n_name[0],{l_extendedprice*1-l_discount}[1],l_extendedprice[2],{1-l_discount}[3],l_discount[4],o_custkey[5],n_nationkey[6]
-                        -> PhysicNLJoin  (inccost=13022, cost=2450, rows=1500) (actual rows=0)
-                            Output: n_name[0],{l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[6],n_nationkey[1]
-                            -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
-                                Output: n_name[1],n_nationkey[0]
-                            -> PhysicRedistribute  (inccost=10547, cost=6, rows=60) (actual rows=0)
+            -> PhysicGather 1 : 10 (inccost=11111, cost=900, rows=90) (actual rows=140)
+                Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
+                -> PhysicHashJoin  (inccost=10211, cost=230, rows=90, memory=1650) (actual rows=0)
+                    Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
+                    Filter: c_nationkey[13]=n_nationkey[2]
+                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                        Output: n_name[1],1,n_nationkey[0]
+                    -> PhysicRedistribute  (inccost=9956, cost=180, rows=90) (actual rows=0)
+                        Output: c_custkey[0],c_name[1],c_acctbal[2],c_address[3],c_phone[4],c_comment[5],{l_extendedprice*1-l_discount}[6],l_extendedprice[7],{1-l_discount}[8],l_discount[9],c_nationkey[10]
+                        -> PhysicHashJoin  (inccost=9776, cost=360, rows=90, memory=4320) (actual rows=0)
+                            Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],c_nationkey[11]
+                            Filter: c_custkey[5]=o_custkey[4]
+                            -> PhysicRedistribute  (inccost=9266, cost=120, rows=60) (actual rows=0)
                                 Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[4]
-                                -> PhysicHashJoin  (inccost=10541, cost=3036, rows=60, memory=104904) (actual rows=0)
-                                    Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],l_discount[3],o_custkey[5]
-                                    Filter: l_orderkey[4]=o_orderkey[6]
-                                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=0)
-                                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
-                                        Filter: l_returnflag[8]='R'
+                                -> PhysicHashJoin  (inccost=9146, cost=1641, rows=60, memory=992) (actual rows=0)
+                                    Output: {l_extendedprice*1-l_discount}[2],l_extendedprice[3],{1-l_discount}[4],l_discount[5],o_custkey[0]
+                                    Filter: l_orderkey[6]=o_orderkey[1]
                                     -> PhysicScanTable orders (inccost=1500, cost=1500, rows=62) (actual rows=0)
                                         Output: o_custkey[1],o_orderkey[0]
                                         Filter: o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM'
+                                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=0)
+                                        Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_orderkey[0]
+                                        Filter: l_returnflag[8]='R'
+                            -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
+                                Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
 
-Emulated 10 machines distributed run with 40 threads
-76,Customer#000000076,71918.906,5745.33,ALGERIA,m3sbCvjMOHyaOofH,e UkGPtqc4,10-349-718-3044,pecial deposits. ironic ideas boost blithely according to the closely ironic theodolites! furiously final deposits n
-29,Customer#000000029,56516.475,7618.27,ALGERIA,sJ5adtfyAkCK63df2,vF25zyQMVYE34uh,10-773-203-7342,its after the carefully final platelets x-ray against
-86,Customer#000000086,24827.0646,3306.32,ALGERIA,US6EGGHXbTTXPL9SBsxQJsuvy,10-677-951-2353,quests. pending dugouts are carefully aroun
+Emulated 10 machines distributed run with 30 threads
+121,Customer#000000121,282635.1719,6428.32,PERU,tv nCR2YKupGN73mQudO,27-411-990-2959,uriously stealthy ideas. carefully final courts use carefully
+124,Customer#000000124,222182.5188,1842.49,CHINA,aTbyVAW5tCd,v09O,28-183-750-7809,le fluffily even dependencies. quietly s
+106,Customer#000000106,190241.3334,3288.42,ARGENTINA,xGCOEAUjUNG,11-751-989-4627,lose slyly. ironic accounts along the evenly regular theodolites wake about the special, final gifts.
+16,Customer#000000016,161422.0461,4681.03,IRAN,cYiaeMLZSMAOQ2 d0W,,20-781-609-3107,kly silent courts. thinly regular theodolites sleep fluffily after
+44,Customer#000000044,149364.5652,7315.94,MOZAMBIQUE,Oi,dOSPwDu4jo4x,,P85E0dmhZGvNtBwi,26-190-260-5375,r requests around the unusual, bold a
+71,Customer#000000071,129481.0245,-611.19,GERMANY,TlGalgdXWBmMV,6agLyWYDyIz9MKzcY8gl,w6t1B,17-710-812-5403,g courts across the regular, final pinto beans are blithely pending ac
+89,Customer#000000089,121663.1243,1530.76,KENYA,dtR, y9JQWUO6FoJExyp8whOU,24-394-451-5404,counts are slyly beyond the slyly final accounts. quickly final ideas wake. r
+112,Customer#000000112,111137.7141,2953.35,ROMANIA,RcfgG3bO7QeCnfjqJT1,29-233-262-8382,rmanently unusual multipliers. blithely ruthless deposits are furiously along the
+62,Customer#000000062,106368.0153,595.61,GERMANY,upJK2Dnw13,,17-361-978-7059,kly special dolphins. pinto beans are slyly. quickly regular accounts are furiously a
+146,Customer#000000146,103265.9888,3328.68,CANADA,GdxkdXG9u7iyI1,,y5tq4ZyrcEy,13-835-723-3223,ffily regular dinos are slyly unusual requests. slyly specia
+19,Customer#000000019,99306.0127,8914.71,CHINA,uc,3bHIx84H,wdrmLOjVsiqXCq2tr,28-396-526-5053,nag. furiously careful packages are slyly at the accounts. furiously regular in
+145,Customer#000000145,99256.9018,9748.93,JORDAN,kQjHmt2kcec cy3hfMh969u,23-562-444-8454,ests? express, express instructions use. blithely fina
+103,Customer#000000103,97311.7724,2757.45,INDONESIA,8KIsQX4LJ7QMsj6DrtFtXu0nUEdV,8a,19-216-107-2107,furiously pending notornis boost slyly around the blithely ironic ideas? final, even instructions cajole fl
+136,Customer#000000136,95855.398,-842.39,GERMANY,QoLsJ0v5C1IQbh,DS1,17-501-210-4726,ackages sleep ironic, final courts. even requests above the blithely bold requests g
+53,Customer#000000053,92568.9124,4113.64,MOROCCO,HnaxHzTfFTZs8MuCpJyTbZ47Cm4wFOOgib,25-168-852-5363,ar accounts are. even foxes are blithely. fluffily pending deposits boost
+49,Customer#000000049,90965.7262,4573.94,IRAN,cNgAeX7Fqrdf7HQN9EwjUa4nxT,68L FKAxzl,20-908-631-4424,nusual foxes! fluffily pending packages maintain to the regular
+37,Customer#000000037,88065.7458,-917.75,INDIA,7EV4Pwh,3SboctTWt,18-385-235-7162,ilent packages are carefully among the deposits. furiousl
+82,Customer#000000082,86998.9644,9468.34,CHINA,zhG3EZbap4c992Gj3bK,3Ne,Xn,28-159-442-5305,s wake. bravely regular accounts are furiously. regula
+125,Customer#000000125,84808.068,-234.12,ROMANIA,,wSZXdVR xxIIfm9s8ITyLl3kgjT6UC07GY0Y,29-261-996-3120,x-ray finally after the packages? regular requests c
+59,Customer#000000059,84655.5711,3458.6,ARGENTINA,zLOCP0wh92OtBihgspOGl4,11-355-584-3112,ously final packages haggle blithely after the express deposits. furiou
 

--- a/test/regress/expect/tpch0001_d/q11.txt
+++ b/test/regress/expect/tpch0001_d/q11.txt
@@ -25,59 +25,59 @@ group by
 		)
 order by
 	value desc
-Total cost: 3136.66, memory=47688
-PhysicOrder  (inccost=3136.66, cost=358.56, rows=80, memory=960) (actual rows=0)
+Total cost: 3150.56, memory=2896
+PhysicOrder  (inccost=3150.56, cost=358.56, rows=80, memory=960) (actual rows=0)
     Output: ps_partkey[0],{sum(ps_supplycost*ps_availqty)}[1]
     Order by: {sum(ps_supplycost*ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=2778.1, cost=240, rows=80, memory=1920) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2792, cost=240, rows=80, memory=1920) (actual rows=0)
         Output: {ps_partkey}[0],{sum(ps_supplycost*ps_availqty)}[1]
         Aggregates: sum(ps_supplycost[2]*ps_availqty[3])
         Group by: ps_partkey[0]
         Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=2620.1, cost=82, rows=1, memory=16) (actual rows=0)
+            -> PhysicHashAgg  (inccost=2634, cost=82, rows=1, memory=16) (actual rows=0)
                 Output: {sum(ps_supplycost*ps_availqty)}[0]*0.0001
                 Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                -> PhysicGather 1 : 10 (inccost=2538.1, cost=8, rows=80) (actual rows=0)
-                    Output: {ps_supplycost*ps_availqty}[0],ps_supplycost[1],ps_availqty[2]
-                    -> PhysicHashJoin  (inccost=2530.1, cost=1681, rows=80, memory=38400) (actual rows=0)
-                        Output: {ps_supplycost*ps_availqty}[0],ps_supplycost[1],ps_availqty[2]
-                        Filter: ps_suppkey[3]=s_suppkey[4]
-                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
-                            Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-                        -> PhysicRedistribute  (inccost=49.1, cost=0.1, rows=1) (actual rows=0)
+                -> PhysicGather 1 : 10 (inccost=2552, cost=800, rows=80) (actual rows=0)
+                    Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
+                    -> PhysicHashJoin  (inccost=1752, cost=882, rows=80, memory=8) (actual rows=0)
+                        Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
+                        Filter: ps_suppkey[4]=s_suppkey[0]
+                        -> PhysicRedistribute  (inccost=70, cost=2, rows=1) (actual rows=0)
                             Output: s_suppkey[0]
-                            -> PhysicHashJoin  (inccost=49, cost=13, rows=1, memory=8) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=68, cost=13, rows=1, memory=8) (actual rows=0)
                                 Output: s_suppkey[1]
                                 Filter: s_nationkey[2]=n_nationkey[0]
                                 -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
                                     Output: n_nationkey[0]
                                     Filter: n_name[1]='GERMANY'
-                                -> PhysicRedistribute  (inccost=11, cost=1, rows=10) (actual rows=0)
+                                -> PhysicRedistribute  (inccost=30, cost=20, rows=10) (actual rows=0)
                                     Output: s_suppkey[0],s_nationkey[1]
                                     -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
                                         Output: s_suppkey[0],s_nationkey[3]
+                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                            Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
 
 Emulated 10 machines distributed run with 30 threads
-        -> PhysicGather 1 : 10 (inccost=2538.1, cost=8, rows=80) (actual rows=0)
-            Output: ps_partkey[0],{ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
-            -> PhysicHashJoin  (inccost=2530.1, cost=1681, rows=80, memory=44800) (actual rows=0)
-                Output: ps_partkey[0],{ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
-                Filter: ps_suppkey[4]=s_suppkey[5]
-                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
-                    Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-                -> PhysicRedistribute  (inccost=49.1, cost=0.1, rows=1) (actual rows=0)
+        -> PhysicGather 1 : 10 (inccost=2552, cost=800, rows=80) (actual rows=0)
+            Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
+            -> PhysicHashJoin  (inccost=1752, cost=882, rows=80, memory=8) (actual rows=0)
+                Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
+                Filter: ps_suppkey[5]=s_suppkey[0]
+                -> PhysicRedistribute  (inccost=70, cost=2, rows=1) (actual rows=0)
                     Output: s_suppkey[0]
-                    -> PhysicHashJoin  (inccost=49, cost=13, rows=1, memory=8) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=68, cost=13, rows=1, memory=8) (actual rows=0)
                         Output: s_suppkey[1]
                         Filter: s_nationkey[2]=n_nationkey[0]
                         -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=0)
                             Output: n_nationkey[0]
                             Filter: n_name[1]='GERMANY'
-                        -> PhysicRedistribute  (inccost=11, cost=1, rows=10) (actual rows=0)
+                        -> PhysicRedistribute  (inccost=30, cost=20, rows=10) (actual rows=0)
                             Output: s_suppkey[0],s_nationkey[1]
                             -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
                                 Output: s_suppkey[0],s_nationkey[3]
+                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                    Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
 
 Emulated 10 machines distributed run with 30 threads
 

--- a/test/regress/expect/tpch0001_d/q11.txt
+++ b/test/regress/expect/tpch0001_d/q11.txt
@@ -25,60 +25,56 @@ group by
 		)
 order by
 	value desc
-Total cost: 3150.56, memory=2896
-PhysicOrder  (inccost=3150.56, cost=358.56, rows=80, memory=960) (actual rows=0)
+Total cost: 3130.56, memory=2896
+PhysicOrder  (inccost=3130.56, cost=358.56, rows=80, memory=960) (actual rows=0)
     Output: ps_partkey[0],{sum(ps_supplycost*ps_availqty)}[1]
     Order by: {sum(ps_supplycost*ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=2792, cost=240, rows=80, memory=1920) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2772, cost=240, rows=80, memory=1920) (actual rows=0)
         Output: {ps_partkey}[0],{sum(ps_supplycost*ps_availqty)}[1]
         Aggregates: sum(ps_supplycost[2]*ps_availqty[3])
         Group by: ps_partkey[0]
         Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=2634, cost=82, rows=1, memory=16) (actual rows=0)
+            -> PhysicHashAgg  (inccost=2614, cost=82, rows=1, memory=16) (actual rows=0)
                 Output: {sum(ps_supplycost*ps_availqty)}[0]*0.0001
                 Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                -> PhysicGather 1 : 10 (inccost=2552, cost=800, rows=80) (actual rows=0)
+                -> PhysicGather 1 : 10 (inccost=2532, cost=800, rows=80) (actual rows=0)
                     Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
-                    -> PhysicHashJoin  (inccost=1752, cost=882, rows=80, memory=8) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0)
                         Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
                         Filter: ps_suppkey[4]=s_suppkey[0]
-                        -> PhysicRedistribute  (inccost=70, cost=2, rows=1) (actual rows=0)
+                        -> PhysicRedistribute  (inccost=50, cost=2, rows=1) (actual rows=0)
                             Output: s_suppkey[0]
-                            -> PhysicHashJoin  (inccost=68, cost=13, rows=1, memory=8) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0)
                                 Output: s_suppkey[1]
                                 Filter: s_nationkey[2]=n_nationkey[0]
                                 -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=0)
                                     Output: n_nationkey[0]
                                     Filter: n_name[1]='GERMANY'
-                                -> PhysicRedistribute  (inccost=30, cost=20, rows=10) (actual rows=0)
-                                    Output: s_suppkey[0],s_nationkey[1]
-                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
-                                        Output: s_suppkey[0],s_nationkey[3]
+                                -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                                    Output: s_suppkey[0],s_nationkey[3]
                         -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
                             Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
 
-Emulated 10 machines distributed run with 30 threads
-        -> PhysicGather 1 : 10 (inccost=2552, cost=800, rows=80) (actual rows=0)
+Emulated 10 machines distributed run with 20 threads
+        -> PhysicGather 1 : 10 (inccost=2532, cost=800, rows=80) (actual rows=0)
             Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
-            -> PhysicHashJoin  (inccost=1752, cost=882, rows=80, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0)
                 Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
                 Filter: ps_suppkey[5]=s_suppkey[0]
-                -> PhysicRedistribute  (inccost=70, cost=2, rows=1) (actual rows=0)
+                -> PhysicRedistribute  (inccost=50, cost=2, rows=1) (actual rows=0)
                     Output: s_suppkey[0]
-                    -> PhysicHashJoin  (inccost=68, cost=13, rows=1, memory=8) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0)
                         Output: s_suppkey[1]
                         Filter: s_nationkey[2]=n_nationkey[0]
                         -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=0)
                             Output: n_nationkey[0]
                             Filter: n_name[1]='GERMANY'
-                        -> PhysicRedistribute  (inccost=30, cost=20, rows=10) (actual rows=0)
-                            Output: s_suppkey[0],s_nationkey[1]
-                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
-                                Output: s_suppkey[0],s_nationkey[3]
+                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                            Output: s_suppkey[0],s_nationkey[3]
                 -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                     Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
 
-Emulated 10 machines distributed run with 30 threads
+Emulated 10 machines distributed run with 20 threads
 
 

--- a/test/regress/expect/tpch0001_d/q12.txt
+++ b/test/regress/expect/tpch0001_d/q12.txt
@@ -26,24 +26,24 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 11311.42, memory=177378
-PhysicOrder  (inccost=11311.42, cost=14.32, rows=7, memory=126) (actual rows=2)
+Total cost: 12547.32, memory=20458
+PhysicOrder  (inccost=12547.32, cost=14.32, rows=7, memory=126) (actual rows=2)
     Output: l_shipmode[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=11297.1, cost=265, rows=7, memory=252) (actual rows=2)
+    -> PhysicHashAgg  (inccost=12533, cost=265, rows=7, memory=252) (actual rows=2)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicGather 1 : 10 (inccost=11032.1, cost=25.1, rows=251) (actual rows=25)
-            Output: l_shipmode[14],{case with 1}[0],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[1],{o_orderpriority='1-URGENT'}[2],o_orderpriority[3],{'1-URGENT'}[4],{o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[10],{o_orderpriority<>'1-URGENT'}[11],{o_orderpriority<>'2-HIGH'}[12]
-            -> PhysicHashJoin  (inccost=11007, cost=3502, rows=251, memory=177000) (actual rows=0)
-                Output: l_shipmode[14],{case with 1}[0],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[1],{o_orderpriority='1-URGENT'}[2],o_orderpriority[3],{'1-URGENT'}[4],{o_orderpriority='2-HIGH'}[5],{'2-HIGH'}[6],{1}[7],{0}[8],{case with 1}[9],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[10],{o_orderpriority<>'1-URGENT'}[11],{o_orderpriority<>'2-HIGH'}[12]
-                Filter: o_orderkey[13]=l_orderkey[15]
-                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
-                    Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],'1-URGENT',o_orderpriority[5]='2-HIGH','2-HIGH',1,0,case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
+        -> PhysicGather 1 : 10 (inccost=12268, cost=2510, rows=251) (actual rows=25)
+            Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
+            -> PhysicHashJoin  (inccost=9758, cost=2253, rows=251, memory=20080) (actual rows=0)
+                Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
+                Filter: o_orderkey[15]=l_orderkey[5]
                 -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=251) (actual rows=0)
-                    Output: l_shipmode[14],l_orderkey[0]
+                    Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                     Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
+                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
+                    Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
 
 Emulated 10 machines distributed run with 10 threads
 MAIL,5,5

--- a/test/regress/expect/tpch0001_d/q16.txt
+++ b/test/regress/expect/tpch0001_d/q16.txt
@@ -28,35 +28,35 @@ order by
 	p_brand,
 	p_type,
 	p_size
-Total cost: 4078.18, memory=31892
-PhysicOrder  (inccost=4078.18, cost=754.38, rows=148, memory=6364) (actual rows=0)
+Total cost: 6300.38, memory=22274
+PhysicOrder  (inccost=6300.38, cost=754.38, rows=148, memory=6364) (actual rows=0)
     Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
     Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
-    -> PhysicHashAgg  (inccost=3323.8, cost=444, rows=148, memory=12728) (actual rows=0)
+    -> PhysicHashAgg  (inccost=5546, cost=444, rows=148, memory=12728) (actual rows=0)
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicGather 1 : 10 (inccost=2879.8, cost=14.8, rows=148) (actual rows=0)
-            Output: p_brand[2],p_type[3],p_size[4],ps_suppkey[0]
-            -> PhysicHashJoin  (inccost=2865, cost=1785, rows=148, memory=12800) (actual rows=0)
-                Output: p_brand[2],p_type[3],p_size[4],ps_suppkey[0]
-                Filter: p_partkey[5]=ps_partkey[1]
-                -> PhysicRedistribute  (inccost=880, cost=80, rows=800) (actual rows=0)
+        -> PhysicGather 1 : 10 (inccost=5102, cost=1480, rows=148) (actual rows=0)
+            Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
+            -> PhysicHashJoin  (inccost=3622, cost=1022, rows=148, memory=3182) (actual rows=0)
+                Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
+                Filter: p_partkey[3]=ps_partkey[5]
+                -> PhysicScanTable part (inccost=200, cost=200, rows=37) (actual rows=0)
+                    Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
+                    Filter: p_brand[3]<>'Brand#45' and p_type[4]not like'MEDIUM POLISHED%' and p_size[5] in (49,14,23, ... <Total: 8> )
+                -> PhysicRedistribute  (inccost=2400, cost=1600, rows=800) (actual rows=0)
                     Output: ps_suppkey[0],ps_partkey[1]
                     -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                         Output: ps_suppkey[1],ps_partkey[0]
                         Filter: ps_suppkey[1] in @1
                         <InSubqueryExpr> cached 1
-                            -> PhysicGather 1 : 10 (inccost=10.1, cost=0.1, rows=1) (actual rows=0)
+                            -> PhysicGather 1 : 10 (inccost=20, cost=10, rows=1) (actual rows=0)
                                 Output: s_suppkey[0]
                                 -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
                                     Output: s_suppkey[0]
                                     Filter: s_comment[6]like'%Customer%Complaints%'
 
 Emulated 10 machines distributed run with 10 threads
-                -> PhysicScanTable part (inccost=200, cost=200, rows=37) (actual rows=0)
-                    Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
-                    Filter: p_brand[3]<>'Brand#45' and p_type[4]not like'MEDIUM POLISHED%' and p_size[5] in (49,14,23, ... <Total: 8> )
 
 Emulated 10 machines distributed run with 20 threads
 

--- a/test/regress/expect/tpch0001_d/q19.txt
+++ b/test/regress/expect/tpch0001_d/q19.txt
@@ -33,24 +33,24 @@ where
 		and l_shipmode in ('AIR', 'AIR REG')
 		and l_shipinstruct = 'DELIVER IN PERSON'
 	)
-Total cost: 2591077.5, memory=16
-PhysicHashAgg  (inccost=2591077.5, cost=1201002, rows=1, memory=16) (actual rows=1)
+Total cost: 2532407, memory=16
+PhysicHashAgg  (inccost=2532407, cost=1201002, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice*1-l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*1-l_discount[4])
-    -> PhysicGather 1 : 10 (inccost=1390075.5, cost=120100, rows=1201000) (actual rows=0)
-        Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],1,l_discount[4]
-        -> PhysicNLJoin  (inccost=1269975.5, cost=1263150, rows=1201000) (actual rows=0)
-            Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],1,l_discount[4]
-            Filter: p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12' and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and l_quantity[6]>=1 and l_quantity[6]<=11 and p_size[12]>=1 and p_size[12]<=5 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23' and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and l_quantity[6]>=10 and l_quantity[6]<=20 and p_size[12]>=1 and p_size[12]<=10 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34' and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and l_quantity[6]>=20 and l_quantity[6]<=30 and p_size[12]>=1 and p_size[12]<=15 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON'
-            -> PhysicRedistribute  (inccost=6605.5, cost=600.5, rows=6005) (actual rows=0)
-                Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],{1}[3],l_discount[4],l_partkey[5],l_quantity[6],l_shipmode[7],l_shipinstruct[8]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
-                    Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
-            -> PhysicRedistribute  (inccost=220, cost=20, rows=200) (actual rows=0)
-                Output: p_partkey[0],p_brand[1],p_container[2],p_size[3]
-                -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
-                    Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
+    -> PhysicNLJoin  (inccost=1331405, cost=1263150, rows=1201000) (actual rows=0)
+        Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],{1}[3],l_discount[4]
+        Filter: p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12' and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and l_quantity[6]>=1 and l_quantity[6]<=11 and p_size[12]>=1 and p_size[12]<=5 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23' and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and l_quantity[6]>=10 and l_quantity[6]<=20 and p_size[12]>=1 and p_size[12]<=10 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34' and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and l_quantity[6]>=20 and l_quantity[6]<=30 and p_size[12]>=1 and p_size[12]<=15 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON'
+        -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=6005)
+            Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
 
-Emulated 10 machines distributed run with 30 threads
+Emulated 10 machines distributed run with 10 threads
+        -> PhysicGather 1 : 10 (inccost=2200, cost=2000, rows=200) (actual rows=0, loops=6005)
+            Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
+            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
+                Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
+
+Emulated 10 machines distributed run with 10 threads
 
 


### PR DESCRIPTION
Distribution attribute is added into physic property. Since in the new framework, all the requirements are regarded as top-to-down requirements, there are 4 different types of distribution requirements:
1) Singleton: not distributed execution
2) Distributed (on Expr list): need to be hash distributed according to certain list of expressions
3) Replicated: data stream is replicated across the threads
4) Any: can be supplied by any distribution (i.e., anything will work)

The default base requirement is singleton and any order posed on top. For query concerning distributed tables, logic tree comes with remote exchange nodes like redistribution and gather. For memo optimization, these nodes are removed from the logic tree and distribution transformation is enabled. Previously, all distributed queries are blocked from using memo, now with an additional option parameter memo_use_remoteexchange_, they can be optimized by memo, and no change in the calculation for non-distributed queries.
There are two special cases for distribution. Replicated distribution is not considered in Any since it uses a different gather enforcement node. For a hash join, a replicated requirement results in replicated requirement on both children. There is also a round robin for table data distribution, it is considered as distributed with empty expression list. It will need to be redistributed if any particular distributed is required but can satisfy any.

For example, this query: `select a1, count(b1) from ad, b where a1 > b2 group by a1 order by a1`
In this case, ad is distributed on a1. The base required property is <a1-asc, singleton> and the root group is aggregate.
<a1-asc, singleton> is then transformed in to <none, singleton>, and that is further transformed into <none, any> and <none, replicated.
Assume hashagg and streamagg is only compatible with singleton, so <none, any> and <none, replicated> cannot be supported. For this group, it may be that <a1-asc, singleton> is directly supported by streamagg, and same property requirement posed on the child group, and <none, singleton> may be supported by hashagg, the requirement on child group is then <none, singleton>.
Consider join group after that similarly, the requirements are transformed to get <none, any> and <none, replicated>. For the case of hashjoin, <none, any> required on top will result in 4 different set of child requirements:
{<none, singleton>, <none, dist on b2>} {<none, dist on a1>, <none, singleton>} {<none, dist on a1>, <none, dist on b2>} {<none, replicated>, <none, dist on b2>}
For {<none, singleton>, <none, singleton>}, the result is singleton, that situation should be considered in the <none, singleton> requirement. Also, the join order is not demonstrated since it is included in the logic join transformation rules.
If there are more than one set of child requirements, the inclusive cost for each set is calculation and the least-cost set is select. In this case, it may be that {<none, dist on a1>, <none, singleton>} is the best set since no enforcement will be needed for the table scan.
