### PR TITLE
teach all expression in the same use the same card

### DIFF
--- a/test/regress/expect/jobench/10a.txt
+++ b/test/regress/expect/jobench/10a.txt
@@ -19,23 +19,23 @@ WHERE ci.note LIKE '%(voice)%'
   AND rt.id = ci.role_id
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
-Total cost: 51550734, memory=6442451144
-PhysicHashAgg  (inccost=51550734, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 51550733, memory=6442451144
+PhysicHashAgg  (inccost=51550733, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=51550731, cost=3140342, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=51550730, cost=3140342, rows=1, memory=2147483656) (actual rows=0)
         Output: name[2],title[0]
         Filter: id[3]=person_role_id[1]
-        -> PhysicHashJoin  (inccost=45270050, cost=1042587, rows=1, memory=24) (actual rows=0)
+        -> PhysicHashJoin  (inccost=45270049, cost=1042587, rows=1, memory=24) (actual rows=0)
             Output: title[3],person_role_id[0]
             Filter: id[4]=movie_id[1] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=41699151, cost=4, rows=1, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=41699150, cost=4, rows=1, memory=8) (actual rows=0)
                 Output: person_role_id[1],movie_id[2],movie_id[3]
                 Filter: id[0]=role_id[4]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='actor'
-                -> PhysicHashJoin  (inccost=41699135, cost=8, rows=2, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=41699134, cost=7, rows=1, memory=40) (actual rows=0)
                     Output: person_role_id[0],movie_id[1],movie_id[2],role_id[3]
                     Filter: id[5]=company_type_id[4]
                     -> PhysicHashJoin  (inccost=41699123, cost=1520, rows=1, memory=96) (actual rows=0)

--- a/test/regress/expect/jobench/10c.txt
+++ b/test/regress/expect/jobench/10c.txt
@@ -17,22 +17,22 @@ WHERE ci.note LIKE '%(producer)%'
   AND rt.id = ci.role_id
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
-Total cost: 52403431, memory=6442468480
-PhysicHashAgg  (inccost=52403431, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 52403432, memory=6442468480
+PhysicHashAgg  (inccost=52403432, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=52403428, cost=3140342, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=52403429, cost=3140342, rows=1, memory=2147483656) (actual rows=0)
         Output: name[2],title[0]
         Filter: id[3]=person_role_id[1]
-        -> PhysicHashJoin  (inccost=46122747, cost=1800763, rows=1, memory=4632) (actual rows=0)
+        -> PhysicHashJoin  (inccost=46122748, cost=1800763, rows=1, memory=4632) (actual rows=0)
             Output: title[3],person_role_id[0]
             Filter: id[4]=movie_id[1] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=41793672, cost=394, rows=193, memory=96) (actual rows=0)
+            -> PhysicHashJoin  (inccost=41793673, cost=394, rows=193, memory=96) (actual rows=0)
                 Output: person_role_id[1],movie_id[2],movie_id[3]
                 Filter: id[0]=role_id[4]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=12) (actual rows=0)
                     Output: id[0]
-                -> PhysicHashJoin  (inccost=41793266, cost=272, rows=176, memory=32) (actual rows=0)
+                -> PhysicHashJoin  (inccost=41793267, cost=273, rows=177, memory=32) (actual rows=0)
                     Output: person_role_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[0]=company_type_id[5]
                     -> PhysicScanTable company_type as ct (inccost=4, cost=4, rows=4) (actual rows=0)

--- a/test/regress/expect/jobench/11c.txt
+++ b/test/regress/expect/jobench/11c.txt
@@ -29,26 +29,26 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mk.movie_id
   AND ml.movie_id = mc.movie_id
   AND mk.movie_id = mc.movie_id
-Total cost: 19582992, memory=2385854366184
-PhysicHashAgg  (inccost=19582992, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 19582994, memory=2390149333528
+PhysicHashAgg  (inccost=19582994, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(note)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(note[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=19582989, cost=4, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=19582991, cost=4, rows=1, memory=2147483656) (actual rows=0)
         Output: name[0],note[2],title[3]
         Filter: company_id[4]=id[1]
         -> PhysicScanTable company_name as cn (inccost=234997, cost=234997, rows=1) (actual rows=0)
             Output: name[1],id[0]
             Filter: country_code[2]!='[pl]' and name[1]like'20th Century Fox%' or name[1]like'Twentieth Century Fox%'
-        -> PhysicHashJoin  (inccost=19347988, cost=2354613, rows=1, memory=2147483680) (actual rows=0)
+        -> PhysicHashJoin  (inccost=19347990, cost=2354613, rows=1, memory=2147483680) (actual rows=0)
             Output: note[0],title[5],company_id[1]
             Filter: movie_id[2]=id[6] and id[6]=movie_id[3] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=14465063, cost=21, rows=1, memory=2147483688) (actual rows=0)
+            -> PhysicHashJoin  (inccost=14465065, cost=21, rows=1, memory=2147483688) (actual rows=0)
                 Output: note[0],company_id[1],movie_id[2],movie_id[3],movie_id[4]
                 Filter: id[6]=link_type_id[5]
-                -> PhysicHashJoin  (inccost=14465024, cost=32212, rows=1, memory=2372969457560) (actual rows=0)
+                -> PhysicHashJoin  (inccost=14465026, cost=32212, rows=1, memory=2377264424904) (actual rows=0)
                     Output: note[0],company_id[1],movie_id[4],movie_id[2],movie_id[3],link_type_id[5]
                     Filter: movie_id[4]=movie_id[3] and movie_id[4]=movie_id[2]
-                    -> PhysicHashJoin  (inccost=14402815, cost=2611042, rows=1105, memory=6464) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=14402817, cost=2611044, rows=1107, memory=6464) (actual rows=0)
                         Output: note[2],company_id[3],movie_id[0],movie_id[4]
                         Filter: movie_id[0]=movie_id[4] and company_type_id[5]=id[1]
                         -> PhysicHashJoin  (inccost=9182644, cost=4524358, rows=404, memory=192) (actual rows=0)

--- a/test/regress/expect/jobench/11d.txt
+++ b/test/regress/expect/jobench/11d.txt
@@ -27,23 +27,23 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mk.movie_id
   AND ml.movie_id = mc.movie_id
   AND mk.movie_id = mc.movie_id
-Total cost: 19817988, memory=2388001849832
-PhysicHashAgg  (inccost=19817988, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 19817990, memory=2392296817176
+PhysicHashAgg  (inccost=19817990, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(note)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(note[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=19817985, cost=235000, rows=1, memory=4294967304) (actual rows=0)
+    -> PhysicHashJoin  (inccost=19817987, cost=235000, rows=1, memory=4294967304) (actual rows=0)
         Output: name[3],note[0],title[1]
         Filter: company_id[2]=id[4]
-        -> PhysicHashJoin  (inccost=19347988, cost=2354613, rows=1, memory=2147483680) (actual rows=0)
+        -> PhysicHashJoin  (inccost=19347990, cost=2354613, rows=1, memory=2147483680) (actual rows=0)
             Output: note[0],title[5],company_id[1]
             Filter: movie_id[2]=id[6] and id[6]=movie_id[3] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=14465063, cost=21, rows=1, memory=2147483688) (actual rows=0)
+            -> PhysicHashJoin  (inccost=14465065, cost=21, rows=1, memory=2147483688) (actual rows=0)
                 Output: note[0],company_id[1],movie_id[2],movie_id[3],movie_id[4]
                 Filter: id[6]=link_type_id[5]
-                -> PhysicHashJoin  (inccost=14465024, cost=32212, rows=1, memory=2372969457560) (actual rows=0)
+                -> PhysicHashJoin  (inccost=14465026, cost=32212, rows=1, memory=2377264424904) (actual rows=0)
                     Output: note[0],company_id[1],movie_id[4],movie_id[2],movie_id[3],link_type_id[5]
                     Filter: movie_id[4]=movie_id[3] and movie_id[4]=movie_id[2]
-                    -> PhysicHashJoin  (inccost=14402815, cost=2611042, rows=1105, memory=6464) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=14402817, cost=2611044, rows=1107, memory=6464) (actual rows=0)
                         Output: note[2],company_id[3],movie_id[0],movie_id[4]
                         Filter: movie_id[0]=movie_id[4] and company_type_id[5]=id[1]
                         -> PhysicHashJoin  (inccost=9182644, cost=4524358, rows=404, memory=192) (actual rows=0)

--- a/test/regress/expect/jobench/14a.txt
+++ b/test/regress/expect/jobench/14a.txt
@@ -37,23 +37,23 @@ WHERE it1.info = 'countries'
   AND k.id = mk.keyword_id
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id
-Total cost: 30360181, memory=45097160400
-PhysicHashAgg  (inccost=30360181, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 30360182, memory=47244644072
+PhysicHashAgg  (inccost=30360182, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=30360178, cost=4, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=30360179, cost=4, rows=1, memory=8) (actual rows=0)
         Output: info[1],title[2]
         Filter: id[0]=info_type_id[3]
         -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
             Output: id[0]
             Filter: info[1]='countries'
-        -> PhysicHashJoin  (inccost=30360061, cost=1338340, rows=1, memory=2147483688) (actual rows=0)
+        -> PhysicHashJoin  (inccost=30360062, cost=1338340, rows=1, memory=2147483688) (actual rows=0)
             Output: info[6],title[0],info_type_id[1]
             Filter: movie_id[2]=movie_id[7] and id[3]=movie_id[7] and movie_id[4]=movie_id[7] and id[5]=info_type_id[8]
-            -> PhysicHashJoin  (inccost=27641686, cost=691697, rows=1, memory=38654706096) (actual rows=0)
+            -> PhysicHashJoin  (inccost=27641687, cost=691697, rows=1, memory=40802189768) (actual rows=0)
                 Output: title[0],info_type_id[4],movie_id[1],id[2],movie_id[5],id[3]
                 Filter: movie_id[1]=movie_id[5] and id[2]=movie_id[5]
-                -> PhysicHashJoin  (inccost=12114269, cost=403357, rows=18, memory=3216) (actual rows=0)
+                -> PhysicHashJoin  (inccost=12114270, cost=403358, rows=19, memory=3216) (actual rows=0)
                     Output: title[3],movie_id[0],id[4],id[1]
                     Filter: id[2]=kind_id[5] and id[4]=movie_id[0]
                     -> PhysicHashJoin  (inccost=9182600, cost=4524072, rows=134, memory=96) (actual rows=0)

--- a/test/regress/expect/jobench/14c.txt
+++ b/test/regress/expect/jobench/14c.txt
@@ -39,26 +39,26 @@ WHERE it1.info = 'countries'
   AND k.id = mk.keyword_id
   AND it1.id = mi.info_type_id
   AND it2.id = mi_idx.info_type_id
-Total cost: 31009255, memory=178241146288
-PhysicHashAgg  (inccost=31009255, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 31009256, memory=180388629952
+PhysicHashAgg  (inccost=31009256, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=31009252, cost=4, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=31009253, cost=4, rows=1, memory=8) (actual rows=0)
         Output: info[1],title[2]
         Filter: id[0]=info_type_id[3]
         -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
             Output: id[0]
             Filter: info[1]='countries'
-        -> PhysicHashJoin  (inccost=31009135, cost=701194, rows=1, memory=4294967320) (actual rows=0)
+        -> PhysicHashJoin  (inccost=31009136, cost=701194, rows=1, memory=4294967320) (actual rows=0)
             Output: info[0],title[1],info_type_id[5]
             Filter: movie_id[6]=movie_id[2] and movie_id[3]=movie_id[6] and id[4]=movie_id[6]
-            -> PhysicHashJoin  (inccost=15472221, cost=5, rows=1, memory=4294967328) (actual rows=0)
+            -> PhysicHashJoin  (inccost=15472222, cost=5, rows=1, memory=4294967328) (actual rows=0)
                 Output: info[0],title[1],movie_id[2],movie_id[3],id[4]
                 Filter: id[6]=kind_id[5]
-                -> PhysicHashJoin  (inccost=15472209, cost=1042741, rows=1, memory=165356242128) (actual rows=0)
+                -> PhysicHashJoin  (inccost=15472210, cost=1042741, rows=1, memory=167503725792) (actual rows=0)
                     Output: info[0],title[3],movie_id[1],movie_id[2],id[4],kind_id[5]
                     Filter: id[4]=movie_id[1] and id[4]=movie_id[2]
-                    -> PhysicHashJoin  (inccost=11901156, cost=1338682, rows=77, memory=2144) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=11901157, cost=1338683, rows=78, memory=2144) (actual rows=0)
                         Output: info[2],movie_id[3],movie_id[0]
                         Filter: movie_id[0]=movie_id[3] and id[1]=info_type_id[4]
                         -> PhysicHashJoin  (inccost=9182439, cost=4524072, rows=134, memory=64) (actual rows=0)

--- a/test/regress/expect/jobench/15a.txt
+++ b/test/regress/expect/jobench/15a.txt
@@ -30,26 +30,26 @@ WHERE cn.country_code = '[us]'
   AND it1.id = mi.info_type_id
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
-Total cost: 31763871, memory=25769804016
-PhysicHashAgg  (inccost=31763871, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 31763870, memory=23622320344
+PhysicHashAgg  (inccost=31763870, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=31763868, cost=361475, rows=1, memory=4294967328) (actual rows=0)
+    -> PhysicHashJoin  (inccost=31763867, cost=361475, rows=1, memory=4294967328) (actual rows=0)
         Output: info[0],title[1]
         Filter: id[2]=movie_id[6] and movie_id[3]=movie_id[6] and movie_id[4]=movie_id[6] and movie_id[5]=movie_id[6]
-        -> PhysicHashJoin  (inccost=31040921, cost=1421962, rows=1, memory=2147483672) (actual rows=0)
+        -> PhysicHashJoin  (inccost=31040920, cost=1421962, rows=1, memory=2147483672) (actual rows=0)
             Output: info[0],title[4],id[5],movie_id[1],movie_id[2],movie_id[3]
             Filter: id[5]=movie_id[2] and id[5]=movie_id[1] and id[5]=movie_id[3]
-            -> PhysicHashJoin  (inccost=27090647, cost=134173, rows=1, memory=2147483680) (actual rows=0)
+            -> PhysicHashJoin  (inccost=27090646, cost=134173, rows=1, memory=2147483680) (actual rows=0)
                 Output: info[0],movie_id[1],movie_id[2],movie_id[3]
                 Filter: id[5]=keyword_id[4]
-                -> PhysicHashJoin  (inccost=26822304, cost=4523933, rows=1, memory=2147483664) (actual rows=0)
+                -> PhysicHashJoin  (inccost=26822303, cost=4523933, rows=1, memory=2147483664) (actual rows=0)
                     Output: info[0],movie_id[3],movie_id[1],movie_id[2],keyword_id[4]
                     Filter: movie_id[3]=movie_id[2] and movie_id[3]=movie_id[1]
-                    -> PhysicHashJoin  (inccost=17774441, cost=4, rows=1, memory=4294967344) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=17774440, cost=4, rows=1, memory=2147483672) (actual rows=0)
                         Output: info[0],movie_id[1],movie_id[2]
                         Filter: id[4]=info_type_id[3]
-                        -> PhysicHashJoin  (inccost=17774324, cost=8, rows=2, memory=2147483680) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=17774323, cost=7, rows=1, memory=2147483680) (actual rows=0)
                             Output: info[0],movie_id[1],movie_id[2],info_type_id[3]
                             Filter: id[5]=company_type_id[4]
                             -> PhysicHashJoin  (inccost=17774312, cost=94462, rows=1, memory=2147483688) (actual rows=0)

--- a/test/regress/expect/jobench/15b.txt
+++ b/test/regress/expect/jobench/15b.txt
@@ -31,26 +31,26 @@ WHERE cn.country_code = '[us]'
   AND it1.id = mi.info_type_id
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
-Total cost: 30984761, memory=23622320336
-PhysicHashAgg  (inccost=30984761, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 30984760, memory=21474836664
+PhysicHashAgg  (inccost=30984760, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=30984758, cost=361475, rows=1, memory=4294967328) (actual rows=0)
+    -> PhysicHashJoin  (inccost=30984757, cost=361475, rows=1, memory=4294967328) (actual rows=0)
         Output: info[0],title[1]
         Filter: id[2]=movie_id[6] and movie_id[3]=movie_id[6] and movie_id[4]=movie_id[6] and movie_id[5]=movie_id[6]
-        -> PhysicHashJoin  (inccost=30261811, cost=737310, rows=1, memory=2147483672) (actual rows=0)
+        -> PhysicHashJoin  (inccost=30261810, cost=737310, rows=1, memory=2147483672) (actual rows=0)
             Output: info[0],title[4],id[5],movie_id[1],movie_id[2],movie_id[3]
             Filter: id[5]=movie_id[2] and id[5]=movie_id[1] and id[5]=movie_id[3]
-            -> PhysicHashJoin  (inccost=26996189, cost=134173, rows=1, memory=2147483680) (actual rows=0)
+            -> PhysicHashJoin  (inccost=26996188, cost=134173, rows=1, memory=2147483680) (actual rows=0)
                 Output: info[0],movie_id[1],movie_id[2],movie_id[3]
                 Filter: id[5]=keyword_id[4]
-                -> PhysicHashJoin  (inccost=26727846, cost=4523933, rows=1, memory=2147483664) (actual rows=0)
+                -> PhysicHashJoin  (inccost=26727845, cost=4523933, rows=1, memory=2147483664) (actual rows=0)
                     Output: info[0],movie_id[3],movie_id[1],movie_id[2],keyword_id[4]
                     Filter: movie_id[3]=movie_id[2] and movie_id[3]=movie_id[1]
-                    -> PhysicHashJoin  (inccost=17679983, cost=4, rows=1, memory=4294967344) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=17679982, cost=4, rows=1, memory=2147483672) (actual rows=0)
                         Output: info[0],movie_id[1],movie_id[2]
                         Filter: id[4]=info_type_id[3]
-                        -> PhysicHashJoin  (inccost=17679866, cost=8, rows=2, memory=2147483680) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=17679865, cost=7, rows=1, memory=2147483680) (actual rows=0)
                             Output: info[0],movie_id[1],movie_id[2],info_type_id[3]
                             Filter: id[5]=company_type_id[4]
                             -> PhysicHashJoin  (inccost=17679854, cost=4, rows=1, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/15c.txt
+++ b/test/regress/expect/jobench/15c.txt
@@ -30,40 +30,40 @@ WHERE cn.country_code = '[us]'
   AND it1.id = mi.info_type_id
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
-Total cost: 34751416, memory=40802189600
-PhysicHashAgg  (inccost=34751416, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 34751415, memory=21474836656
+PhysicHashAgg  (inccost=34751415, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=34751413, cost=361475, rows=1, memory=4294967328) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34751412, cost=361475, rows=1, memory=4294967328) (actual rows=0)
         Output: info[0],title[1]
         Filter: id[2]=movie_id[6] and movie_id[3]=movie_id[6] and movie_id[4]=movie_id[6] and movie_id[5]=movie_id[6]
-        -> PhysicHashJoin  (inccost=34028466, cost=134173, rows=1, memory=4294967336) (actual rows=0)
-            Output: info[0],title[1],id[2],movie_id[3],movie_id[4],movie_id[5]
-            Filter: id[7]=keyword_id[6]
-            -> PhysicHashJoin  (inccost=33760123, cost=4523933, rows=1, memory=4294967320) (actual rows=0)
-                Output: info[0],title[1],id[2],movie_id[5],movie_id[3],movie_id[4],keyword_id[6]
-                Filter: id[2]=movie_id[5] and movie_id[5]=movie_id[4] and movie_id[5]=movie_id[3]
-                -> PhysicHashJoin  (inccost=24712260, cost=4, rows=1, memory=8589934656) (actual rows=0)
-                    Output: info[0],title[1],id[2],movie_id[3],movie_id[4]
-                    Filter: id[6]=info_type_id[5]
-                    -> PhysicHashJoin  (inccost=24712143, cost=8, rows=2, memory=4294967336) (actual rows=0)
-                        Output: info[0],title[1],id[2],movie_id[3],movie_id[4],info_type_id[5]
-                        Filter: id[7]=company_type_id[6]
-                        -> PhysicHashJoin  (inccost=24712131, cost=94462, rows=1, memory=4294967344) (actual rows=0)
-                            Output: info[0],title[1],id[2],movie_id[3],movie_id[4],info_type_id[5],company_type_id[6]
-                            Filter: id[8]=company_id[7]
-                            -> PhysicHashJoin  (inccost=24382672, cost=2609132, rows=1, memory=4294967320) (actual rows=0)
-                                Output: info[0],title[1],id[2],movie_id[3],movie_id[5],info_type_id[4],company_type_id[6],company_id[7]
-                                Filter: movie_id[3]=movie_id[5] and id[2]=movie_id[5]
-                                -> PhysicHashJoin  (inccost=19164411, cost=1800379, rows=1, memory=2147483664) (actual rows=0)
-                                    Output: info[0],title[3],id[4],movie_id[1],info_type_id[2]
-                                    Filter: id[4]=movie_id[1]
+        -> PhysicHashJoin  (inccost=34028465, cost=1800379, rows=1, memory=2147483672) (actual rows=0)
+            Output: info[0],title[4],id[5],movie_id[1],movie_id[2],movie_id[3]
+            Filter: id[5]=movie_id[2] and id[5]=movie_id[1] and id[5]=movie_id[3]
+            -> PhysicHashJoin  (inccost=29699774, cost=134173, rows=1, memory=2147483680) (actual rows=0)
+                Output: info[0],movie_id[1],movie_id[2],movie_id[3]
+                Filter: id[5]=keyword_id[4]
+                -> PhysicHashJoin  (inccost=29431431, cost=4523933, rows=1, memory=2147483664) (actual rows=0)
+                    Output: info[0],movie_id[3],movie_id[1],movie_id[2],keyword_id[4]
+                    Filter: movie_id[3]=movie_id[2] and movie_id[3]=movie_id[1]
+                    -> PhysicHashJoin  (inccost=20383568, cost=7, rows=1, memory=2147483672) (actual rows=0)
+                        Output: info[0],movie_id[1],movie_id[2]
+                        Filter: id[4]=company_type_id[3]
+                        -> PhysicHashJoin  (inccost=20383557, cost=94462, rows=1, memory=2147483680) (actual rows=0)
+                            Output: info[0],movie_id[1],movie_id[2],company_type_id[3]
+                            Filter: id[5]=company_id[4]
+                            -> PhysicHashJoin  (inccost=20054098, cost=2609132, rows=1, memory=2147483656) (actual rows=0)
+                                Output: info[0],movie_id[1],movie_id[2],company_type_id[3],company_id[4]
+                                Filter: movie_id[1]=movie_id[2]
+                                -> PhysicHashJoin  (inccost=14835837, cost=4, rows=1, memory=8) (actual rows=0)
+                                    Output: info[1],movie_id[2]
+                                    Filter: id[0]=info_type_id[3]
+                                    -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
+                                        Output: id[0]
+                                        Filter: info[1]='release dates'
                                     -> PhysicScanTable movie_info as mi (inccost=14835720, cost=14835720, rows=1) (actual rows=0)
                                         Output: info[3],movie_id[1],info_type_id[2]
                                         Filter: note[4]like'%internet%' and info[3]is notnull and info[3]like'USA:% 199%' or info[3]like'USA:% 200%'
-                                    -> PhysicScanTable title as t (inccost=2528312, cost=2528312, rows=1800376) (actual rows=0)
-                                        Output: title[1],id[0]
-                                        Filter: production_year[4]>1990
                                 -> PhysicScanTable movie_companies as mc (inccost=2609129, cost=2609129, rows=2609129) (actual rows=0)
                                     Output: movie_id[1],company_type_id[3],company_id[2]
                             -> PhysicScanTable company_name as cn (inccost=234997, cost=234997, rows=94459) (actual rows=0)
@@ -71,13 +71,13 @@ PhysicHashAgg  (inccost=34751416, cost=3, rows=1, memory=4294967296) (actual row
                                 Filter: country_code[2]='[us]'
                         -> PhysicScanTable company_type as ct (inccost=4, cost=4, rows=4) (actual rows=0)
                             Output: id[0]
-                    -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
-                        Output: id[0]
-                        Filter: info[1]='release dates'
-                -> PhysicScanTable movie_keyword as mk (inccost=4523930, cost=4523930, rows=4523930) (actual rows=0)
-                    Output: movie_id[1],keyword_id[2]
-            -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=134170) (actual rows=0)
-                Output: id[0]
+                    -> PhysicScanTable movie_keyword as mk (inccost=4523930, cost=4523930, rows=4523930) (actual rows=0)
+                        Output: movie_id[1],keyword_id[2]
+                -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=134170) (actual rows=0)
+                    Output: id[0]
+            -> PhysicScanTable title as t (inccost=2528312, cost=2528312, rows=1800376) (actual rows=0)
+                Output: title[1],id[0]
+                Filter: production_year[4]>1990
         -> PhysicScanTable aka_title as at (inccost=361472, cost=361472, rows=361472) (actual rows=0)
             Output: movie_id[1]
 ,

--- a/test/regress/expect/jobench/15d.txt
+++ b/test/regress/expect/jobench/15d.txt
@@ -27,31 +27,31 @@ WHERE cn.country_code = '[us]'
   AND it1.id = mi.info_type_id
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
-Total cost: 34752587, memory=6442452552
-PhysicHashAgg  (inccost=34752587, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 34752589, memory=6442452600
+PhysicHashAgg  (inccost=34752589, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(title)}[0],{min(title)}[1]
     Aggregates: min(title[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=34752584, cost=361475, rows=1, memory=2147483680) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34752586, cost=361475, rows=1, memory=2147483680) (actual rows=0)
         Output: title[5],title[0]
         Filter: id[1]=movie_id[6] and movie_id[2]=movie_id[6] and movie_id[3]=movie_id[6] and movie_id[4]=movie_id[6]
-        -> PhysicHashJoin  (inccost=34029637, cost=1800379, rows=1, memory=24) (actual rows=0)
+        -> PhysicHashJoin  (inccost=34029639, cost=1800379, rows=1, memory=24) (actual rows=0)
             Output: title[3],id[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[4]=movie_id[1] and id[4]=movie_id[0] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=29700946, cost=134173, rows=1, memory=32) (actual rows=0)
+            -> PhysicHashJoin  (inccost=29700948, cost=134173, rows=1, memory=32) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2]
                 Filter: id[4]=keyword_id[3]
-                -> PhysicHashJoin  (inccost=29432603, cost=4523981, rows=1, memory=384) (actual rows=0)
+                -> PhysicHashJoin  (inccost=29432605, cost=4523981, rows=1, memory=400) (actual rows=0)
                     Output: movie_id[2],movie_id[0],movie_id[1],keyword_id[3]
                     Filter: movie_id[2]=movie_id[1] and movie_id[2]=movie_id[0]
-                    -> PhysicHashJoin  (inccost=20384692, cost=44, rows=24, memory=32) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=20384694, cost=45, rows=25, memory=32) (actual rows=0)
                         Output: movie_id[1],movie_id[2]
                         Filter: id[0]=company_type_id[3]
                         -> PhysicScanTable company_type as ct (inccost=4, cost=4, rows=4) (actual rows=0)
                             Output: id[0]
-                        -> PhysicHashJoin  (inccost=20384644, cost=94535, rows=12, memory=992) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=20384645, cost=94535, rows=12, memory=1024) (actual rows=0)
                             Output: movie_id[0],movie_id[1],company_type_id[2]
                             Filter: id[4]=company_id[3]
-                            -> PhysicHashJoin  (inccost=20055112, cost=2609186, rows=31, memory=104) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=20055113, cost=2609187, rows=32, memory=104) (actual rows=0)
                                 Output: movie_id[0],movie_id[1],company_type_id[2],company_id[3]
                                 Filter: movie_id[0]=movie_id[1]
                                 -> PhysicHashJoin  (inccost=14836797, cost=964, rows=13, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/16a.txt
+++ b/test/regress/expect/jobench/16a.txt
@@ -23,26 +23,26 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 100041592, memory=6442455664
-PhysicHashAgg  (inccost=100041592, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 100041596, memory=6442455760
+PhysicHashAgg  (inccost=100041596, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=100041589, cost=901346, rows=1, memory=2147483664) (actual rows=0)
+    -> PhysicHashJoin  (inccost=100041593, cost=901346, rows=1, memory=2147483664) (actual rows=0)
         Output: name[3],title[0]
         Filter: person_id[4]=id[1] and person_id[4]=person_id[2]
-        -> PhysicHashJoin  (inccost=98238900, cost=156518, rows=1, memory=40) (actual rows=0)
+        -> PhysicHashJoin  (inccost=98238904, cost=156518, rows=1, memory=40) (actual rows=0)
             Output: title[5],id[0],person_id[1]
             Filter: movie_id[2]=id[6] and id[6]=movie_id[3] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=95554070, cost=4167494, rows=1, memory=32) (actual rows=0)
+            -> PhysicHashJoin  (inccost=95554074, cost=4167494, rows=1, memory=32) (actual rows=0)
                 Output: id[4],person_id[0],movie_id[1],movie_id[2],movie_id[3]
                 Filter: id[4]=person_id[0]
-                -> PhysicHashJoin  (inccost=87219085, cost=94462, rows=1, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=87219089, cost=94462, rows=1, memory=40) (actual rows=0)
                     Output: person_id[0],movie_id[1],movie_id[2],movie_id[3]
                     Filter: company_id[4]=id[5]
-                    -> PhysicHashJoin  (inccost=86889626, cost=36244713, rows=1, memory=4320) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=86889630, cost=36244713, rows=1, memory=4416) (actual rows=0)
                         Output: person_id[3],movie_id[4],movie_id[0],movie_id[1],company_id[2]
                         Filter: movie_id[4]=movie_id[1] and movie_id[4]=movie_id[0]
-                        -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                             Output: movie_id[0],movie_id[1],company_id[2]
                             Filter: movie_id[1]=movie_id[0]
                             -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/16b.txt
+++ b/test/regress/expect/jobench/16b.txt
@@ -21,26 +21,26 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 102413389, memory=6442455664
-PhysicHashAgg  (inccost=102413389, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 102413393, memory=6442455760
+PhysicHashAgg  (inccost=102413393, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=102413386, cost=901346, rows=1, memory=2147483664) (actual rows=0)
+    -> PhysicHashJoin  (inccost=102413390, cost=901346, rows=1, memory=2147483664) (actual rows=0)
         Output: name[3],title[0]
         Filter: person_id[4]=id[1] and person_id[4]=person_id[2]
-        -> PhysicHashJoin  (inccost=100610697, cost=2528315, rows=1, memory=40) (actual rows=0)
+        -> PhysicHashJoin  (inccost=100610701, cost=2528315, rows=1, memory=40) (actual rows=0)
             Output: title[5],id[0],person_id[1]
             Filter: movie_id[2]=id[6] and id[6]=movie_id[3] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=95554070, cost=4167494, rows=1, memory=32) (actual rows=0)
+            -> PhysicHashJoin  (inccost=95554074, cost=4167494, rows=1, memory=32) (actual rows=0)
                 Output: id[4],person_id[0],movie_id[1],movie_id[2],movie_id[3]
                 Filter: id[4]=person_id[0]
-                -> PhysicHashJoin  (inccost=87219085, cost=94462, rows=1, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=87219089, cost=94462, rows=1, memory=40) (actual rows=0)
                     Output: person_id[0],movie_id[1],movie_id[2],movie_id[3]
                     Filter: company_id[4]=id[5]
-                    -> PhysicHashJoin  (inccost=86889626, cost=36244713, rows=1, memory=4320) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=86889630, cost=36244713, rows=1, memory=4416) (actual rows=0)
                         Output: person_id[3],movie_id[4],movie_id[0],movie_id[1],company_id[2]
                         Filter: movie_id[4]=movie_id[1] and movie_id[4]=movie_id[0]
-                        -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                             Output: movie_id[0],movie_id[1],company_id[2]
                             Filter: movie_id[1]=movie_id[0]
                             -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/16c.txt
+++ b/test/regress/expect/jobench/16c.txt
@@ -22,26 +22,26 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 102056741, memory=6442455664
-PhysicHashAgg  (inccost=102056741, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 102056745, memory=6442455760
+PhysicHashAgg  (inccost=102056745, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=102056738, cost=901346, rows=1, memory=2147483664) (actual rows=0)
+    -> PhysicHashJoin  (inccost=102056742, cost=901346, rows=1, memory=2147483664) (actual rows=0)
         Output: name[3],title[0]
         Filter: person_id[4]=id[1] and person_id[4]=person_id[2]
-        -> PhysicHashJoin  (inccost=100254049, cost=2171667, rows=1, memory=40) (actual rows=0)
+        -> PhysicHashJoin  (inccost=100254053, cost=2171667, rows=1, memory=40) (actual rows=0)
             Output: title[5],id[0],person_id[1]
             Filter: movie_id[2]=id[6] and id[6]=movie_id[3] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=95554070, cost=4167494, rows=1, memory=32) (actual rows=0)
+            -> PhysicHashJoin  (inccost=95554074, cost=4167494, rows=1, memory=32) (actual rows=0)
                 Output: id[4],person_id[0],movie_id[1],movie_id[2],movie_id[3]
                 Filter: id[4]=person_id[0]
-                -> PhysicHashJoin  (inccost=87219085, cost=94462, rows=1, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=87219089, cost=94462, rows=1, memory=40) (actual rows=0)
                     Output: person_id[0],movie_id[1],movie_id[2],movie_id[3]
                     Filter: company_id[4]=id[5]
-                    -> PhysicHashJoin  (inccost=86889626, cost=36244713, rows=1, memory=4320) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=86889630, cost=36244713, rows=1, memory=4416) (actual rows=0)
                         Output: person_id[3],movie_id[4],movie_id[0],movie_id[1],company_id[2]
                         Filter: movie_id[4]=movie_id[1] and movie_id[4]=movie_id[0]
-                        -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                             Output: movie_id[0],movie_id[1],company_id[2]
                             Filter: movie_id[1]=movie_id[0]
                             -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/16d.txt
+++ b/test/regress/expect/jobench/16d.txt
@@ -23,26 +23,26 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 101473407, memory=6442455664
-PhysicHashAgg  (inccost=101473407, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 101473411, memory=6442455760
+PhysicHashAgg  (inccost=101473411, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=101473404, cost=901346, rows=1, memory=2147483664) (actual rows=0)
+    -> PhysicHashJoin  (inccost=101473408, cost=901346, rows=1, memory=2147483664) (actual rows=0)
         Output: name[3],title[0]
         Filter: person_id[4]=id[1] and person_id[4]=person_id[2]
-        -> PhysicHashJoin  (inccost=99670715, cost=1588333, rows=1, memory=40) (actual rows=0)
+        -> PhysicHashJoin  (inccost=99670719, cost=1588333, rows=1, memory=40) (actual rows=0)
             Output: title[5],id[0],person_id[1]
             Filter: movie_id[2]=id[6] and id[6]=movie_id[3] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=95554070, cost=4167494, rows=1, memory=32) (actual rows=0)
+            -> PhysicHashJoin  (inccost=95554074, cost=4167494, rows=1, memory=32) (actual rows=0)
                 Output: id[4],person_id[0],movie_id[1],movie_id[2],movie_id[3]
                 Filter: id[4]=person_id[0]
-                -> PhysicHashJoin  (inccost=87219085, cost=94462, rows=1, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=87219089, cost=94462, rows=1, memory=40) (actual rows=0)
                     Output: person_id[0],movie_id[1],movie_id[2],movie_id[3]
                     Filter: company_id[4]=id[5]
-                    -> PhysicHashJoin  (inccost=86889626, cost=36244713, rows=1, memory=4320) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=86889630, cost=36244713, rows=1, memory=4416) (actual rows=0)
                         Output: person_id[3],movie_id[4],movie_id[0],movie_id[1],company_id[2]
                         Filter: movie_id[4]=movie_id[1] and movie_id[4]=movie_id[0]
-                        -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                             Output: movie_id[0],movie_id[1],company_id[2]
                             Filter: movie_id[1]=movie_id[0]
                             -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/17a.txt
+++ b/test/regress/expect/jobench/17a.txt
@@ -19,23 +19,23 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 100617786, memory=6442511504
-PhysicHashAgg  (inccost=100617786, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 100617841, memory=6442512824
+PhysicHashAgg  (inccost=100617841, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[0]
     Aggregates: min(name[0])
-    -> PhysicHashJoin  (inccost=100617783, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
+    -> PhysicHashJoin  (inccost=100617838, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
         Output: name[0]
         Filter: movie_id[1]=id[4] and id[4]=movie_id[2] and id[4]=movie_id[3]
-        -> PhysicHashJoin  (inccost=95561156, cost=4167494, rows=1, memory=32) (actual rows=0)
+        -> PhysicHashJoin  (inccost=95561211, cost=4167494, rows=1, memory=32) (actual rows=0)
             Output: name[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[5]=person_id[3]
-            -> PhysicHashJoin  (inccost=87226171, cost=94462, rows=1, memory=40) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87226226, cost=94462, rows=1, memory=40) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2],person_id[3]
                 Filter: company_id[4]=id[5]
-                -> PhysicHashJoin  (inccost=86896712, cost=2614256, rows=1, memory=60192) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86896767, cost=2614256, rows=1, memory=61512) (actual rows=0)
                     Output: movie_id[0],movie_id[1],movie_id[3],person_id[2],company_id[4]
                     Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                    -> PhysicHashJoin  (inccost=81673327, cost=36246918, rows=2508, memory=264) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=81673382, cost=36246973, rows=2563, memory=264) (actual rows=0)
                         Output: movie_id[1],movie_id[0],person_id[2]
                         Filter: movie_id[1]=movie_id[0]
                         -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/17b.txt
+++ b/test/regress/expect/jobench/17b.txt
@@ -18,23 +18,23 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 100758324, memory=6442511504
-PhysicHashAgg  (inccost=100758324, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 100758379, memory=6442512824
+PhysicHashAgg  (inccost=100758379, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[0]
     Aggregates: min(name[0])
-    -> PhysicHashJoin  (inccost=100758321, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
+    -> PhysicHashJoin  (inccost=100758376, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
         Output: name[0]
         Filter: movie_id[1]=id[4] and id[4]=movie_id[2] and id[4]=movie_id[3]
-        -> PhysicHashJoin  (inccost=95701694, cost=4167494, rows=1, memory=32) (actual rows=0)
+        -> PhysicHashJoin  (inccost=95701749, cost=4167494, rows=1, memory=32) (actual rows=0)
             Output: name[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[5]=person_id[3]
-            -> PhysicHashJoin  (inccost=87366709, cost=235000, rows=1, memory=40) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87366764, cost=235000, rows=1, memory=40) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2],person_id[3]
                 Filter: company_id[4]=id[5]
-                -> PhysicHashJoin  (inccost=86896712, cost=2614256, rows=1, memory=60192) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86896767, cost=2614256, rows=1, memory=61512) (actual rows=0)
                     Output: movie_id[0],movie_id[1],movie_id[3],person_id[2],company_id[4]
                     Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                    -> PhysicHashJoin  (inccost=81673327, cost=36246918, rows=2508, memory=264) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=81673382, cost=36246973, rows=2563, memory=264) (actual rows=0)
                         Output: movie_id[1],movie_id[0],person_id[2]
                         Filter: movie_id[1]=movie_id[0]
                         -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/17c.txt
+++ b/test/regress/expect/jobench/17c.txt
@@ -18,23 +18,23 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 100758324, memory=6442511504
-PhysicHashAgg  (inccost=100758324, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 100758379, memory=6442512824
+PhysicHashAgg  (inccost=100758379, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[0]
     Aggregates: min(name[0])
-    -> PhysicHashJoin  (inccost=100758321, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
+    -> PhysicHashJoin  (inccost=100758376, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
         Output: name[0]
         Filter: movie_id[1]=id[4] and id[4]=movie_id[2] and id[4]=movie_id[3]
-        -> PhysicHashJoin  (inccost=95701694, cost=4167494, rows=1, memory=32) (actual rows=0)
+        -> PhysicHashJoin  (inccost=95701749, cost=4167494, rows=1, memory=32) (actual rows=0)
             Output: name[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[5]=person_id[3]
-            -> PhysicHashJoin  (inccost=87366709, cost=235000, rows=1, memory=40) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87366764, cost=235000, rows=1, memory=40) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2],person_id[3]
                 Filter: company_id[4]=id[5]
-                -> PhysicHashJoin  (inccost=86896712, cost=2614256, rows=1, memory=60192) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86896767, cost=2614256, rows=1, memory=61512) (actual rows=0)
                     Output: movie_id[0],movie_id[1],movie_id[3],person_id[2],company_id[4]
                     Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                    -> PhysicHashJoin  (inccost=81673327, cost=36246918, rows=2508, memory=264) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=81673382, cost=36246973, rows=2563, memory=264) (actual rows=0)
                         Output: movie_id[1],movie_id[0],person_id[2]
                         Filter: movie_id[1]=movie_id[0]
                         -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/17d.txt
+++ b/test/regress/expect/jobench/17d.txt
@@ -17,23 +17,23 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 96757532, memory=4295027856
-PhysicHashAgg  (inccost=96757532, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 96757587, memory=4295029176
+PhysicHashAgg  (inccost=96757587, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(name)}[0]
     Aggregates: min(name[0])
-    -> PhysicHashJoin  (inccost=96757529, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
+    -> PhysicHashJoin  (inccost=96757584, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
         Output: name[0]
         Filter: movie_id[1]=id[4] and id[4]=movie_id[2] and id[4]=movie_id[3]
-        -> PhysicHashJoin  (inccost=91700902, cost=166702, rows=1, memory=32) (actual rows=0)
+        -> PhysicHashJoin  (inccost=91700957, cost=166702, rows=1, memory=32) (actual rows=0)
             Output: name[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[5]=person_id[3]
-            -> PhysicHashJoin  (inccost=87366709, cost=235000, rows=1, memory=40) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87366764, cost=235000, rows=1, memory=40) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2],person_id[3]
                 Filter: company_id[4]=id[5]
-                -> PhysicHashJoin  (inccost=86896712, cost=2614256, rows=1, memory=60192) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86896767, cost=2614256, rows=1, memory=61512) (actual rows=0)
                     Output: movie_id[0],movie_id[1],movie_id[3],person_id[2],company_id[4]
                     Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                    -> PhysicHashJoin  (inccost=81673327, cost=36246918, rows=2508, memory=264) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=81673382, cost=36246973, rows=2563, memory=264) (actual rows=0)
                         Output: movie_id[1],movie_id[0],person_id[2]
                         Filter: movie_id[1]=movie_id[0]
                         -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/17e.txt
+++ b/test/regress/expect/jobench/17e.txt
@@ -17,23 +17,23 @@ WHERE cn.country_code ='[us]'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 100617786, memory=4295027856
-PhysicHashAgg  (inccost=100617786, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 100617841, memory=4295029176
+PhysicHashAgg  (inccost=100617841, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(name)}[0]
     Aggregates: min(name[0])
-    -> PhysicHashJoin  (inccost=100617783, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
+    -> PhysicHashJoin  (inccost=100617838, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
         Output: name[0]
         Filter: movie_id[1]=id[4] and id[4]=movie_id[2] and id[4]=movie_id[3]
-        -> PhysicHashJoin  (inccost=95561156, cost=4167494, rows=1, memory=32) (actual rows=0)
+        -> PhysicHashJoin  (inccost=95561211, cost=4167494, rows=1, memory=32) (actual rows=0)
             Output: name[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[5]=person_id[3]
-            -> PhysicHashJoin  (inccost=87226171, cost=94462, rows=1, memory=40) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87226226, cost=94462, rows=1, memory=40) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2],person_id[3]
                 Filter: company_id[4]=id[5]
-                -> PhysicHashJoin  (inccost=86896712, cost=2614256, rows=1, memory=60192) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86896767, cost=2614256, rows=1, memory=61512) (actual rows=0)
                     Output: movie_id[0],movie_id[1],movie_id[3],person_id[2],company_id[4]
                     Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                    -> PhysicHashJoin  (inccost=81673327, cost=36246918, rows=2508, memory=264) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=81673382, cost=36246973, rows=2563, memory=264) (actual rows=0)
                         Output: movie_id[1],movie_id[0],person_id[2]
                         Filter: movie_id[1]=movie_id[0]
                         -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/17f.txt
+++ b/test/regress/expect/jobench/17f.txt
@@ -17,23 +17,23 @@ WHERE k.keyword ='character-name-in-title'
   AND ci.movie_id = mc.movie_id
   AND ci.movie_id = mk.movie_id
   AND mc.movie_id = mk.movie_id
-Total cost: 100758324, memory=4295027856
-PhysicHashAgg  (inccost=100758324, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 100758379, memory=4295029176
+PhysicHashAgg  (inccost=100758379, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(name)}[0]
     Aggregates: min(name[0])
-    -> PhysicHashJoin  (inccost=100758321, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
+    -> PhysicHashJoin  (inccost=100758376, cost=2528315, rows=1, memory=2147483672) (actual rows=0)
         Output: name[0]
         Filter: movie_id[1]=id[4] and id[4]=movie_id[2] and id[4]=movie_id[3]
-        -> PhysicHashJoin  (inccost=95701694, cost=4167494, rows=1, memory=32) (actual rows=0)
+        -> PhysicHashJoin  (inccost=95701749, cost=4167494, rows=1, memory=32) (actual rows=0)
             Output: name[4],movie_id[0],movie_id[1],movie_id[2]
             Filter: id[5]=person_id[3]
-            -> PhysicHashJoin  (inccost=87366709, cost=235000, rows=1, memory=40) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87366764, cost=235000, rows=1, memory=40) (actual rows=0)
                 Output: movie_id[0],movie_id[1],movie_id[2],person_id[3]
                 Filter: company_id[4]=id[5]
-                -> PhysicHashJoin  (inccost=86896712, cost=2614256, rows=1, memory=60192) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86896767, cost=2614256, rows=1, memory=61512) (actual rows=0)
                     Output: movie_id[0],movie_id[1],movie_id[3],person_id[2],company_id[4]
                     Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                    -> PhysicHashJoin  (inccost=81673327, cost=36246918, rows=2508, memory=264) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=81673382, cost=36246973, rows=2563, memory=264) (actual rows=0)
                         Output: movie_id[1],movie_id[0],person_id[2]
                         Filter: movie_id[1]=movie_id[0]
                         -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/19c.txt
+++ b/test/regress/expect/jobench/19c.txt
@@ -36,35 +36,35 @@ WHERE ci.note IN ('(voice)',
   AND n.id = an.person_id
   AND ci.person_id = an.person_id
   AND chn.id = ci.person_role_id
-Total cost: 76526641, memory=10737422968
-PhysicHashAgg  (inccost=76526641, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 76526642, memory=10737422992
+PhysicHashAgg  (inccost=76526642, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=76526638, cost=901346, rows=1, memory=4294967312) (actual rows=0)
+    -> PhysicHashJoin  (inccost=76526639, cost=901346, rows=1, memory=4294967312) (actual rows=0)
         Output: name[0],title[1]
         Filter: id[2]=person_id[4] and person_id[3]=person_id[4]
-        -> PhysicHashJoin  (inccost=74723949, cost=1421962, rows=1, memory=2147483688) (actual rows=0)
+        -> PhysicHashJoin  (inccost=74723950, cost=1421962, rows=1, memory=2147483688) (actual rows=0)
             Output: name[0],title[6],id[1],person_id[2]
             Filter: id[7]=movie_id[3] and id[7]=movie_id[4] and id[7]=movie_id[5]
-            -> PhysicHashJoin  (inccost=70773675, cost=4, rows=1, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=70773676, cost=4, rows=1, memory=8) (actual rows=0)
                 Output: name[1],id[2],person_id[3],movie_id[4],movie_id[5],movie_id[6]
                 Filter: id[0]=role_id[7]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='actress'
-                -> PhysicHashJoin  (inccost=70773659, cost=1483554, rows=1, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=70773660, cost=1483554, rows=1, memory=40) (actual rows=0)
                     Output: name[5],id[6],person_id[0],movie_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[6]=person_id[0]
-                    -> PhysicHashJoin  (inccost=65122614, cost=3140342, rows=1, memory=48) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=65122615, cost=3140342, rows=1, memory=48) (actual rows=0)
                         Output: person_id[0],movie_id[1],movie_id[2],movie_id[3],role_id[4]
                         Filter: id[6]=person_role_id[5]
-                        -> PhysicHashJoin  (inccost=58841933, cost=94462, rows=1, memory=56) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=58841934, cost=94462, rows=1, memory=56) (actual rows=0)
                             Output: person_id[0],movie_id[1],movie_id[2],movie_id[3],role_id[4],person_role_id[5]
                             Filter: id[7]=company_id[6]
-                            -> PhysicHashJoin  (inccost=58512474, cost=2208728, rows=1, memory=3960) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=58512475, cost=2208728, rows=1, memory=3984) (actual rows=0)
                                 Output: person_id[3],movie_id[0],movie_id[1],movie_id[4],role_id[5],person_role_id[6],company_id[2]
                                 Filter: movie_id[1]=movie_id[4] and movie_id[0]=movie_id[4]
-                                -> PhysicHashJoin  (inccost=20059402, cost=2609432, rows=165, memory=552) (actual rows=0)
+                                -> PhysicHashJoin  (inccost=20059403, cost=2609433, rows=166, memory=552) (actual rows=0)
                                     Output: movie_id[0],movie_id[1],company_id[2]
                                     Filter: movie_id[1]=movie_id[0]
                                     -> PhysicHashJoin  (inccost=14840841, cost=5008, rows=69, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/19d.txt
+++ b/test/regress/expect/jobench/19d.txt
@@ -32,35 +32,35 @@ WHERE ci.note IN ('(voice)',
   AND n.id = an.person_id
   AND ci.person_id = an.person_id
   AND chn.id = ci.person_role_id
-Total cost: 93487906, memory=10751124664
-PhysicHashAgg  (inccost=93487906, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 93487908, memory=10751124712
+PhysicHashAgg  (inccost=93487908, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=93487903, cost=901346, rows=1, memory=4294967312) (actual rows=0)
+    -> PhysicHashJoin  (inccost=93487905, cost=901346, rows=1, memory=4294967312) (actual rows=0)
         Output: name[0],title[1]
         Filter: id[2]=person_id[4] and person_id[3]=person_id[4]
-        -> PhysicHashJoin  (inccost=91685214, cost=1421962, rows=1, memory=2147483688) (actual rows=0)
+        -> PhysicHashJoin  (inccost=91685216, cost=1421962, rows=1, memory=2147483688) (actual rows=0)
             Output: name[0],title[6],id[1],person_id[2]
             Filter: id[7]=movie_id[3] and id[7]=movie_id[4] and id[7]=movie_id[5]
-            -> PhysicHashJoin  (inccost=87734940, cost=4, rows=1, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=87734942, cost=4, rows=1, memory=8) (actual rows=0)
                 Output: name[1],id[2],person_id[3],movie_id[4],movie_id[5],movie_id[6]
                 Filter: id[0]=role_id[7]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='actress'
-                -> PhysicHashJoin  (inccost=87734924, cost=1483554, rows=1, memory=40) (actual rows=0)
+                -> PhysicHashJoin  (inccost=87734926, cost=1483554, rows=1, memory=40) (actual rows=0)
                     Output: name[5],id[6],person_id[0],movie_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[6]=person_id[0]
-                    -> PhysicHashJoin  (inccost=82083879, cost=3140342, rows=1, memory=48) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=82083881, cost=3140342, rows=1, memory=48) (actual rows=0)
                         Output: person_id[0],movie_id[1],movie_id[2],movie_id[3],role_id[4]
                         Filter: id[6]=person_role_id[5]
-                        -> PhysicHashJoin  (inccost=75803198, cost=94462, rows=1, memory=56) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=75803200, cost=94462, rows=1, memory=56) (actual rows=0)
                             Output: person_id[0],movie_id[1],movie_id[2],movie_id[3],role_id[4],person_role_id[5]
                             Filter: id[7]=company_id[6]
-                            -> PhysicHashJoin  (inccost=75473739, cost=3211282, rows=1, memory=12034584) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=75473741, cost=3211282, rows=1, memory=12034632) (actual rows=0)
                                 Output: person_id[3],movie_id[0],movie_id[1],movie_id[4],role_id[5],person_role_id[6],company_id[2]
                                 Filter: movie_id[1]=movie_id[4] and movie_id[0]=movie_id[4]
-                                -> PhysicHashJoin  (inccost=36018113, cost=3528476, rows=501441, memory=1671624) (actual rows=0)
+                                -> PhysicHashJoin  (inccost=36018115, cost=3528478, rows=501443, memory=1671624) (actual rows=0)
                                     Output: movie_id[0],movie_id[1],company_id[2]
                                     Filter: movie_id[1]=movie_id[0]
                                     -> PhysicHashJoin  (inccost=29880508, cost=15044675, rows=208953, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/20c.txt
+++ b/test/regress/expect/jobench/20c.txt
@@ -39,20 +39,20 @@ WHERE cct1.kind = 'cast'
   AND k.id = mk.keyword_id
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
-Total cost: 98618025, memory=18350249811640
-PhysicHashAgg  (inccost=98618025, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 98618038, memory=18350249812264
+PhysicHashAgg  (inccost=98618038, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=98618022, cost=135089, rows=1, memory=4294967336) (actual rows=0)
+    -> PhysicHashJoin  (inccost=98618035, cost=135089, rows=1, memory=4294967336) (actual rows=0)
         Output: name[0],title[1]
         Filter: id[2]=movie_id[7] and movie_id[3]=movie_id[7] and movie_id[4]=movie_id[7] and id[5]=subject_id[8] and id[6]=status_id[9]
-        -> PhysicHashJoin  (inccost=98347847, cost=1439042, rows=1, memory=18341658179208) (actual rows=0)
+        -> PhysicHashJoin  (inccost=98347860, cost=1439042, rows=1, memory=18341658179208) (actual rows=0)
             Output: name[0],title[6],id[7],movie_id[1],movie_id[2],id[3],id[4]
             Filter: id[5]=kind_id[8] and id[7]=movie_id[1] and id[7]=movie_id[2]
-            -> PhysicHashJoin  (inccost=94380493, cost=4192640, rows=8541, memory=397968) (actual rows=0)
+            -> PhysicHashJoin  (inccost=94380506, cost=4192640, rows=8541, memory=398592) (actual rows=0)
                 Output: name[6],movie_id[0],movie_id[1],id[2],id[3],id[4]
                 Filter: id[7]=person_id[5]
-                -> PhysicHashJoin  (inccost=86020362, cost=1184879, rows=8291, memory=1289848) (actual rows=0)
+                -> PhysicHashJoin  (inccost=86020375, cost=1184892, rows=8304, memory=1289848) (actual rows=0)
                     Output: movie_id[0],movie_id[1],id[2],id[3],id[4],person_id[5]
                     Filter: id[7]=person_role_id[6]
                     -> PhysicHashJoin  (inccost=81695144, cost=36267983, rows=23033, memory=9696) (actual rows=0)

--- a/test/regress/expect/jobench/21c.txt
+++ b/test/regress/expect/jobench/21c.txt
@@ -41,29 +41,29 @@ WHERE cn.country_code !='[pl]'
   AND ml.movie_id = mi.movie_id
   AND mk.movie_id = mi.movie_id
   AND mc.movie_id = mi.movie_id
-Total cost: 34947054, memory=6442452584
-PhysicHashAgg  (inccost=34947054, cost=3, rows=1, memory=4294967360) (actual rows=1)
+Total cost: 34947056, memory=6442452616
+PhysicHashAgg  (inccost=34947056, cost=3, rows=1, memory=4294967360) (actual rows=1)
     Output: {min(name)}[0],{min(link)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(link[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=34947051, cost=9763, rows=1, memory=2147483720) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34947053, cost=9763, rows=1, memory=2147483720) (actual rows=0)
         Output: name[3],link[0],title[1]
         Filter: company_id[2]=id[4]
-        -> PhysicHashJoin  (inccost=34702291, cost=1956445, rows=1, memory=104) (actual rows=0)
+        -> PhysicHashJoin  (inccost=34702293, cost=1956445, rows=1, memory=104) (actual rows=0)
             Output: link[0],title[6],company_id[1]
             Filter: movie_id[2]=id[7] and id[7]=movie_id[3] and id[7]=movie_id[4] and movie_id[5]=id[7]
-            -> PhysicHashJoin  (inccost=30217534, cost=4, rows=1, memory=48) (actual rows=0)
+            -> PhysicHashJoin  (inccost=30217536, cost=4, rows=1, memory=48) (actual rows=0)
                 Output: link[6],company_id[0],movie_id[1],movie_id[2],movie_id[3],movie_id[4]
                 Filter: id[7]=link_type_id[5]
-                -> PhysicHashJoin  (inccost=30217512, cost=30000, rows=1, memory=32) (actual rows=0)
+                -> PhysicHashJoin  (inccost=30217514, cost=30000, rows=1, memory=32) (actual rows=0)
                     Output: company_id[0],movie_id[4],movie_id[1],movie_id[2],movie_id[3],link_type_id[5]
                     Filter: movie_id[4]=movie_id[2] and movie_id[4]=movie_id[3] and movie_id[4]=movie_id[1]
-                    -> PhysicHashJoin  (inccost=30157515, cost=4, rows=1, memory=40) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=30157517, cost=4, rows=1, memory=40) (actual rows=0)
                         Output: company_id[0],movie_id[1],movie_id[2],movie_id[3]
                         Filter: company_type_id[4]=id[5]
-                        -> PhysicHashJoin  (inccost=30157507, cost=2609260, rows=1, memory=1008) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=30157509, cost=2609260, rows=1, memory=1040) (actual rows=0)
                             Output: company_id[2],movie_id[0],movie_id[3],movie_id[1],company_type_id[4]
                             Filter: movie_id[3]=movie_id[1] and movie_id[0]=movie_id[3]
-                            -> PhysicHashJoin  (inccost=24939118, cost=921333, rows=63, memory=264) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=24939120, cost=921335, rows=65, memory=264) (actual rows=0)
                                 Output: movie_id[0],movie_id[1]
                                 Filter: movie_id[0]=movie_id[1]
                                 -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/22a.txt
+++ b/test/regress/expect/jobench/22a.txt
@@ -45,20 +45,20 @@ WHERE cn.country_code != '[us]'
   AND it2.id = mi_idx.info_type_id
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id
-Total cost: 33635193, memory=27917289776
-PhysicHashAgg  (inccost=33635193, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 33635192, memory=25769806088
+PhysicHashAgg  (inccost=33635192, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=33635190, cost=235000, rows=1, memory=4294967304) (actual rows=0)
+    -> PhysicHashJoin  (inccost=33635189, cost=235000, rows=1, memory=4294967304) (actual rows=0)
         Output: name[3],info[0],title[1]
         Filter: id[4]=company_id[2]
-        -> PhysicHashJoin  (inccost=33165193, cost=5, rows=1, memory=4294967312) (actual rows=0)
+        -> PhysicHashJoin  (inccost=33165192, cost=5, rows=1, memory=4294967312) (actual rows=0)
             Output: info[0],title[1],company_id[2]
             Filter: id[4]=kind_id[3]
-            -> PhysicHashJoin  (inccost=33165181, cost=681419, rows=1, memory=4294967376) (actual rows=0)
+            -> PhysicHashJoin  (inccost=33165180, cost=681419, rows=1, memory=2147483688) (actual rows=0)
                 Output: info[0],title[6],company_id[1],kind_id[7]
                 Filter: id[8]=movie_id[2] and id[8]=movie_id[3] and id[8]=movie_id[4] and id[8]=movie_id[5]
-                -> PhysicHashJoin  (inccost=29955450, cost=8, rows=2, memory=2147483696) (actual rows=0)
+                -> PhysicHashJoin  (inccost=29955449, cost=7, rows=1, memory=2147483696) (actual rows=0)
                     Output: info[0],company_id[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5]
                     Filter: id[7]=company_type_id[6]
                     -> PhysicHashJoin  (inccost=29955438, cost=4, rows=1, memory=2147483704) (actual rows=0)

--- a/test/regress/expect/jobench/22b.txt
+++ b/test/regress/expect/jobench/22b.txt
@@ -45,20 +45,20 @@ WHERE cn.country_code != '[us]'
   AND it2.id = mi_idx.info_type_id
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id
-Total cost: 33502715, memory=27917289776
-PhysicHashAgg  (inccost=33502715, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 33502714, memory=25769806088
+PhysicHashAgg  (inccost=33502714, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=33502712, cost=235000, rows=1, memory=4294967304) (actual rows=0)
+    -> PhysicHashJoin  (inccost=33502711, cost=235000, rows=1, memory=4294967304) (actual rows=0)
         Output: name[3],info[0],title[1]
         Filter: id[4]=company_id[2]
-        -> PhysicHashJoin  (inccost=33032715, cost=5, rows=1, memory=4294967312) (actual rows=0)
+        -> PhysicHashJoin  (inccost=33032714, cost=5, rows=1, memory=4294967312) (actual rows=0)
             Output: info[0],title[1],company_id[2]
             Filter: id[4]=kind_id[3]
-            -> PhysicHashJoin  (inccost=33032703, cost=548941, rows=1, memory=4294967376) (actual rows=0)
+            -> PhysicHashJoin  (inccost=33032702, cost=548941, rows=1, memory=2147483688) (actual rows=0)
                 Output: info[0],title[6],company_id[1],kind_id[7]
                 Filter: id[8]=movie_id[2] and id[8]=movie_id[3] and id[8]=movie_id[4] and id[8]=movie_id[5]
-                -> PhysicHashJoin  (inccost=29955450, cost=8, rows=2, memory=2147483696) (actual rows=0)
+                -> PhysicHashJoin  (inccost=29955449, cost=7, rows=1, memory=2147483696) (actual rows=0)
                     Output: info[0],company_id[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5]
                     Filter: id[7]=company_type_id[6]
                     -> PhysicHashJoin  (inccost=29955438, cost=4, rows=1, memory=2147483704) (actual rows=0)

--- a/test/regress/expect/jobench/22c.txt
+++ b/test/regress/expect/jobench/22c.txt
@@ -51,20 +51,20 @@ WHERE cn.country_code != '[us]'
   AND it2.id = mi_idx.info_type_id
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id
-Total cost: 34192465, memory=27917289776
-PhysicHashAgg  (inccost=34192465, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 34192464, memory=25769806088
+PhysicHashAgg  (inccost=34192464, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=34192462, cost=235000, rows=1, memory=4294967304) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34192461, cost=235000, rows=1, memory=4294967304) (actual rows=0)
         Output: name[3],info[0],title[1]
         Filter: id[4]=company_id[2]
-        -> PhysicHashJoin  (inccost=33722465, cost=5, rows=1, memory=4294967312) (actual rows=0)
+        -> PhysicHashJoin  (inccost=33722464, cost=5, rows=1, memory=4294967312) (actual rows=0)
             Output: info[0],title[1],company_id[2]
             Filter: id[4]=kind_id[3]
-            -> PhysicHashJoin  (inccost=33722453, cost=1042587, rows=1, memory=4294967376) (actual rows=0)
+            -> PhysicHashJoin  (inccost=33722452, cost=1042587, rows=1, memory=2147483688) (actual rows=0)
                 Output: info[0],title[6],company_id[1],kind_id[7]
                 Filter: id[8]=movie_id[2] and id[8]=movie_id[3] and id[8]=movie_id[4] and id[8]=movie_id[5]
-                -> PhysicHashJoin  (inccost=30151554, cost=8, rows=2, memory=2147483696) (actual rows=0)
+                -> PhysicHashJoin  (inccost=30151553, cost=7, rows=1, memory=2147483696) (actual rows=0)
                     Output: info[0],company_id[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5]
                     Filter: id[7]=company_type_id[6]
                     -> PhysicHashJoin  (inccost=30151542, cost=4, rows=1, memory=2147483704) (actual rows=0)

--- a/test/regress/expect/jobench/22d.txt
+++ b/test/regress/expect/jobench/22d.txt
@@ -49,26 +49,26 @@ WHERE cn.country_code != '[us]'
   AND it2.id = mi_idx.info_type_id
   AND ct.id = mc.company_type_id
   AND cn.id = mc.company_id
-Total cost: 36697540, memory=19327354192
-PhysicHashAgg  (inccost=36697540, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 36697539, memory=19327354160
+PhysicHashAgg  (inccost=36697539, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=36697537, cost=235000, rows=1, memory=4294967304) (actual rows=0)
+    -> PhysicHashJoin  (inccost=36697536, cost=235000, rows=1, memory=4294967304) (actual rows=0)
         Output: name[3],info[0],title[1]
         Filter: id[4]=company_id[2]
-        -> PhysicHashJoin  (inccost=36227540, cost=5, rows=1, memory=4294967312) (actual rows=0)
+        -> PhysicHashJoin  (inccost=36227539, cost=5, rows=1, memory=4294967312) (actual rows=0)
             Output: info[0],title[1],company_id[2]
             Filter: id[4]=kind_id[3]
-            -> PhysicHashJoin  (inccost=36227528, cost=1042587, rows=1, memory=2147483688) (actual rows=0)
+            -> PhysicHashJoin  (inccost=36227527, cost=1042587, rows=1, memory=2147483688) (actual rows=0)
                 Output: info[0],title[6],company_id[1],kind_id[7]
                 Filter: id[8]=movie_id[2] and id[8]=movie_id[3] and id[8]=movie_id[4] and id[8]=movie_id[5]
-                -> PhysicHashJoin  (inccost=32656629, cost=4, rows=1, memory=2147483696) (actual rows=0)
+                -> PhysicHashJoin  (inccost=32656628, cost=4, rows=1, memory=2147483696) (actual rows=0)
                     Output: info[0],company_id[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5]
                     Filter: id[7]=info_type_id[6]
-                    -> PhysicHashJoin  (inccost=32656512, cost=1338340, rows=1, memory=64) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=32656511, cost=1338340, rows=1, memory=32) (actual rows=0)
                         Output: info[4],company_id[0],movie_id[1],movie_id[2],movie_id[5],movie_id[3],info_type_id[6]
                         Filter: movie_id[3]=movie_id[5] and movie_id[1]=movie_id[5] and movie_id[2]=movie_id[5]
-                        -> PhysicHashJoin  (inccost=29938137, cost=8, rows=2, memory=40) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=29938136, cost=7, rows=1, memory=40) (actual rows=0)
                             Output: company_id[0],movie_id[1],movie_id[2],movie_id[3]
                             Filter: id[5]=company_type_id[4]
                             -> PhysicHashJoin  (inccost=29938125, cost=2609134, rows=1, memory=32) (actual rows=0)

--- a/test/regress/expect/jobench/23a.txt
+++ b/test/regress/expect/jobench/23a.txt
@@ -36,20 +36,20 @@ WHERE cct1.kind = 'complete+verified'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
   AND cct1.id = cc.status_id
-Total cost: 33920246, memory=19327353174
-PhysicHashAgg  (inccost=33920246, cost=3, rows=1, memory=2147483678) (actual rows=1)
+Total cost: 33920245, memory=17179869502
+PhysicHashAgg  (inccost=33920245, cost=3, rows=1, memory=2147483678) (actual rows=1)
     Output: {min(kind)}[0],{min(title)}[1]
     Aggregates: min(kind[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=33920243, cost=4, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=33920242, cost=4, rows=1, memory=2147483656) (actual rows=0)
         Output: kind[2],title[0]
         Filter: id[3]=kind_id[1]
-        -> PhysicHashJoin  (inccost=33920232, cost=134173, rows=1, memory=2147483664) (actual rows=0)
+        -> PhysicHashJoin  (inccost=33920231, cost=134173, rows=1, memory=2147483664) (actual rows=0)
             Output: title[0],kind_id[1]
             Filter: id[3]=keyword_id[2]
-            -> PhysicHashJoin  (inccost=33651889, cost=4, rows=1, memory=4294967344) (actual rows=0)
+            -> PhysicHashJoin  (inccost=33651888, cost=4, rows=1, memory=2147483672) (actual rows=0)
                 Output: title[0],kind_id[1],keyword_id[2]
                 Filter: id[4]=status_id[3]
-                -> PhysicHashJoin  (inccost=33651881, cost=8, rows=2, memory=2147483680) (actual rows=0)
+                -> PhysicHashJoin  (inccost=33651880, cost=7, rows=1, memory=2147483680) (actual rows=0)
                     Output: title[0],kind_id[1],keyword_id[2],status_id[3]
                     Filter: id[5]=company_type_id[4]
                     -> PhysicHashJoin  (inccost=33651869, cost=94462, rows=1, memory=2147483688) (actual rows=0)

--- a/test/regress/expect/jobench/23b.txt
+++ b/test/regress/expect/jobench/23b.txt
@@ -38,20 +38,20 @@ WHERE cct1.kind = 'complete+verified'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
   AND cct1.id = cc.status_id
-Total cost: 33786080, memory=19327353174
-PhysicHashAgg  (inccost=33786080, cost=3, rows=1, memory=2147483678) (actual rows=1)
+Total cost: 33786079, memory=17179869502
+PhysicHashAgg  (inccost=33786079, cost=3, rows=1, memory=2147483678) (actual rows=1)
     Output: {min(kind)}[0],{min(title)}[1]
     Aggregates: min(kind[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=33786077, cost=4, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=33786076, cost=4, rows=1, memory=2147483656) (actual rows=0)
         Output: kind[2],title[0]
         Filter: id[3]=kind_id[1]
-        -> PhysicHashJoin  (inccost=33786066, cost=7, rows=1, memory=2147483664) (actual rows=0)
+        -> PhysicHashJoin  (inccost=33786065, cost=7, rows=1, memory=2147483664) (actual rows=0)
             Output: title[0],kind_id[1]
             Filter: id[3]=keyword_id[2]
-            -> PhysicHashJoin  (inccost=33651889, cost=4, rows=1, memory=4294967344) (actual rows=0)
+            -> PhysicHashJoin  (inccost=33651888, cost=4, rows=1, memory=2147483672) (actual rows=0)
                 Output: title[0],kind_id[1],keyword_id[2]
                 Filter: id[4]=status_id[3]
-                -> PhysicHashJoin  (inccost=33651881, cost=8, rows=2, memory=2147483680) (actual rows=0)
+                -> PhysicHashJoin  (inccost=33651880, cost=7, rows=1, memory=2147483680) (actual rows=0)
                     Output: title[0],kind_id[1],keyword_id[2],status_id[3]
                     Filter: id[5]=company_type_id[4]
                     -> PhysicHashJoin  (inccost=33651869, cost=94462, rows=1, memory=2147483688) (actual rows=0)

--- a/test/regress/expect/jobench/23c.txt
+++ b/test/regress/expect/jobench/23c.txt
@@ -39,20 +39,20 @@ WHERE cct1.kind = 'complete+verified'
   AND cn.id = mc.company_id
   AND ct.id = mc.company_type_id
   AND cct1.id = cc.status_id
-Total cost: 34298666, memory=19327353174
-PhysicHashAgg  (inccost=34298666, cost=3, rows=1, memory=2147483678) (actual rows=1)
+Total cost: 34298665, memory=17179869502
+PhysicHashAgg  (inccost=34298665, cost=3, rows=1, memory=2147483678) (actual rows=1)
     Output: {min(kind)}[0],{min(title)}[1]
     Aggregates: min(kind[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=34298663, cost=7, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34298662, cost=7, rows=1, memory=2147483656) (actual rows=0)
         Output: kind[2],title[0]
         Filter: id[3]=kind_id[1]
-        -> PhysicHashJoin  (inccost=34298649, cost=134173, rows=1, memory=2147483664) (actual rows=0)
+        -> PhysicHashJoin  (inccost=34298648, cost=134173, rows=1, memory=2147483664) (actual rows=0)
             Output: title[0],kind_id[1]
             Filter: id[3]=keyword_id[2]
-            -> PhysicHashJoin  (inccost=34030306, cost=4, rows=1, memory=4294967344) (actual rows=0)
+            -> PhysicHashJoin  (inccost=34030305, cost=4, rows=1, memory=2147483672) (actual rows=0)
                 Output: title[0],kind_id[1],keyword_id[2]
                 Filter: id[4]=status_id[3]
-                -> PhysicHashJoin  (inccost=34030298, cost=8, rows=2, memory=2147483680) (actual rows=0)
+                -> PhysicHashJoin  (inccost=34030297, cost=7, rows=1, memory=2147483680) (actual rows=0)
                     Output: title[0],kind_id[1],keyword_id[2],status_id[3]
                     Filter: id[5]=company_type_id[4]
                     -> PhysicHashJoin  (inccost=34030286, cost=94462, rows=1, memory=2147483688) (actual rows=0)

--- a/test/regress/expect/jobench/26c.txt
+++ b/test/regress/expect/jobench/26c.txt
@@ -48,36 +48,36 @@ WHERE cct1.kind = 'cast'
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
   AND it2.id = mi_idx.info_type_id
-Total cost: 101260875, memory=414464349672
-PhysicHashAgg  (inccost=101260875, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 101260876, memory=414464349672
+PhysicHashAgg  (inccost=101260876, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=101260872, cost=135089, rows=1, memory=6442450992) (actual rows=0)
+    -> PhysicHashJoin  (inccost=101260873, cost=135089, rows=1, memory=6442450992) (actual rows=0)
         Output: name[0],info[1],title[2]
         Filter: id[3]=movie_id[9] and movie_id[4]=movie_id[9] and movie_id[5]=movie_id[9] and movie_id[9]=movie_id[6] and id[7]=subject_id[10] and id[8]=status_id[11]
-        -> PhysicHashJoin  (inccost=100990697, cost=1421962, rows=1, memory=4294967344) (actual rows=0)
+        -> PhysicHashJoin  (inccost=100990698, cost=1421962, rows=1, memory=4294967344) (actual rows=0)
             Output: name[0],info[1],title[8],id[9],movie_id[2],movie_id[3],movie_id[4],id[5],id[6]
             Filter: id[7]=kind_id[10] and id[9]=movie_id[2] and id[9]=movie_id[3] and id[9]=movie_id[4]
-            -> PhysicHashJoin  (inccost=97040423, cost=4167494, rows=1, memory=4294967352) (actual rows=0)
+            -> PhysicHashJoin  (inccost=97040424, cost=4167494, rows=1, memory=4294967352) (actual rows=0)
                 Output: name[0],info[1],movie_id[2],movie_id[3],movie_id[4],id[5],id[6],id[7]
                 Filter: id[9]=person_id[8]
-                -> PhysicNLJoin  (inccost=88705438, cost=121, rows=1) (actual rows=0)
+                -> PhysicNLJoin  (inccost=88705439, cost=121, rows=1) (actual rows=0)
                     Output: name[0],info[1],movie_id[2],movie_id[3],movie_id[4],id[5],id[6],id[8],person_id[7]
-                    -> PhysicNLJoin  (inccost=88705310, cost=121, rows=1) (actual rows=0)
+                    -> PhysicNLJoin  (inccost=88705311, cost=121, rows=1) (actual rows=0)
                         Output: name[0],info[1],movie_id[2],movie_id[3],movie_id[4],id[6],id[7],person_id[5]
-                        -> PhysicHashJoin  (inccost=88705060, cost=1130525, rows=1, memory=2147483688) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=88705061, cost=1130525, rows=1, memory=2147483688) (actual rows=0)
                             Output: name[6],info[0],movie_id[1],movie_id[2],movie_id[3],person_id[4]
                             Filter: id[7]=person_role_id[5]
-                            -> PhysicHashJoin  (inccost=84434196, cost=36244709, rows=1, memory=390842026848) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=84434197, cost=36244709, rows=1, memory=390842026848) (actual rows=0)
                                 Output: info[0],movie_id[1],movie_id[3],movie_id[2],person_id[4],person_role_id[5]
                                 Filter: movie_id[3]=movie_id[2] and movie_id[1]=movie_id[3]
-                                -> PhysicHashJoin  (inccost=11945143, cost=1094, rows=182, memory=8) (actual rows=0)
+                                -> PhysicHashJoin  (inccost=11945144, cost=1094, rows=182, memory=8) (actual rows=0)
                                     Output: info[1],movie_id[2],movie_id[3]
                                     Filter: id[0]=info_type_id[4]
                                     -> PhysicScanTable info_type as it2 (inccost=113, cost=113, rows=1) (actual rows=0)
                                         Output: id[0]
                                         Filter: info[1]='rating'
-                                    -> PhysicHashJoin  (inccost=11943936, cost=1381550, rows=909, memory=2424) (actual rows=0)
+                                    -> PhysicHashJoin  (inccost=11943937, cost=1381551, rows=910, memory=2424) (actual rows=0)
                                         Output: info[1],movie_id[0],movie_id[2],info_type_id[3]
                                         Filter: movie_id[0]=movie_id[2]
                                         -> PhysicHashJoin  (inccost=9182351, cost=4524251, rows=303, memory=72) (actual rows=0)

--- a/test/regress/expect/jobench/27a.txt
+++ b/test/regress/expect/jobench/27a.txt
@@ -49,7 +49,7 @@ WHERE cct1.kind IN ('cast',
   AND mk.movie_id = cc.movie_id
   AND mc.movie_id = cc.movie_id
   AND mi.movie_id = cc.movie_id
-Total cost: 33403653, memory=19327353688
+Total cost: 33403653, memory=17179870000
 PhysicHashAgg  (inccost=33403653, cost=3, rows=1, memory=4294967360) (actual rows=1)
     Output: {min(name)}[0],{min(link)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(link[1]), min(title[2])
@@ -62,10 +62,10 @@ PhysicHashAgg  (inccost=33403653, cost=3, rows=1, memory=4294967360) (actual row
             -> PhysicHashJoin  (inccost=33133453, cost=937557, rows=1, memory=2147483704) (actual rows=0)
                 Output: name[0],title[8],id[9],id[1],id[2],movie_id[3],movie_id[4],movie_id[5],movie_id[6],link_type_id[7]
                 Filter: id[9]=movie_id[5] and movie_id[6]=id[9] and id[9]=movie_id[4] and movie_id[3]=id[9]
-                -> PhysicHashJoin  (inccost=29667584, cost=30000, rows=1, memory=4294967376) (actual rows=0)
+                -> PhysicHashJoin  (inccost=29667584, cost=30000, rows=1, memory=2147483688) (actual rows=0)
                     Output: name[0],id[1],id[2],movie_id[6],movie_id[3],movie_id[4],movie_id[5],link_type_id[7]
                     Filter: movie_id[6]=movie_id[4] and movie_id[6]=movie_id[5] and movie_id[6]=movie_id[3]
-                    -> PhysicNLJoin  (inccost=29607587, cost=132, rows=2) (actual rows=0)
+                    -> PhysicNLJoin  (inccost=29607587, cost=132, rows=1) (actual rows=0)
                         Output: name[0],id[5],id[1],movie_id[2],movie_id[3],movie_id[4]
                         -> PhysicNLJoin  (inccost=29607451, cost=121, rows=1) (actual rows=0)
                             Output: name[0],id[4],movie_id[1],movie_id[2],movie_id[3]

--- a/test/regress/expect/jobench/27b.txt
+++ b/test/regress/expect/jobench/27b.txt
@@ -49,7 +49,7 @@ WHERE cct1.kind IN ('cast',
   AND mk.movie_id = cc.movie_id
   AND mc.movie_id = cc.movie_id
   AND mi.movie_id = cc.movie_id
-Total cost: 32514049, memory=19327353688
+Total cost: 32514049, memory=17179870000
 PhysicHashAgg  (inccost=32514049, cost=3, rows=1, memory=4294967360) (actual rows=1)
     Output: {min(name)}[0],{min(link)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(link[1]), min(title[2])
@@ -62,10 +62,10 @@ PhysicHashAgg  (inccost=32514049, cost=3, rows=1, memory=4294967360) (actual row
             -> PhysicHashJoin  (inccost=32243849, cost=47953, rows=1, memory=2147483704) (actual rows=0)
                 Output: name[0],title[8],id[9],id[1],id[2],movie_id[3],movie_id[4],movie_id[5],movie_id[6],link_type_id[7]
                 Filter: id[9]=movie_id[5] and movie_id[6]=id[9] and id[9]=movie_id[4] and movie_id[3]=id[9]
-                -> PhysicHashJoin  (inccost=29667584, cost=30000, rows=1, memory=4294967376) (actual rows=0)
+                -> PhysicHashJoin  (inccost=29667584, cost=30000, rows=1, memory=2147483688) (actual rows=0)
                     Output: name[0],id[1],id[2],movie_id[6],movie_id[3],movie_id[4],movie_id[5],link_type_id[7]
                     Filter: movie_id[6]=movie_id[4] and movie_id[6]=movie_id[5] and movie_id[6]=movie_id[3]
-                    -> PhysicNLJoin  (inccost=29607587, cost=132, rows=2) (actual rows=0)
+                    -> PhysicNLJoin  (inccost=29607587, cost=132, rows=1) (actual rows=0)
                         Output: name[0],id[5],id[1],movie_id[2],movie_id[3],movie_id[4]
                         -> PhysicNLJoin  (inccost=29607451, cost=121, rows=1) (actual rows=0)
                             Output: name[0],id[4],movie_id[1],movie_id[2],movie_id[3]

--- a/test/regress/expect/jobench/28a.txt
+++ b/test/regress/expect/jobench/28a.txt
@@ -63,70 +63,70 @@ WHERE cct1.kind = 'crew'
   AND cn.id = mc.company_id
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
-Total cost: 34842310, memory=47244643120
-PhysicHashAgg  (inccost=34842310, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 34842303, memory=40802191896
+PhysicHashAgg  (inccost=34842303, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=34842307, cost=135089, rows=1, memory=6442451000) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34842300, cost=135089, rows=1, memory=6442451000) (actual rows=0)
         Output: name[0],info[1],title[2]
         Filter: id[3]=movie_id[10] and movie_id[4]=movie_id[10] and movie_id[5]=movie_id[10] and movie_id[6]=movie_id[10] and movie_id[7]=movie_id[10] and id[8]=subject_id[11] and id[9]=status_id[12]
-        -> PhysicHashJoin  (inccost=34572132, cost=5, rows=1, memory=6442451008) (actual rows=0)
+        -> PhysicHashJoin  (inccost=34572125, cost=5, rows=1, memory=6442451008) (actual rows=0)
             Output: name[0],info[1],title[2],id[3],movie_id[4],movie_id[5],movie_id[6],movie_id[7],id[8],id[9]
             Filter: id[11]=kind_id[10]
-            -> PhysicHashJoin  (inccost=34572120, cost=1421962, rows=1, memory=4294967344) (actual rows=0)
+            -> PhysicHashJoin  (inccost=34572113, cost=1421962, rows=1, memory=4294967344) (actual rows=0)
                 Output: name[0],info[1],title[8],id[9],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7],kind_id[10]
                 Filter: id[9]=movie_id[4] and id[9]=movie_id[3] and id[9]=movie_id[5] and id[9]=movie_id[2]
-                -> PhysicHashJoin  (inccost=30621846, cost=4, rows=1, memory=4294967352) (actual rows=0)
+                -> PhysicHashJoin  (inccost=30621839, cost=4, rows=1, memory=4294967352) (actual rows=0)
                     Output: name[0],info[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7]
                     Filter: id[9]=info_type_id[8]
-                    -> PhysicHashJoin  (inccost=30621729, cost=1338340, rows=1, memory=17179869504) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=30621722, cost=1338340, rows=1, memory=2147483688) (actual rows=0)
                         Output: name[0],info[6],movie_id[1],movie_id[2],movie_id[3],movie_id[7],id[4],id[5],info_type_id[8]
                         Filter: movie_id[1]=movie_id[7] and movie_id[3]=movie_id[7] and movie_id[2]=movie_id[7]
-                        -> PhysicHashJoin  (inccost=27903354, cost=20, rows=8, memory=2147483696) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=27903347, cost=13, rows=1, memory=8589934784) (actual rows=0)
                             Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[5]
                             Filter: id[7]=company_type_id[6]
-                            -> PhysicHashJoin  (inccost=27903330, cost=235000, rows=1, memory=224) (actual rows=0)
-                                Output: name[7],movie_id[0],movie_id[1],movie_id[2],id[3],id[4],company_type_id[5]
-                                Filter: id[8]=company_id[6]
-                                -> PhysicNLJoin  (inccost=27433333, cost=154, rows=4) (actual rows=0)
-                                    Output: movie_id[0],movie_id[1],movie_id[2],id[3],id[6],company_type_id[4],company_id[5]
-                                    -> PhysicHashJoin  (inccost=27433175, cost=4, rows=1, memory=16) (actual rows=0)
-                                        Output: movie_id[2],movie_id[3],movie_id[4],id[0],company_type_id[5],company_id[6]
-                                        Filter: id[1]=info_type_id[7]
-                                        -> PhysicNLJoin  (inccost=238, cost=121, rows=1) (actual rows=0)
-                                            Output: id[1],id[0]
-                                            -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
-                                                Output: id[0]
-                                                Filter: info[1]='countries'
-                                            -> PhysicScanTable comp_cast_type as cct1 (inccost=4, cost=4, rows=1) (actual rows=0)
-                                                Output: id[0]
-                                                Filter: kind[1]='crew'
-                                        -> PhysicHashJoin  (inccost=27432933, cost=701250, rows=1, memory=928) (actual rows=0)
-                                            Output: movie_id[0],movie_id[4],movie_id[1],company_type_id[2],company_id[3],info_type_id[5]
-                                            Filter: movie_id[0]=movie_id[4] and movie_id[4]=movie_id[1]
-                                            -> PhysicHashJoin  (inccost=11895963, cost=104662, rows=29, memory=1072) (actual rows=0)
-                                                Output: movie_id[0],movie_id[1],company_type_id[2],company_id[3]
-                                                Filter: movie_id[0]=movie_id[1]
-                                                -> PhysicHashJoin  (inccost=9182172, cost=4524072, rows=134, memory=32) (actual rows=0)
-                                                    Output: movie_id[1]
-                                                    Filter: id[0]=keyword_id[2]
-                                                    -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=4) (actual rows=0)
-                                                        Output: id[0]
-                                                        Filter: keyword[1] in ('murder','murder-in-title','blood','violence')
-                                                    -> PhysicScanTable movie_keyword as mk (inccost=4523930, cost=4523930, rows=4523930) (actual rows=0)
-                                                        Output: movie_id[1],keyword_id[2]
-                                                -> PhysicScanTable movie_companies as mc (inccost=2609129, cost=2609129, rows=104365) (actual rows=0)
-                                                    Output: movie_id[1],company_type_id[3],company_id[2]
-                                                    Filter: note[4]not like'%(USA)%' and note[4]like'%(200%)%'
-                                            -> PhysicScanTable movie_info as mi (inccost=14835720, cost=14835720, rows=701191) (actual rows=0)
-                                                Output: movie_id[1],info_type_id[2]
-                                                Filter: info[3] in ('Sweden','Norway','Germany', ... <Total: 10> )
-                                    -> PhysicScanTable comp_cast_type as cct2 (inccost=4, cost=4, rows=4) (actual rows=0)
+                            -> PhysicNLJoin  (inccost=27903330, cost=154, rows=4) (actual rows=0)
+                                Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[6],company_type_id[5]
+                                -> PhysicHashJoin  (inccost=27903172, cost=4, rows=1, memory=2147483696) (actual rows=0)
+                                    Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],company_type_id[5]
+                                    Filter: id[7]=info_type_id[6]
+                                    -> PhysicNLJoin  (inccost=27903055, cost=121, rows=1) (actual rows=0)
+                                        Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[6],company_type_id[4],info_type_id[5]
+                                        -> PhysicHashJoin  (inccost=27902930, cost=235000, rows=1, memory=48) (actual rows=0)
+                                            Output: name[6],movie_id[0],movie_id[1],movie_id[2],company_type_id[3],info_type_id[4]
+                                            Filter: id[7]=company_id[5]
+                                            -> PhysicHashJoin  (inccost=27432933, cost=701250, rows=1, memory=928) (actual rows=0)
+                                                Output: movie_id[0],movie_id[4],movie_id[1],company_type_id[2],info_type_id[5],company_id[3]
+                                                Filter: movie_id[0]=movie_id[4] and movie_id[4]=movie_id[1]
+                                                -> PhysicHashJoin  (inccost=11895963, cost=104662, rows=29, memory=1072) (actual rows=0)
+                                                    Output: movie_id[0],movie_id[1],company_type_id[2],company_id[3]
+                                                    Filter: movie_id[0]=movie_id[1]
+                                                    -> PhysicHashJoin  (inccost=9182172, cost=4524072, rows=134, memory=32) (actual rows=0)
+                                                        Output: movie_id[1]
+                                                        Filter: id[0]=keyword_id[2]
+                                                        -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=4) (actual rows=0)
+                                                            Output: id[0]
+                                                            Filter: keyword[1] in ('murder','murder-in-title','blood','violence')
+                                                        -> PhysicScanTable movie_keyword as mk (inccost=4523930, cost=4523930, rows=4523930) (actual rows=0)
+                                                            Output: movie_id[1],keyword_id[2]
+                                                    -> PhysicScanTable movie_companies as mc (inccost=2609129, cost=2609129, rows=104365) (actual rows=0)
+                                                        Output: movie_id[1],company_type_id[3],company_id[2]
+                                                        Filter: note[4]not like'%(USA)%' and note[4]like'%(200%)%'
+                                                -> PhysicScanTable movie_info as mi (inccost=14835720, cost=14835720, rows=701191) (actual rows=0)
+                                                    Output: movie_id[1],info_type_id[2]
+                                                    Filter: info[3] in ('Sweden','Norway','Germany', ... <Total: 10> )
+                                            -> PhysicScanTable company_name as cn (inccost=234997, cost=234997, rows=234997) (actual rows=0)
+                                                Output: name[1],id[0]
+                                                Filter: country_code[2]!='[us]'
+                                        -> PhysicScanTable comp_cast_type as cct1 (inccost=4, cost=4, rows=1) (actual rows=0)
+                                            Output: id[0]
+                                            Filter: kind[1]='crew'
+                                    -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
                                         Output: id[0]
-                                        Filter: kind[1]!='complete+verified'
-                                -> PhysicScanTable company_name as cn (inccost=234997, cost=234997, rows=234997) (actual rows=0)
-                                    Output: name[1],id[0]
-                                    Filter: country_code[2]!='[us]'
+                                        Filter: info[1]='countries'
+                                -> PhysicScanTable comp_cast_type as cct2 (inccost=4, cost=4, rows=4) (actual rows=0)
+                                    Output: id[0]
+                                    Filter: kind[1]!='complete+verified'
                             -> PhysicScanTable company_type as ct (inccost=4, cost=4, rows=4) (actual rows=0)
                                 Output: id[0]
                         -> PhysicScanTable movie_info_idx as mi_idx (inccost=1380035, cost=1380035, rows=1338337) (actual rows=0)

--- a/test/regress/expect/jobench/28b.txt
+++ b/test/regress/expect/jobench/28b.txt
@@ -57,70 +57,70 @@ WHERE cct1.kind = 'crew'
   AND cn.id = mc.company_id
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
-Total cost: 32853070, memory=47244643120
-PhysicHashAgg  (inccost=32853070, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 32853063, memory=40802191896
+PhysicHashAgg  (inccost=32853063, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=32853067, cost=135089, rows=1, memory=6442451000) (actual rows=0)
+    -> PhysicHashJoin  (inccost=32853060, cost=135089, rows=1, memory=6442451000) (actual rows=0)
         Output: name[0],info[1],title[2]
         Filter: id[3]=movie_id[10] and movie_id[4]=movie_id[10] and movie_id[5]=movie_id[10] and movie_id[6]=movie_id[10] and movie_id[7]=movie_id[10] and id[8]=subject_id[11] and id[9]=status_id[12]
-        -> PhysicHashJoin  (inccost=32582892, cost=5, rows=1, memory=6442451008) (actual rows=0)
+        -> PhysicHashJoin  (inccost=32582885, cost=5, rows=1, memory=6442451008) (actual rows=0)
             Output: name[0],info[1],title[2],id[3],movie_id[4],movie_id[5],movie_id[6],movie_id[7],id[8],id[9]
             Filter: id[11]=kind_id[10]
-            -> PhysicHashJoin  (inccost=32582880, cost=1042587, rows=1, memory=4294967344) (actual rows=0)
+            -> PhysicHashJoin  (inccost=32582873, cost=1042587, rows=1, memory=4294967344) (actual rows=0)
                 Output: name[0],info[1],title[8],id[9],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7],kind_id[10]
                 Filter: id[9]=movie_id[4] and id[9]=movie_id[3] and id[9]=movie_id[5] and id[9]=movie_id[2]
-                -> PhysicHashJoin  (inccost=29011981, cost=4, rows=1, memory=4294967352) (actual rows=0)
+                -> PhysicHashJoin  (inccost=29011974, cost=4, rows=1, memory=4294967352) (actual rows=0)
                     Output: name[0],info[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7]
                     Filter: id[9]=info_type_id[8]
-                    -> PhysicHashJoin  (inccost=29011864, cost=303242, rows=1, memory=17179869504) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=29011857, cost=303242, rows=1, memory=2147483688) (actual rows=0)
                         Output: name[0],info[6],movie_id[1],movie_id[2],movie_id[3],movie_id[7],id[4],id[5],info_type_id[8]
                         Filter: movie_id[1]=movie_id[7] and movie_id[3]=movie_id[7] and movie_id[2]=movie_id[7]
-                        -> PhysicHashJoin  (inccost=27328587, cost=20, rows=8, memory=2147483696) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=27328580, cost=13, rows=1, memory=8589934784) (actual rows=0)
                             Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[5]
                             Filter: id[7]=company_type_id[6]
-                            -> PhysicHashJoin  (inccost=27328563, cost=235000, rows=1, memory=224) (actual rows=0)
-                                Output: name[7],movie_id[0],movie_id[1],movie_id[2],id[3],id[4],company_type_id[5]
-                                Filter: id[8]=company_id[6]
-                                -> PhysicNLJoin  (inccost=26858566, cost=154, rows=4) (actual rows=0)
-                                    Output: movie_id[0],movie_id[1],movie_id[2],id[3],id[6],company_type_id[4],company_id[5]
-                                    -> PhysicHashJoin  (inccost=26858408, cost=4, rows=1, memory=16) (actual rows=0)
-                                        Output: movie_id[2],movie_id[3],movie_id[4],id[0],company_type_id[5],company_id[6]
-                                        Filter: id[1]=info_type_id[7]
-                                        -> PhysicNLJoin  (inccost=238, cost=121, rows=1) (actual rows=0)
-                                            Output: id[1],id[0]
-                                            -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
-                                                Output: id[0]
-                                                Filter: info[1]='countries'
-                                            -> PhysicScanTable comp_cast_type as cct1 (inccost=4, cost=4, rows=1) (actual rows=0)
-                                                Output: id[0]
-                                                Filter: kind[1]='crew'
-                                        -> PhysicHashJoin  (inccost=26858166, cost=126483, rows=1, memory=928) (actual rows=0)
-                                            Output: movie_id[0],movie_id[4],movie_id[1],company_type_id[2],company_id[3],info_type_id[5]
-                                            Filter: movie_id[0]=movie_id[4] and movie_id[4]=movie_id[1]
-                                            -> PhysicHashJoin  (inccost=11895963, cost=104662, rows=29, memory=1072) (actual rows=0)
-                                                Output: movie_id[0],movie_id[1],company_type_id[2],company_id[3]
-                                                Filter: movie_id[0]=movie_id[1]
-                                                -> PhysicHashJoin  (inccost=9182172, cost=4524072, rows=134, memory=32) (actual rows=0)
-                                                    Output: movie_id[1]
-                                                    Filter: id[0]=keyword_id[2]
-                                                    -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=4) (actual rows=0)
-                                                        Output: id[0]
-                                                        Filter: keyword[1] in ('murder','murder-in-title','blood','violence')
-                                                    -> PhysicScanTable movie_keyword as mk (inccost=4523930, cost=4523930, rows=4523930) (actual rows=0)
-                                                        Output: movie_id[1],keyword_id[2]
-                                                -> PhysicScanTable movie_companies as mc (inccost=2609129, cost=2609129, rows=104365) (actual rows=0)
-                                                    Output: movie_id[1],company_type_id[3],company_id[2]
-                                                    Filter: note[4]not like'%(USA)%' and note[4]like'%(200%)%'
-                                            -> PhysicScanTable movie_info as mi (inccost=14835720, cost=14835720, rows=126424) (actual rows=0)
-                                                Output: movie_id[1],info_type_id[2]
-                                                Filter: info[3] in ('Sweden','Germany','Swedish','German')
-                                    -> PhysicScanTable comp_cast_type as cct2 (inccost=4, cost=4, rows=4) (actual rows=0)
+                            -> PhysicNLJoin  (inccost=27328563, cost=154, rows=4) (actual rows=0)
+                                Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[6],company_type_id[5]
+                                -> PhysicHashJoin  (inccost=27328405, cost=4, rows=1, memory=2147483696) (actual rows=0)
+                                    Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],company_type_id[5]
+                                    Filter: id[7]=info_type_id[6]
+                                    -> PhysicNLJoin  (inccost=27328288, cost=121, rows=1) (actual rows=0)
+                                        Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[6],company_type_id[4],info_type_id[5]
+                                        -> PhysicHashJoin  (inccost=27328163, cost=235000, rows=1, memory=48) (actual rows=0)
+                                            Output: name[6],movie_id[0],movie_id[1],movie_id[2],company_type_id[3],info_type_id[4]
+                                            Filter: id[7]=company_id[5]
+                                            -> PhysicHashJoin  (inccost=26858166, cost=126483, rows=1, memory=928) (actual rows=0)
+                                                Output: movie_id[0],movie_id[4],movie_id[1],company_type_id[2],info_type_id[5],company_id[3]
+                                                Filter: movie_id[0]=movie_id[4] and movie_id[4]=movie_id[1]
+                                                -> PhysicHashJoin  (inccost=11895963, cost=104662, rows=29, memory=1072) (actual rows=0)
+                                                    Output: movie_id[0],movie_id[1],company_type_id[2],company_id[3]
+                                                    Filter: movie_id[0]=movie_id[1]
+                                                    -> PhysicHashJoin  (inccost=9182172, cost=4524072, rows=134, memory=32) (actual rows=0)
+                                                        Output: movie_id[1]
+                                                        Filter: id[0]=keyword_id[2]
+                                                        -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=4) (actual rows=0)
+                                                            Output: id[0]
+                                                            Filter: keyword[1] in ('murder','murder-in-title','blood','violence')
+                                                        -> PhysicScanTable movie_keyword as mk (inccost=4523930, cost=4523930, rows=4523930) (actual rows=0)
+                                                            Output: movie_id[1],keyword_id[2]
+                                                    -> PhysicScanTable movie_companies as mc (inccost=2609129, cost=2609129, rows=104365) (actual rows=0)
+                                                        Output: movie_id[1],company_type_id[3],company_id[2]
+                                                        Filter: note[4]not like'%(USA)%' and note[4]like'%(200%)%'
+                                                -> PhysicScanTable movie_info as mi (inccost=14835720, cost=14835720, rows=126424) (actual rows=0)
+                                                    Output: movie_id[1],info_type_id[2]
+                                                    Filter: info[3] in ('Sweden','Germany','Swedish','German')
+                                            -> PhysicScanTable company_name as cn (inccost=234997, cost=234997, rows=234997) (actual rows=0)
+                                                Output: name[1],id[0]
+                                                Filter: country_code[2]!='[us]'
+                                        -> PhysicScanTable comp_cast_type as cct1 (inccost=4, cost=4, rows=1) (actual rows=0)
+                                            Output: id[0]
+                                            Filter: kind[1]='crew'
+                                    -> PhysicScanTable info_type as it1 (inccost=113, cost=113, rows=1) (actual rows=0)
                                         Output: id[0]
-                                        Filter: kind[1]!='complete+verified'
-                                -> PhysicScanTable company_name as cn (inccost=234997, cost=234997, rows=234997) (actual rows=0)
-                                    Output: name[1],id[0]
-                                    Filter: country_code[2]!='[us]'
+                                        Filter: info[1]='countries'
+                                -> PhysicScanTable comp_cast_type as cct2 (inccost=4, cost=4, rows=4) (actual rows=0)
+                                    Output: id[0]
+                                    Filter: kind[1]!='complete+verified'
                             -> PhysicScanTable company_type as ct (inccost=4, cost=4, rows=4) (actual rows=0)
                                 Output: id[0]
                         -> PhysicScanTable movie_info_idx as mi_idx (inccost=1380035, cost=1380035, rows=303239) (actual rows=0)

--- a/test/regress/expect/jobench/28c.txt
+++ b/test/regress/expect/jobench/28c.txt
@@ -63,26 +63,26 @@ WHERE cct1.kind = 'cast'
   AND cn.id = mc.company_id
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
-Total cost: 34462890, memory=36507224504
-PhysicHashAgg  (inccost=34462890, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 34462889, memory=34359740816
+PhysicHashAgg  (inccost=34462889, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(info[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=34462887, cost=135089, rows=1, memory=6442451000) (actual rows=0)
+    -> PhysicHashJoin  (inccost=34462886, cost=135089, rows=1, memory=6442451000) (actual rows=0)
         Output: name[0],info[1],title[2]
         Filter: id[3]=movie_id[10] and movie_id[4]=movie_id[10] and movie_id[5]=movie_id[10] and movie_id[6]=movie_id[10] and movie_id[7]=movie_id[10] and id[8]=subject_id[11] and id[9]=status_id[12]
-        -> PhysicHashJoin  (inccost=34192712, cost=5, rows=1, memory=6442451008) (actual rows=0)
+        -> PhysicHashJoin  (inccost=34192711, cost=5, rows=1, memory=6442451008) (actual rows=0)
             Output: name[0],info[1],title[2],id[3],movie_id[4],movie_id[5],movie_id[6],movie_id[7],id[8],id[9]
             Filter: id[11]=kind_id[10]
-            -> PhysicHashJoin  (inccost=34192700, cost=1042587, rows=1, memory=4294967344) (actual rows=0)
+            -> PhysicHashJoin  (inccost=34192699, cost=1042587, rows=1, memory=4294967344) (actual rows=0)
                 Output: name[0],info[1],title[8],id[9],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7],kind_id[10]
                 Filter: id[9]=movie_id[4] and id[9]=movie_id[3] and id[9]=movie_id[5] and id[9]=movie_id[2]
-                -> PhysicHashJoin  (inccost=30621801, cost=4, rows=1, memory=4294967352) (actual rows=0)
+                -> PhysicHashJoin  (inccost=30621800, cost=4, rows=1, memory=4294967352) (actual rows=0)
                     Output: name[0],info[1],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7]
                     Filter: id[9]=info_type_id[8]
-                    -> PhysicHashJoin  (inccost=30621684, cost=1338340, rows=1, memory=4294967376) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=30621683, cost=1338340, rows=1, memory=2147483688) (actual rows=0)
                         Output: name[0],info[6],movie_id[1],movie_id[2],movie_id[3],movie_id[7],id[4],id[5],info_type_id[8]
                         Filter: movie_id[1]=movie_id[7] and movie_id[3]=movie_id[7] and movie_id[2]=movie_id[7]
-                        -> PhysicHashJoin  (inccost=27903309, cost=8, rows=2, memory=2147483696) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=27903308, cost=7, rows=1, memory=2147483696) (actual rows=0)
                             Output: name[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[5]
                             Filter: id[7]=company_type_id[6]
                             -> PhysicHashJoin  (inccost=27903297, cost=4, rows=1, memory=2147483704) (actual rows=0)

--- a/test/regress/expect/jobench/2a.txt
+++ b/test/regress/expect/jobench/2a.txt
@@ -11,17 +11,17 @@ WHERE cn.country_code ='[de]'
   AND t.id = mk.movie_id
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id
-Total cost: 19703447, memory=4294971896
-PhysicHashAgg  (inccost=19703447, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 19703451, memory=4294971992
+PhysicHashAgg  (inccost=19703451, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(title)}[0]
     Aggregates: min(title[0])
-    -> PhysicHashJoin  (inccost=19703444, cost=10885, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=19703448, cost=10885, rows=1, memory=2147483656) (actual rows=0)
         Output: title[0]
         Filter: id[2]=company_id[1]
-        -> PhysicHashJoin  (inccost=19457562, cost=2528681, rows=1, memory=4320) (actual rows=0)
+        -> PhysicHashJoin  (inccost=19457566, cost=2528681, rows=1, memory=4416) (actual rows=0)
             Output: title[3],company_id[0]
             Filter: movie_id[1]=id[4] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+            -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                 Output: company_id[1],movie_id[2],movie_id[0]
                 Filter: movie_id[2]=movie_id[0]
                 -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/2b.txt
+++ b/test/regress/expect/jobench/2b.txt
@@ -11,17 +11,17 @@ WHERE cn.country_code ='[nl]'
   AND t.id = mk.movie_id
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id
-Total cost: 19695170, memory=4294971896
-PhysicHashAgg  (inccost=19695170, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 19695174, memory=4294971992
+PhysicHashAgg  (inccost=19695174, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(title)}[0]
     Aggregates: min(title[0])
-    -> PhysicHashJoin  (inccost=19695167, cost=2608, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=19695171, cost=2608, rows=1, memory=2147483656) (actual rows=0)
         Output: title[0]
         Filter: id[2]=company_id[1]
-        -> PhysicHashJoin  (inccost=19457562, cost=2528681, rows=1, memory=4320) (actual rows=0)
+        -> PhysicHashJoin  (inccost=19457566, cost=2528681, rows=1, memory=4416) (actual rows=0)
             Output: title[3],company_id[0]
             Filter: movie_id[1]=id[4] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+            -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                 Output: company_id[1],movie_id[2],movie_id[0]
                 Filter: movie_id[2]=movie_id[0]
                 -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/2c.txt
+++ b/test/regress/expect/jobench/2c.txt
@@ -11,17 +11,17 @@ WHERE cn.country_code ='[sm]'
   AND t.id = mk.movie_id
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id
-Total cost: 19692574, memory=4294971896
-PhysicHashAgg  (inccost=19692574, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 19692578, memory=4294971992
+PhysicHashAgg  (inccost=19692578, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(title)}[0]
     Aggregates: min(title[0])
-    -> PhysicHashJoin  (inccost=19692571, cost=12, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=19692575, cost=12, rows=1, memory=2147483656) (actual rows=0)
         Output: title[0]
         Filter: id[2]=company_id[1]
-        -> PhysicHashJoin  (inccost=19457562, cost=2528681, rows=1, memory=4320) (actual rows=0)
+        -> PhysicHashJoin  (inccost=19457566, cost=2528681, rows=1, memory=4416) (actual rows=0)
             Output: title[3],company_id[0]
             Filter: movie_id[1]=id[4] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+            -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                 Output: company_id[1],movie_id[2],movie_id[0]
                 Filter: movie_id[2]=movie_id[0]
                 -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/2d.txt
+++ b/test/regress/expect/jobench/2d.txt
@@ -11,17 +11,17 @@ WHERE cn.country_code ='[us]'
   AND t.id = mk.movie_id
   AND mk.keyword_id = k.id
   AND mc.movie_id = mk.movie_id
-Total cost: 19787024, memory=4294971896
-PhysicHashAgg  (inccost=19787024, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 19787028, memory=4294971992
+PhysicHashAgg  (inccost=19787028, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(title)}[0]
     Aggregates: min(title[0])
-    -> PhysicHashJoin  (inccost=19787021, cost=94462, rows=1, memory=2147483656) (actual rows=0)
+    -> PhysicHashJoin  (inccost=19787025, cost=94462, rows=1, memory=2147483656) (actual rows=0)
         Output: title[0]
         Filter: id[2]=company_id[1]
-        -> PhysicHashJoin  (inccost=19457562, cost=2528681, rows=1, memory=4320) (actual rows=0)
+        -> PhysicHashJoin  (inccost=19457566, cost=2528681, rows=1, memory=4416) (actual rows=0)
             Output: title[3],company_id[0]
             Filter: movie_id[1]=id[4] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=14400569, cost=2609375, rows=180, memory=264) (actual rows=0)
+            -> PhysicHashJoin  (inccost=14400573, cost=2609379, rows=184, memory=264) (actual rows=0)
                 Output: company_id[1],movie_id[2],movie_id[0]
                 Filter: movie_id[2]=movie_id[0]
                 -> PhysicHashJoin  (inccost=9182065, cost=4523965, rows=33, memory=8) (actual rows=0)

--- a/test/regress/expect/jobench/30a.txt
+++ b/test/regress/expect/jobench/30a.txt
@@ -56,7 +56,7 @@ WHERE cct1.kind IN ('cast',
   AND k.id = mk.keyword_id
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
-Total cost: 77337150, memory=34359740328
+Total cost: 77337150, memory=32212256624
 PhysicHashAgg  (inccost=77337150, cost=3, rows=1, memory=8589934592) (actual rows=1)
     Output: {min(info)}[0],{min(info)}[1],{min(name)}[2],{min(title)}[3]
     Aggregates: min(info[0]), min(info[1]), min(name[2]), min(title[3])
@@ -69,12 +69,12 @@ PhysicHashAgg  (inccost=77337150, cost=3, rows=1, memory=8589934592) (actual row
             -> PhysicHashJoin  (inccost=73116698, cost=2683942, rows=1, memory=4294967352) (actual rows=0)
                 Output: info[0],info[1],name[9],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7]
                 Filter: id[10]=person_id[8]
-                -> PhysicHashJoin  (inccost=66265265, cost=1380038, rows=1, memory=4294967408) (actual rows=0)
+                -> PhysicHashJoin  (inccost=66265265, cost=1380038, rows=1, memory=2147483704) (actual rows=0)
                     Output: info[0],info[8],movie_id[1],movie_id[2],movie_id[9],movie_id[3],id[4],id[5],person_id[6]
                     Filter: movie_id[9]=movie_id[3] and movie_id[1]=movie_id[9] and movie_id[2]=movie_id[9] and id[7]=info_type_id[10]
-                    -> PhysicNLJoin  (inccost=63505192, cost=121, rows=2) (actual rows=0)
+                    -> PhysicNLJoin  (inccost=63505192, cost=121, rows=1) (actual rows=0)
                         Output: info[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[5],person_id[6],id[7]
-                        -> PhysicNLJoin  (inccost=63504958, cost=132, rows=2) (actual rows=0)
+                        -> PhysicNLJoin  (inccost=63504958, cost=132, rows=1) (actual rows=0)
                             Output: info[0],movie_id[1],movie_id[2],movie_id[3],id[6],id[4],person_id[5]
                             -> PhysicNLJoin  (inccost=63504822, cost=121, rows=1) (actual rows=0)
                                 Output: info[0],movie_id[1],movie_id[2],movie_id[3],id[5],person_id[4]

--- a/test/regress/expect/jobench/30b.txt
+++ b/test/regress/expect/jobench/30b.txt
@@ -59,7 +59,7 @@ WHERE cct1.kind IN ('cast',
   AND k.id = mk.keyword_id
   AND cct1.id = cc.subject_id
   AND cct2.id = cc.status_id
-Total cost: 75985156, memory=34359740328
+Total cost: 75985156, memory=32212256624
 PhysicHashAgg  (inccost=75985156, cost=3, rows=1, memory=8589934592) (actual rows=1)
     Output: {min(info)}[0],{min(info)}[1],{min(name)}[2],{min(title)}[3]
     Aggregates: min(info[0]), min(info[1]), min(name[2]), min(title[3])
@@ -72,12 +72,12 @@ PhysicHashAgg  (inccost=75985156, cost=3, rows=1, memory=8589934592) (actual row
             -> PhysicHashJoin  (inccost=73116698, cost=2683942, rows=1, memory=4294967352) (actual rows=0)
                 Output: info[0],info[1],name[9],movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[6],id[7]
                 Filter: id[10]=person_id[8]
-                -> PhysicHashJoin  (inccost=66265265, cost=1380038, rows=1, memory=4294967408) (actual rows=0)
+                -> PhysicHashJoin  (inccost=66265265, cost=1380038, rows=1, memory=2147483704) (actual rows=0)
                     Output: info[0],info[8],movie_id[1],movie_id[2],movie_id[9],movie_id[3],id[4],id[5],person_id[6]
                     Filter: movie_id[9]=movie_id[3] and movie_id[1]=movie_id[9] and movie_id[2]=movie_id[9] and id[7]=info_type_id[10]
-                    -> PhysicNLJoin  (inccost=63505192, cost=121, rows=2) (actual rows=0)
+                    -> PhysicNLJoin  (inccost=63505192, cost=121, rows=1) (actual rows=0)
                         Output: info[0],movie_id[1],movie_id[2],movie_id[3],id[4],id[5],person_id[6],id[7]
-                        -> PhysicNLJoin  (inccost=63504958, cost=132, rows=2) (actual rows=0)
+                        -> PhysicNLJoin  (inccost=63504958, cost=132, rows=1) (actual rows=0)
                             Output: info[0],movie_id[1],movie_id[2],movie_id[3],id[6],id[4],person_id[5]
                             -> PhysicNLJoin  (inccost=63504822, cost=121, rows=1) (actual rows=0)
                                 Output: info[0],movie_id[1],movie_id[2],movie_id[3],id[5],person_id[4]

--- a/test/regress/expect/jobench/32a.txt
+++ b/test/regress/expect/jobench/32a.txt
@@ -14,25 +14,25 @@ WHERE k.keyword ='10,000-mile-club'
   AND ml.linked_movie_id = t2.id
   AND lt.id = ml.link_type_id
   AND mk.movie_id = t1.id
-Total cost: 21967616, memory=5430187302124728
-PhysicHashAgg  (inccost=21967616, cost=3, rows=1, memory=4294967360) (actual rows=1)
+Total cost: 21967618, memory=5430187302124728
+PhysicHashAgg  (inccost=21967618, cost=3, rows=1, memory=4294967360) (actual rows=1)
     Output: {min(link)}[0],{min(title)}[1],{min(title)}[2]
     Aggregates: min(link[0]), min(title[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=21967613, cost=41284, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=21967615, cost=41284, rows=1, memory=8) (actual rows=0)
         Output: link[1],title[2],title[3]
         Filter: keyword_id[4]=id[0]
         -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=1) (actual rows=0)
             Output: id[0]
             Filter: keyword[1]='10,000-mile-club'
-        -> PhysicHashJoin  (inccost=21792159, cost=2570121, rows=41281, memory=566935704192) (actual rows=0)
+        -> PhysicHashJoin  (inccost=21792161, cost=2570121, rows=41281, memory=566935704192) (actual rows=0)
             Output: link[0],title[1],title[4],keyword_id[2]
             Filter: linked_movie_id[3]=id[5]
-            -> PhysicHashJoin  (inccost=16693726, cost=535, rows=264, memory=1296) (actual rows=0)
+            -> PhysicHashJoin  (inccost=16693728, cost=535, rows=264, memory=1296) (actual rows=0)
                 Output: link[0],title[2],keyword_id[3],linked_movie_id[4]
                 Filter: id[1]=link_type_id[5]
                 -> PhysicScanTable link_type as lt (inccost=18, cost=18, rows=18) (actual rows=0)
                     Output: link[1],id[0]
-                -> PhysicHashJoin  (inccost=16693173, cost=30330, rows=233, memory=107374183200) (actual rows=0)
+                -> PhysicHashJoin  (inccost=16693175, cost=30332, rows=235, memory=107374183200) (actual rows=0)
                     Output: title[0],keyword_id[1],linked_movie_id[3],link_type_id[4]
                     Filter: movie_id[5]=id[2]
                     -> PhysicHashJoin  (inccost=16632846, cost=9580604, rows=50, memory=5429508697268672) (actual rows=0)

--- a/test/regress/expect/jobench/32b.txt
+++ b/test/regress/expect/jobench/32b.txt
@@ -14,25 +14,25 @@ WHERE k.keyword ='character-name-in-title'
   AND ml.linked_movie_id = t2.id
   AND lt.id = ml.link_type_id
   AND mk.movie_id = t1.id
-Total cost: 21967616, memory=5430187302124728
-PhysicHashAgg  (inccost=21967616, cost=3, rows=1, memory=4294967360) (actual rows=1)
+Total cost: 21967618, memory=5430187302124728
+PhysicHashAgg  (inccost=21967618, cost=3, rows=1, memory=4294967360) (actual rows=1)
     Output: {min(link)}[0],{min(title)}[1],{min(title)}[2]
     Aggregates: min(link[0]), min(title[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=21967613, cost=41284, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=21967615, cost=41284, rows=1, memory=8) (actual rows=0)
         Output: link[1],title[2],title[3]
         Filter: keyword_id[4]=id[0]
         -> PhysicScanTable keyword as k (inccost=134170, cost=134170, rows=1) (actual rows=0)
             Output: id[0]
             Filter: keyword[1]='character-name-in-title'
-        -> PhysicHashJoin  (inccost=21792159, cost=2570121, rows=41281, memory=566935704192) (actual rows=0)
+        -> PhysicHashJoin  (inccost=21792161, cost=2570121, rows=41281, memory=566935704192) (actual rows=0)
             Output: link[0],title[1],title[4],keyword_id[2]
             Filter: linked_movie_id[3]=id[5]
-            -> PhysicHashJoin  (inccost=16693726, cost=535, rows=264, memory=1296) (actual rows=0)
+            -> PhysicHashJoin  (inccost=16693728, cost=535, rows=264, memory=1296) (actual rows=0)
                 Output: link[0],title[2],keyword_id[3],linked_movie_id[4]
                 Filter: id[1]=link_type_id[5]
                 -> PhysicScanTable link_type as lt (inccost=18, cost=18, rows=18) (actual rows=0)
                     Output: link[1],id[0]
-                -> PhysicHashJoin  (inccost=16693173, cost=30330, rows=233, memory=107374183200) (actual rows=0)
+                -> PhysicHashJoin  (inccost=16693175, cost=30332, rows=235, memory=107374183200) (actual rows=0)
                     Output: title[0],keyword_id[1],linked_movie_id[3],link_type_id[4]
                     Filter: movie_id[5]=id[2]
                     -> PhysicHashJoin  (inccost=16632846, cost=9580604, rows=50, memory=5429508697268672) (actual rows=0)

--- a/test/regress/expect/jobench/33a.txt
+++ b/test/regress/expect/jobench/33a.txt
@@ -47,23 +47,23 @@ WHERE cn1.country_code = '[us]'
   AND ml.linked_movie_id = mi_idx2.movie_id
   AND ml.linked_movie_id = mc2.movie_id
   AND mi_idx2.movie_id = mc2.movie_id
-Total cost: 24791438, memory=105868797625264
-PhysicHashAgg  (inccost=24791438, cost=3, rows=1, memory=12884901888) (actual rows=1)
+Total cost: 24791462, memory=106023416449264
+PhysicHashAgg  (inccost=24791462, cost=3, rows=1, memory=12884901888) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[1],{min(info)}[2],{min(info)}[3],{min(title)}[4],{min(title)}[5]
     Aggregates: min(name[0]), min(name[1]), min(info[2]), min(info[3]), min(title[4]), min(title[5])
-    -> PhysicHashJoin  (inccost=24791435, cost=94462, rows=1, memory=10737418248) (actual rows=0)
+    -> PhysicHashJoin  (inccost=24791459, cost=94462, rows=1, memory=10737418248) (actual rows=0)
         Output: name[6],name[0],info[1],info[2],title[3],title[4]
         Filter: id[7]=company_id[5]
-        -> PhysicHashJoin  (inccost=24461976, cost=458964, rows=1, memory=8589934632) (actual rows=0)
+        -> PhysicHashJoin  (inccost=24462000, cost=458964, rows=1, memory=8589934632) (actual rows=0)
             Output: name[0],info[1],info[2],title[3],title[9],company_id[4]
             Filter: id[10]=linked_movie_id[5] and id[10]=movie_id[6] and id[7]=kind_id[11] and id[10]=movie_id[8]
-            -> PhysicHashJoin  (inccost=21474700, cost=2528315, rows=1, memory=6442451016) (actual rows=0)
+            -> PhysicHashJoin  (inccost=21474724, cost=2528315, rows=1, memory=6442451016) (actual rows=0)
                 Output: name[0],info[1],info[2],title[12],company_id[3],linked_movie_id[4],movie_id[5],id[6],movie_id[7]
                 Filter: id[13]=movie_id[8] and id[13]=movie_id[9] and id[10]=kind_id[14] and id[13]=movie_id[11]
-                -> PhysicHashJoin  (inccost=16418073, cost=2610554, rows=1, memory=4432406288000) (actual rows=0)
+                -> PhysicHashJoin  (inccost=16418097, cost=2610554, rows=1, memory=4587025112000) (actual rows=0)
                     Output: name[0],info[1],info[2],company_id[10],linked_movie_id[3],movie_id[4],id[5],movie_id[6],movie_id[7],movie_id[8],id[9],movie_id[11]
                     Filter: movie_id[8]=movie_id[11] and movie_id[7]=movie_id[11]
-                    -> PhysicHashJoin  (inccost=11198390, cost=1380755, rows=688, memory=68719477632) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=11198414, cost=1380779, rows=712, memory=68719477632) (actual rows=0)
                         Output: name[0],info[9],info[1],linked_movie_id[2],movie_id[3],id[4],movie_id[5],movie_id[6],movie_id[10],id[7]
                         Filter: movie_id[6]=movie_id[10] and id[8]=info_type_id[11]
                         -> PhysicNLJoin  (inccost=8437600, cost=286, rows=16) (actual rows=0)

--- a/test/regress/expect/jobench/33b.txt
+++ b/test/regress/expect/jobench/33b.txt
@@ -45,23 +45,23 @@ WHERE cn1.country_code = '[nl]'
   AND ml.linked_movie_id = mi_idx2.movie_id
   AND ml.linked_movie_id = mc2.movie_id
   AND mi_idx2.movie_id = mc2.movie_id
-Total cost: 23941717, memory=35207994828888
-PhysicHashAgg  (inccost=23941717, cost=3, rows=1, memory=12884901888) (actual rows=1)
+Total cost: 23941739, memory=35349728750888
+PhysicHashAgg  (inccost=23941739, cost=3, rows=1, memory=12884901888) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[1],{min(info)}[2],{min(info)}[3],{min(title)}[4],{min(title)}[5]
     Aggregates: min(name[0]), min(name[1]), min(info[2]), min(info[3]), min(title[4]), min(title[5])
-    -> PhysicHashJoin  (inccost=23941714, cost=2608, rows=1, memory=10737418248) (actual rows=0)
+    -> PhysicHashJoin  (inccost=23941736, cost=2608, rows=1, memory=10737418248) (actual rows=0)
         Output: name[6],name[0],info[1],info[2],title[3],title[4]
         Filter: id[7]=company_id[5]
-        -> PhysicHashJoin  (inccost=23704109, cost=123077, rows=1, memory=8589934632) (actual rows=0)
+        -> PhysicHashJoin  (inccost=23704131, cost=123077, rows=1, memory=8589934632) (actual rows=0)
             Output: name[0],info[1],info[2],title[3],title[9],company_id[4]
             Filter: id[10]=linked_movie_id[5] and id[10]=movie_id[6] and id[7]=kind_id[11] and id[10]=movie_id[8]
-            -> PhysicHashJoin  (inccost=21052720, cost=2528315, rows=1, memory=6442451016) (actual rows=0)
+            -> PhysicHashJoin  (inccost=21052742, cost=2528315, rows=1, memory=6442451016) (actual rows=0)
                 Output: name[0],info[1],info[2],title[12],company_id[3],linked_movie_id[4],movie_id[5],id[6],movie_id[7]
                 Filter: id[13]=movie_id[8] and id[13]=movie_id[9] and id[10]=kind_id[14] and id[13]=movie_id[11]
-                -> PhysicHashJoin  (inccost=15996093, cost=2609604, rows=1, memory=1385126965000) (actual rows=0)
+                -> PhysicHashJoin  (inccost=15996115, cost=2609604, rows=1, memory=1526860887000) (actual rows=0)
                     Output: name[0],info[1],info[2],company_id[10],linked_movie_id[3],movie_id[4],id[5],movie_id[6],movie_id[7],movie_id[8],id[9],movie_id[11]
                     Filter: movie_id[8]=movie_id[11] and movie_id[7]=movie_id[11]
-                    -> PhysicHashJoin  (inccost=10777360, cost=1380260, rows=215, memory=21474836760) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=10777382, cost=1380282, rows=237, memory=21474836760) (actual rows=0)
                         Output: name[0],info[9],info[1],linked_movie_id[2],movie_id[3],id[4],movie_id[5],movie_id[6],movie_id[10],id[7]
                         Filter: movie_id[6]=movie_id[10] and id[8]=info_type_id[11]
                         -> PhysicNLJoin  (inccost=8017065, cost=165, rows=5) (actual rows=0)

--- a/test/regress/expect/jobench/33c.txt
+++ b/test/regress/expect/jobench/33c.txt
@@ -49,28 +49,28 @@ WHERE cn1.country_code != '[us]'
   AND ml.linked_movie_id = mi_idx2.movie_id
   AND ml.linked_movie_id = mc2.movie_id
   AND mi_idx2.movie_id = mc2.movie_id
-Total cost: 25574646, memory=121891173267136
-PhysicHashAgg  (inccost=25574646, cost=3, rows=1, memory=12884901888) (actual rows=1)
+Total cost: 25569178, memory=107917497085320
+PhysicHashAgg  (inccost=25569178, cost=3, rows=1, memory=12884901888) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[1],{min(info)}[2],{min(info)}[3],{min(title)}[4],{min(title)}[5]
     Aggregates: min(name[0]), min(name[1]), min(info[2]), min(info[3]), min(title[4]), min(title[5])
-    -> PhysicHashJoin  (inccost=25574643, cost=235000, rows=1, memory=10737418248) (actual rows=0)
+    -> PhysicHashJoin  (inccost=25569175, cost=235000, rows=1, memory=10737418248) (actual rows=0)
         Output: name[6],name[0],info[1],info[2],title[3],title[4]
         Filter: id[7]=company_id[5]
-        -> PhysicHashJoin  (inccost=25104646, cost=1073460, rows=1, memory=8589934632) (actual rows=0)
+        -> PhysicHashJoin  (inccost=25099178, cost=1073460, rows=1, memory=8589934632) (actual rows=0)
             Output: name[0],info[1],info[2],title[3],title[9],company_id[4]
             Filter: id[10]=linked_movie_id[5] and id[10]=movie_id[6] and id[7]=kind_id[11] and id[10]=movie_id[8]
-            -> PhysicHashJoin  (inccost=21502874, cost=2609132, rows=1, memory=8589934648) (actual rows=0)
-                Output: name[0],info[1],info[2],title[3],company_id[11],linked_movie_id[4],movie_id[5],id[6],movie_id[7]
-                Filter: movie_id[8]=movie_id[12] and movie_id[9]=movie_id[12] and id[10]=movie_id[12]
-                -> PhysicHashJoin  (inccost=16284613, cost=2534107, rows=1, memory=18580028684000) (actual rows=0)
-                    Output: name[0],info[1],info[2],title[10],linked_movie_id[3],movie_id[4],id[5],movie_id[6],movie_id[7],movie_id[8],id[11]
-                    Filter: id[9]=kind_id[12] and id[11]=movie_id[7] and id[11]=movie_id[8]
-                    -> PhysicHashJoin  (inccost=11222194, cost=1383053, rows=2884, memory=274877910528) (actual rows=0)
-                        Output: name[0],info[9],info[1],linked_movie_id[2],movie_id[3],id[4],movie_id[5],movie_id[10],movie_id[6],id[7]
-                        Filter: movie_id[6]=movie_id[10] and id[8]=info_type_id[11]
-                        -> PhysicNLJoin  (inccost=8459106, cost=516, rows=64) (actual rows=0)
+            -> PhysicHashJoin  (inccost=21497406, cost=2528315, rows=1, memory=6442451016) (actual rows=0)
+                Output: name[0],info[1],info[2],title[12],company_id[3],linked_movie_id[4],movie_id[5],id[6],movie_id[7]
+                Filter: id[13]=movie_id[8] and id[13]=movie_id[9] and id[10]=kind_id[14] and id[13]=movie_id[11]
+                -> PhysicHashJoin  (inccost=16440779, cost=1382176, rows=1, memory=4595615083760) (actual rows=0)
+                    Output: name[0],info[11],info[1],company_id[2],linked_movie_id[3],movie_id[4],id[5],movie_id[6],movie_id[7],movie_id[12],id[8],movie_id[9]
+                    Filter: movie_id[7]=movie_id[12] and id[10]=info_type_id[13] and movie_id[12]=movie_id[9]
+                    -> PhysicHashJoin  (inccost=13678568, cost=2610333, rows=1070, memory=287762812584) (actual rows=0)
+                        Output: name[0],info[1],company_id[9],linked_movie_id[2],movie_id[3],id[4],movie_id[5],movie_id[6],id[7],movie_id[10],id[8]
+                        Filter: movie_id[6]=movie_id[10]
+                        -> PhysicNLJoin  (inccost=8459106, cost=516, rows=67) (actual rows=0)
                             Output: name[0],info[1],linked_movie_id[2],movie_id[3],id[8],movie_id[4],movie_id[5],id[6],id[7]
-                            -> PhysicNLJoin  (inccost=8458583, cost=312, rows=32) (actual rows=0)
+                            -> PhysicNLJoin  (inccost=8458583, cost=312, rows=33) (actual rows=0)
                                 Output: name[0],info[1],linked_movie_id[2],movie_id[3],movie_id[4],movie_id[5],id[7],id[6]
                                 -> PhysicHashJoin  (inccost=8458264, cost=235045, rows=16, memory=34359739136) (actual rows=0)
                                     Output: name[7],info[0],linked_movie_id[1],movie_id[2],movie_id[3],movie_id[4],id[5]
@@ -113,12 +113,12 @@ PhysicHashAgg  (inccost=25574646, cost=3, rows=1, memory=12884901888) (actual ro
                             -> PhysicScanTable kind_type as kt2 (inccost=7, cost=7, rows=2) (actual rows=0)
                                 Output: id[0]
                                 Filter: kind[1] in ('tv series','episode')
-                        -> PhysicScanTable movie_info_idx as mi_idx1 (inccost=1380035, cost=1380035, rows=1380035) (actual rows=0)
-                            Output: info[3],movie_id[1],info_type_id[2]
-                    -> PhysicScanTable title as t1 (inccost=2528312, cost=2528312, rows=2528312) (actual rows=0)
-                        Output: title[1],id[0],kind_id[3]
-                -> PhysicScanTable movie_companies as mc1 (inccost=2609129, cost=2609129, rows=2609129) (actual rows=0)
-                    Output: company_id[2],movie_id[1]
+                        -> PhysicScanTable movie_companies as mc1 (inccost=2609129, cost=2609129, rows=2609129) (actual rows=0)
+                            Output: company_id[2],movie_id[1]
+                    -> PhysicScanTable movie_info_idx as mi_idx1 (inccost=1380035, cost=1380035, rows=1380035) (actual rows=0)
+                        Output: info[3],movie_id[1],info_type_id[2]
+                -> PhysicScanTable title as t1 (inccost=2528312, cost=2528312, rows=2528312) (actual rows=0)
+                    Output: title[1],id[0],kind_id[3]
             -> PhysicScanTable title as t2 (inccost=2528312, cost=2528312, rows=1073457) (actual rows=0)
                 Output: title[1],id[0],kind_id[3]
                 Filter: production_year[4]>=2000 and production_year[4]<=2010

--- a/test/regress/expect/jobench/4a.txt
+++ b/test/regress/expect/jobench/4a.txt
@@ -14,20 +14,20 @@ WHERE it.info ='rating'
   AND mk.movie_id = mi_idx.movie_id
   AND k.id = mk.keyword_id
   AND it.id = mi_idx.info_type_id
-Total cost: 14693920, memory=17336635743448
-PhysicHashAgg  (inccost=14693920, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 14693921, memory=17338783227120
+PhysicHashAgg  (inccost=14693921, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=14693917, cost=4, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=14693918, cost=4, rows=1, memory=8) (actual rows=0)
         Output: info[1],title[2]
         Filter: id[0]=info_type_id[3]
         -> PhysicScanTable info_type as it (inccost=113, cost=113, rows=1) (actual rows=0)
             Output: id[0]
             Filter: info[1]='rating'
-        -> PhysicHashJoin  (inccost=14693800, cost=1058729, rows=1, memory=17332340716712) (actual rows=0)
+        -> PhysicHashJoin  (inccost=14693801, cost=1058729, rows=1, memory=17334488200384) (actual rows=0)
             Output: info[0],title[4],info_type_id[1]
             Filter: id[5]=movie_id[2] and id[5]=movie_id[3]
-            -> PhysicHashJoin  (inccost=11106759, cost=537051, rows=8071, memory=57720) (actual rows=0)
+            -> PhysicHashJoin  (inccost=11106760, cost=537052, rows=8072, memory=57720) (actual rows=0)
                 Output: info[1],info_type_id[2],movie_id[3],movie_id[0]
                 Filter: movie_id[0]=movie_id[3]
                 -> PhysicHashJoin  (inccost=9189673, cost=4531573, rows=7215, memory=1712) (actual rows=0)

--- a/test/regress/expect/jobench/4c.txt
+++ b/test/regress/expect/jobench/4c.txt
@@ -14,20 +14,20 @@ WHERE it.info ='rating'
   AND mk.movie_id = mi_idx.movie_id
   AND k.id = mk.keyword_id
   AND it.id = mi_idx.info_type_id
-Total cost: 15756045, memory=27129161287768
-PhysicHashAgg  (inccost=15756045, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 15756046, memory=27131308771440
+PhysicHashAgg  (inccost=15756046, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(info)}[0],{min(title)}[1]
     Aggregates: min(info[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=15756042, cost=4, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=15756043, cost=4, rows=1, memory=8) (actual rows=0)
         Output: info[1],title[2]
         Filter: id[0]=info_type_id[3]
         -> PhysicScanTable info_type as it (inccost=113, cost=113, rows=1) (actual rows=0)
             Output: id[0]
             Filter: info[1]='rating'
-        -> PhysicHashJoin  (inccost=15755925, cost=1825641, rows=1, memory=27124866261032) (actual rows=0)
+        -> PhysicHashJoin  (inccost=15755926, cost=1825641, rows=1, memory=27127013744704) (actual rows=0)
             Output: info[0],title[4],info_type_id[1]
             Filter: id[5]=movie_id[2] and id[5]=movie_id[3]
-            -> PhysicHashJoin  (inccost=11401972, cost=832264, rows=12631, memory=57720) (actual rows=0)
+            -> PhysicHashJoin  (inccost=11401973, cost=832265, rows=12632, memory=57720) (actual rows=0)
                 Output: info[1],info_type_id[2],movie_id[3],movie_id[0]
                 Filter: movie_id[0]=movie_id[3]
                 -> PhysicHashJoin  (inccost=9189673, cost=4531573, rows=7215, memory=1712) (actual rows=0)

--- a/test/regress/expect/jobench/5c.txt
+++ b/test/regress/expect/jobench/5c.txt
@@ -23,20 +23,20 @@ WHERE ct.kind = 'production companies'
   AND mc.movie_id = mi.movie_id
   AND ct.id = mc.company_type_id
   AND it.id = mi.info_type_id
-Total cost: 22597246, memory=2148325696
-PhysicHashAgg  (inccost=22597246, cost=3, rows=1, memory=2147483648) (actual rows=1)
+Total cost: 22597247, memory=2148325720
+PhysicHashAgg  (inccost=22597247, cost=3, rows=1, memory=2147483648) (actual rows=1)
     Output: {min(title)}[0]
     Aggregates: min(title[0])
-    -> PhysicHashJoin  (inccost=22597243, cost=4, rows=1, memory=8) (actual rows=0)
+    -> PhysicHashJoin  (inccost=22597244, cost=4, rows=1, memory=8) (actual rows=0)
         Output: title[1]
         Filter: id[0]=company_type_id[2]
         -> PhysicScanTable company_type as ct (inccost=4, cost=4, rows=1) (actual rows=0)
             Output: id[0]
             Filter: kind[1]='production companies'
-        -> PhysicHashJoin  (inccost=22597235, cost=1842643, rows=1, memory=507168) (actual rows=0)
+        -> PhysicHashJoin  (inccost=22597236, cost=1842643, rows=1, memory=507192) (actual rows=0)
             Output: title[3],company_type_id[0]
             Filter: id[4]=movie_id[1] and id[4]=movie_id[2]
-            -> PhysicHashJoin  (inccost=18226280, cost=34636, rows=21132, memory=904) (actual rows=0)
+            -> PhysicHashJoin  (inccost=18226281, cost=34637, rows=21133, memory=904) (actual rows=0)
                 Output: company_type_id[1],movie_id[2],movie_id[3]
                 Filter: id[0]=info_type_id[4]
                 -> PhysicScanTable info_type as it (inccost=113, cost=113, rows=113) (actual rows=0)

--- a/test/regress/expect/jobench/6a.txt
+++ b/test/regress/expect/jobench/6a.txt
@@ -14,17 +14,17 @@ WHERE k.keyword = 'marvel-cinematic-universe'
   AND t.id = ci.movie_id
   AND ci.movie_id = mk.movie_id
   AND n.id = ci.person_id
-Total cost: 88769663, memory=60129542336
-PhysicHashAgg  (inccost=88769663, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 88769664, memory=64424509648
+PhysicHashAgg  (inccost=88769664, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(keyword)}[0],{min(name)}[1],{min(title)}[2]
     Aggregates: min(keyword[0]), min(name[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=88769660, cost=4, rows=1, memory=4294967304) (actual rows=0)
+    -> PhysicHashJoin  (inccost=88769661, cost=4, rows=1, memory=4294967304) (actual rows=0)
         Output: keyword[3],name[0],title[1]
         Filter: id[4]=keyword_id[2]
-        -> PhysicHashJoin  (inccost=88635486, cost=4523937, rows=1, memory=8589934624) (actual rows=0)
+        -> PhysicHashJoin  (inccost=88635487, cost=4523937, rows=1, memory=12884901936) (actual rows=0)
             Output: name[0],title[1],keyword_id[4]
             Filter: id[2]=movie_id[5] and movie_id[3]=movie_id[5]
-            -> PhysicHashJoin  (inccost=79587619, cost=403107, rows=2, memory=36507222152) (actual rows=0)
+            -> PhysicHashJoin  (inccost=79587620, cost=403108, rows=3, memory=36507222152) (actual rows=0)
                 Output: name[0],title[2],id[3],movie_id[1]
                 Filter: id[3]=movie_id[1]
                 -> PhysicHashJoin  (inccost=76656200, cost=36244365, rows=17, memory=4294967312) (actual rows=0)

--- a/test/regress/expect/jobench/7a.txt
+++ b/test/regress/expect/jobench/7a.txt
@@ -28,26 +28,26 @@ WHERE an.name LIKE '%a%'
   AND pi.person_id = ci.person_id
   AND an.person_id = ci.person_id
   AND ci.movie_id = ml.linked_movie_id
-Total cost: 93661185, memory=10737509336
-PhysicHashAgg  (inccost=93661185, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 93663006, memory=10737509336
+PhysicHashAgg  (inccost=93663006, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=93661182, cost=901346, rows=1, memory=4294967320) (actual rows=0)
+    -> PhysicHashJoin  (inccost=93663003, cost=901346, rows=1, memory=4294967320) (actual rows=0)
         Output: name[0],title[1]
         Filter: id[2]=person_id[5] and person_id[3]=person_id[5] and person_id[5]=person_id[4]
-        -> PhysicHashJoin  (inccost=91858493, cost=350247, rows=1, memory=2147483688) (actual rows=0)
+        -> PhysicHashJoin  (inccost=91860314, cost=350247, rows=1, memory=2147483688) (actual rows=0)
             Output: name[0],title[6],id[1],person_id[2],person_id[3]
             Filter: id[7]=movie_id[4] and linked_movie_id[5]=id[7]
-            -> PhysicHashJoin  (inccost=88979934, cost=865014, rows=1, memory=24992) (actual rows=0)
+            -> PhysicHashJoin  (inccost=88981755, cost=865014, rows=1, memory=24992) (actual rows=0)
                 Output: name[4],id[5],person_id[0],person_id[1],movie_id[2],linked_movie_id[3]
                 Filter: id[5]=person_id[0] and person_id[1]=id[5]
-                -> PhysicHashJoin  (inccost=83947429, cost=4207856, rows=781, memory=36048) (actual rows=0)
+                -> PhysicHashJoin  (inccost=83949250, cost=4207856, rows=781, memory=36048) (actual rows=0)
                     Output: person_id[0],person_id[2],movie_id[3],linked_movie_id[4]
                     Filter: id[5]=info_type_id[1] and person_id[0]=person_id[2]
                     -> PhysicScanTable person_info as pi (inccost=2963664, cost=2963664, rows=2253) (actual rows=0)
                         Output: person_id[1],info_type_id[2]
                         Filter: note[4]='Volker Boehm'
-                    -> PhysicHashJoin  (inccost=76775909, cost=40448840, rows=4200748, memory=29984) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=76777730, cost=40450661, rows=4202569, memory=29984) (actual rows=0)
                         Output: person_id[2],movie_id[3],linked_movie_id[0],id[1]
                         Filter: movie_id[3]=linked_movie_id[0]
                         -> PhysicNLJoin  (inccost=82725, cost=20724, rows=1874) (actual rows=0)

--- a/test/regress/expect/jobench/7b.txt
+++ b/test/regress/expect/jobench/7b.txt
@@ -26,26 +26,26 @@ WHERE an.name LIKE '%a%'
   AND pi.person_id = ci.person_id
   AND an.person_id = ci.person_id
   AND ci.movie_id = ml.linked_movie_id
-Total cost: 95209746, memory=10737509336
-PhysicHashAgg  (inccost=95209746, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 95211567, memory=10737509336
+PhysicHashAgg  (inccost=95211567, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=95209743, cost=901346, rows=1, memory=4294967320) (actual rows=0)
+    -> PhysicHashJoin  (inccost=95211564, cost=901346, rows=1, memory=4294967320) (actual rows=0)
         Output: name[0],title[1]
         Filter: id[2]=person_id[5] and person_id[3]=person_id[5] and person_id[5]=person_id[4]
-        -> PhysicHashJoin  (inccost=93407054, cost=78320, rows=1, memory=2147483688) (actual rows=0)
+        -> PhysicHashJoin  (inccost=93408875, cost=78320, rows=1, memory=2147483688) (actual rows=0)
             Output: name[0],title[6],id[1],person_id[2],person_id[3]
             Filter: id[7]=movie_id[4] and linked_movie_id[5]=id[7]
-            -> PhysicHashJoin  (inccost=90800422, cost=2685502, rows=1, memory=24992) (actual rows=0)
+            -> PhysicHashJoin  (inccost=90802243, cost=2685502, rows=1, memory=24992) (actual rows=0)
                 Output: name[4],id[5],person_id[0],person_id[1],movie_id[2],linked_movie_id[3]
                 Filter: id[5]=person_id[0] and person_id[1]=id[5]
-                -> PhysicHashJoin  (inccost=83947429, cost=4207856, rows=781, memory=36048) (actual rows=0)
+                -> PhysicHashJoin  (inccost=83949250, cost=4207856, rows=781, memory=36048) (actual rows=0)
                     Output: person_id[0],person_id[2],movie_id[3],linked_movie_id[4]
                     Filter: id[5]=info_type_id[1] and person_id[0]=person_id[2]
                     -> PhysicScanTable person_info as pi (inccost=2963664, cost=2963664, rows=2253) (actual rows=0)
                         Output: person_id[1],info_type_id[2]
                         Filter: note[4]='Volker Boehm'
-                    -> PhysicHashJoin  (inccost=76775909, cost=40448840, rows=4200748, memory=29984) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=76777730, cost=40450661, rows=4202569, memory=29984) (actual rows=0)
                         Output: person_id[2],movie_id[3],linked_movie_id[0],id[1]
                         Filter: movie_id[3]=linked_movie_id[0]
                         -> PhysicNLJoin  (inccost=82725, cost=20724, rows=1874) (actual rows=0)

--- a/test/regress/expect/jobench/7c.txt
+++ b/test/regress/expect/jobench/7c.txt
@@ -33,29 +33,29 @@ WHERE an.name IS NOT NULL
   AND pi.person_id = ci.person_id
   AND an.person_id = ci.person_id
   AND ci.movie_id = ml.linked_movie_id
-Total cost: 134156334, memory=8218679820863720
-PhysicHashAgg  (inccost=134156334, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 134156894, memory=8218679820863720
+PhysicHashAgg  (inccost=134156894, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(info)}[1]
     Aggregates: min(name[0]), min(info[1])
-    -> PhysicHashJoin  (inccost=134156331, cost=901346, rows=1, memory=4294967320) (actual rows=0)
+    -> PhysicHashJoin  (inccost=134156891, cost=901346, rows=1, memory=4294967320) (actual rows=0)
         Output: name[0],info[1]
         Filter: id[2]=person_id[5] and person_id[3]=person_id[5] and person_id[5]=person_id[4]
-        -> PhysicHashJoin  (inccost=132353642, cost=1601407, rows=1, memory=4294967336) (actual rows=0)
+        -> PhysicHashJoin  (inccost=132354202, cost=1601407, rows=1, memory=4294967336) (actual rows=0)
             Output: name[0],info[1],id[2],person_id[3],person_id[4]
             Filter: id[7]=movie_id[5] and linked_movie_id[6]=id[7]
-            -> PhysicHashJoin  (inccost=128223923, cost=9509641, rows=1, memory=6364420025584896) (actual rows=0)
+            -> PhysicHashJoin  (inccost=128224483, cost=9509641, rows=1, memory=6364420025584896) (actual rows=0)
                 Output: name[3],info[0],id[4],person_id[1],person_id[5],movie_id[6],linked_movie_id[7]
                 Filter: id[4]=person_id[1] and id[8]=info_type_id[2] and person_id[1]=person_id[5]
                 -> PhysicScanTable person_info as pi (inccost=2963664, cost=2963664, rows=2963664) (actual rows=0)
                     Output: info[3],person_id[1],info_type_id[2]
                     Filter: note[4]is notnull
-                -> PhysicHashJoin  (inccost=115750618, cost=22119492, rows=3582312, memory=1854246910256856) (actual rows=0)
+                -> PhysicHashJoin  (inccost=115751178, cost=22119492, rows=3582312, memory=1854246910256856) (actual rows=0)
                     Output: name[0],id[1],person_id[2],movie_id[3],linked_movie_id[4],id[5]
                     Filter: person_id[2]=id[1]
                     -> PhysicScanTable name as n (inccost=4167491, cost=4167491, rows=863451) (actual rows=0)
                         Output: name[1],id[0]
                         Filter: name_pcode_cf[5]>='A' and name_pcode_cf[5]<='F' and gender[4]='m' or gender[4]='f' and name[1]like'A%'
-                    -> PhysicHashJoin  (inccost=89463635, cost=53069060, rows=16809718, memory=119984) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=89464195, cost=53069620, rows=16810278, memory=119984) (actual rows=0)
                         Output: person_id[2],movie_id[3],linked_movie_id[0],id[1]
                         Filter: movie_id[3]=linked_movie_id[0]
                         -> PhysicNLJoin  (inccost=150231, cost=82599, rows=7499) (actual rows=0)

--- a/test/regress/expect/jobench/8c.txt
+++ b/test/regress/expect/jobench/8c.txt
@@ -17,30 +17,30 @@ WHERE cn.country_code ='[us]'
   AND ci.role_id = rt.id
   AND a1.person_id = ci.person_id
   AND ci.movie_id = mc.movie_id
-Total cost: 251548716, memory=5429519477172656
-PhysicHashAgg  (inccost=251548716, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 251548720, memory=5429519477172656
+PhysicHashAgg  (inccost=251548720, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=251548713, cost=901350, rows=1, memory=6442450992) (actual rows=0)
+    -> PhysicHashJoin  (inccost=251548717, cost=901350, rows=1, memory=6442450992) (actual rows=0)
         Output: name[3],title[0]
         Filter: person_id[4]=id[1] and person_id[4]=person_id[2]
-        -> PhysicHashJoin  (inccost=249746020, cost=8325709, rows=3, memory=5429508697268672) (actual rows=0)
+        -> PhysicHashJoin  (inccost=249746024, cost=8325709, rows=3, memory=5429508697268672) (actual rows=0)
             Output: title[0],id[2],person_id[3]
             Filter: movie_id[4]=id[1] and id[1]=movie_id[5]
             -> PhysicScanTable title as t (inccost=2528312, cost=2528312, rows=2528312) (actual rows=0)
                 Output: title[1],id[0]
-            -> PhysicHashJoin  (inccost=238891999, cost=39228993, rows=3269082, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=238892003, cost=39228993, rows=3269082, memory=8) (actual rows=0)
                 Output: id[1],person_id[2],movie_id[3],movie_id[4]
                 Filter: role_id[5]=id[0]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='writer'
-                -> PhysicHashJoin  (inccost=199662994, cost=79256627, rows=35959909, memory=33339928) (actual rows=0)
+                -> PhysicHashJoin  (inccost=199662998, cost=79256627, rows=35959909, memory=33339928) (actual rows=0)
                     Output: id[0],person_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[0]=person_id[1]
                     -> PhysicScanTable name as n1 (inccost=4167491, cost=4167491, rows=4167491) (actual rows=0)
                         Output: id[0]
-                    -> PhysicHashJoin  (inccost=116238876, cost=73303598, rows=34961732, memory=8390088) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=116238880, cost=73303602, rows=34961736, memory=8390088) (actual rows=0)
                         Output: person_id[1],movie_id[2],movie_id[0],role_id[3]
                         Filter: movie_id[2]=movie_id[0]
                         -> PhysicHashJoin  (inccost=6690934, cost=3846808, rows=1048761, memory=755672) (actual rows=0)

--- a/test/regress/expect/jobench/8d.txt
+++ b/test/regress/expect/jobench/8d.txt
@@ -17,30 +17,30 @@ WHERE cn.country_code ='[us]'
   AND ci.role_id = rt.id
   AND an1.person_id = ci.person_id
   AND ci.movie_id = mc.movie_id
-Total cost: 251548716, memory=5429519477172656
-PhysicHashAgg  (inccost=251548716, cost=3, rows=1, memory=4294967296) (actual rows=1)
+Total cost: 251548720, memory=5429519477172656
+PhysicHashAgg  (inccost=251548720, cost=3, rows=1, memory=4294967296) (actual rows=1)
     Output: {min(name)}[0],{min(title)}[1]
     Aggregates: min(name[0]), min(title[1])
-    -> PhysicHashJoin  (inccost=251548713, cost=901350, rows=1, memory=6442450992) (actual rows=0)
+    -> PhysicHashJoin  (inccost=251548717, cost=901350, rows=1, memory=6442450992) (actual rows=0)
         Output: name[3],title[0]
         Filter: person_id[4]=id[1] and person_id[4]=person_id[2]
-        -> PhysicHashJoin  (inccost=249746020, cost=8325709, rows=3, memory=5429508697268672) (actual rows=0)
+        -> PhysicHashJoin  (inccost=249746024, cost=8325709, rows=3, memory=5429508697268672) (actual rows=0)
             Output: title[0],id[2],person_id[3]
             Filter: movie_id[4]=id[1] and id[1]=movie_id[5]
             -> PhysicScanTable title as t (inccost=2528312, cost=2528312, rows=2528312) (actual rows=0)
                 Output: title[1],id[0]
-            -> PhysicHashJoin  (inccost=238891999, cost=39228993, rows=3269082, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=238892003, cost=39228993, rows=3269082, memory=8) (actual rows=0)
                 Output: id[1],person_id[2],movie_id[3],movie_id[4]
                 Filter: role_id[5]=id[0]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='costume designer'
-                -> PhysicHashJoin  (inccost=199662994, cost=79256627, rows=35959909, memory=33339928) (actual rows=0)
+                -> PhysicHashJoin  (inccost=199662998, cost=79256627, rows=35959909, memory=33339928) (actual rows=0)
                     Output: id[0],person_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[0]=person_id[1]
                     -> PhysicScanTable name as n1 (inccost=4167491, cost=4167491, rows=4167491) (actual rows=0)
                         Output: id[0]
-                    -> PhysicHashJoin  (inccost=116238876, cost=73303598, rows=34961732, memory=8390088) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=116238880, cost=73303602, rows=34961736, memory=8390088) (actual rows=0)
                         Output: person_id[1],movie_id[2],movie_id[0],role_id[3]
                         Filter: movie_id[2]=movie_id[0]
                         -> PhysicHashJoin  (inccost=6690934, cost=3846808, rows=1048761, memory=755672) (actual rows=0)

--- a/test/regress/expect/jobench/9a.txt
+++ b/test/regress/expect/jobench/9a.txt
@@ -30,26 +30,26 @@ WHERE ci.note IN ('(voice)',
   AND chn.id = ci.person_role_id
   AND an.person_id = n.id
   AND an.person_id = ci.person_id
-Total cost: 57779599, memory=36848673547728
-PhysicHashAgg  (inccost=57779599, cost=3, rows=1, memory=6442450944) (actual rows=1)
+Total cost: 57779600, memory=36850821031408
+PhysicHashAgg  (inccost=57779600, cost=3, rows=1, memory=6442450944) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[1],{min(title)}[2]
     Aggregates: min(name[0]), min(name[1]), min(title[2])
-    -> PhysicHashJoin  (inccost=57779596, cost=901346, rows=1, memory=4294967312) (actual rows=0)
+    -> PhysicHashJoin  (inccost=57779597, cost=901346, rows=1, memory=4294967312) (actual rows=0)
         Output: name[4],name[0],title[1]
         Filter: person_id[5]=id[2] and person_id[5]=person_id[3]
-        -> PhysicHashJoin  (inccost=55976907, cost=1140605, rows=1, memory=242665655840) (actual rows=0)
+        -> PhysicHashJoin  (inccost=55976908, cost=1140605, rows=1, memory=242665655840) (actual rows=0)
             Output: name[0],title[5],id[1],person_id[2]
             Filter: movie_id[3]=id[6] and id[6]=movie_id[4]
-            -> PhysicHashJoin  (inccost=52307990, cost=1362, rows=113, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=52307991, cost=1362, rows=113, memory=8) (actual rows=0)
                 Output: name[1],id[2],person_id[3],movie_id[4],movie_id[5]
                 Filter: role_id[6]=id[0]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='actress'
-                -> PhysicHashJoin  (inccost=52306616, cost=332041, rows=1247, memory=36595269390880) (actual rows=0)
+                -> PhysicHashJoin  (inccost=52306617, cost=332041, rows=1247, memory=36597416874560) (actual rows=0)
                     Output: name[0],id[5],person_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[5]=person_id[1]
-                    -> PhysicHashJoin  (inccost=47807084, cost=3191462, rows=17041, memory=681640) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=47807085, cost=3191463, rows=17042, memory=681640) (actual rows=0)
                         Output: name[5],person_id[0],movie_id[1],movie_id[2],role_id[3]
                         Filter: id[6]=person_role_id[4]
                         -> PhysicHashJoin  (inccost=41475283, cost=2242216, rows=17041, memory=67120) (actual rows=0)

--- a/test/regress/expect/jobench/9b.txt
+++ b/test/regress/expect/jobench/9b.txt
@@ -28,26 +28,26 @@ WHERE ci.note = '(voice)'
   AND chn.id = ci.person_role_id
   AND an.person_id = n.id
   AND an.person_id = ci.person_id
-Total cost: 56325152, memory=1219770768392
-PhysicHashAgg  (inccost=56325152, cost=3, rows=1, memory=8589934592) (actual rows=1)
+Total cost: 56325153, memory=1221918252072
+PhysicHashAgg  (inccost=56325153, cost=3, rows=1, memory=8589934592) (actual rows=1)
     Output: {min(name)}[0],{min(name)}[1],{min(name)}[2],{min(title)}[3]
     Aggregates: min(name[0]), min(name[1]), min(name[2]), min(title[3])
-    -> PhysicHashJoin  (inccost=56325149, cost=901346, rows=1, memory=6442450960) (actual rows=0)
+    -> PhysicHashJoin  (inccost=56325150, cost=901346, rows=1, memory=6442450960) (actual rows=0)
         Output: name[5],name[0],name[1],title[2]
         Filter: person_id[6]=id[3] and person_id[6]=person_id[4]
-        -> PhysicHashJoin  (inccost=54522460, cost=527895, rows=1, memory=4294967328) (actual rows=0)
+        -> PhysicHashJoin  (inccost=54522461, cost=527895, rows=1, memory=4294967328) (actual rows=0)
             Output: name[0],name[1],title[6],id[2],person_id[3]
             Filter: movie_id[4]=id[7] and id[7]=movie_id[5]
-            -> PhysicHashJoin  (inccost=51466253, cost=4, rows=1, memory=8) (actual rows=0)
+            -> PhysicHashJoin  (inccost=51466254, cost=4, rows=1, memory=8) (actual rows=0)
                 Output: name[1],name[2],id[3],person_id[4],movie_id[5],movie_id[6]
                 Filter: role_id[7]=id[0]
                 -> PhysicScanTable role_type as rt (inccost=12, cost=12, rows=1) (actual rows=0)
                     Output: id[0]
                     Filter: role[1]='actress'
-                -> PhysicHashJoin  (inccost=51466237, cost=12989, rows=1, memory=1200443377120) (actual rows=0)
+                -> PhysicHashJoin  (inccost=51466238, cost=12989, rows=1, memory=1202590860800) (actual rows=0)
                     Output: name[0],name[5],id[6],person_id[1],movie_id[2],movie_id[3],role_id[4]
                     Filter: id[6]=person_id[1]
-                    -> PhysicHashJoin  (inccost=47285757, cost=3142016, rows=559, memory=22360) (actual rows=0)
+                    -> PhysicHashJoin  (inccost=47285758, cost=3142017, rows=560, memory=22360) (actual rows=0)
                         Output: name[5],person_id[0],movie_id[1],movie_id[2],role_id[3]
                         Filter: id[6]=person_role_id[4]
                         -> PhysicHashJoin  (inccost=41003402, cost=1818470, rows=559, memory=2680) (actual rows=0)

--- a/test/regress/expect/tpch0001/q05.txt
+++ b/test/regress/expect/tpch0001/q05.txt
@@ -22,20 +22,20 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 17565.97, memory=10303
-PhysicOrder  (inccost=17565.97, cost=82.97, rows=25, memory=825) (actual rows=0)
+Total cost: 17615.97, memory=10303
+PhysicOrder  (inccost=17615.97, cost=82.97, rows=25, memory=825) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*1-l_discount)}[1]
     Order by: {sum(l_extendedprice*1-l_discount)}[1]
-    -> PhysicHashAgg  (inccost=17483, cost=133, rows=25, memory=1650) (actual rows=0)
+    -> PhysicHashAgg  (inccost=17533, cost=133, rows=25, memory=1650) (actual rows=0)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicHashJoin  (inccost=17350, cost=883, rows=83, memory=3600) (actual rows=0)
+        -> PhysicHashJoin  (inccost=17400, cost=883, rows=83, memory=3600) (actual rows=0)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
             Filter: c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9]
             -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=150)
                 Output: 1,c_custkey[0],c_nationkey[3]
-            -> PhysicHashJoin  (inccost=16317, cost=1360, rows=450, memory=330) (actual rows=0)
+            -> PhysicHashJoin  (inccost=16367, cost=1410, rows=500, memory=330) (actual rows=0)
                 Output: n_name[0],{l_extendedprice*1-l_discount}[3],l_extendedprice[4],{1-l_discount}[5],l_discount[6],o_custkey[7],s_nationkey[1]
                 Filter: l_suppkey[8]=s_suppkey[2]
                 -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=290) (actual rows=0)

--- a/test/regress/expect/tpch0001/q08.txt
+++ b/test/regress/expect/tpch0001/q08.txt
@@ -35,34 +35,34 @@ group by
 	o_year
 order by
 	o_year
-Total cost: 46099.1, memory=26170
-PhysicOrder  (inccost=46099.1, cost=0.1, rows=1, memory=16) (actual rows=2)
+Total cost: 46098.1, memory=26170
+PhysicOrder  (inccost=46098.1, cost=0.1, rows=1, memory=16) (actual rows=2)
     Output: o_year[0],{sum(case with 1)/sum(volume)(as mkt_share)}[1]
     Order by: o_year[0]
-    -> PhysicHashAgg  (inccost=46099, cost=9, rows=1, memory=32) (actual rows=2)
+    -> PhysicHashAgg  (inccost=46098, cost=9, rows=1, memory=32) (actual rows=2)
         Output: {o_year}[0],{sum(case with 1)}[1]/{sum(volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(volume[5])
         Group by: o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=46090, cost=7, rows=7) (actual rows=5)
+        -> PhysicFromQuery <all_nations> (inccost=46089, cost=7, rows=7) (actual rows=5)
             Output: o_year[0],case with 1,nation[2]='BRAZIL',nation[2],'BRAZIL',volume[1],0
-            -> PhysicHashJoin  (inccost=46083, cost=1516, rows=7, memory=8) (actual rows=5)
+            -> PhysicHashJoin  (inccost=46082, cost=1516, rows=7, memory=8) (actual rows=5)
                 Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3]
                 Filter: p_partkey[0]=l_partkey[4]
                 -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=1)
                     Output: p_partkey[0]
                     Filter: p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=44367, cost=9045, rows=1507, memory=8) (actual rows=385)
+                -> PhysicHashJoin  (inccost=44366, cost=9045, rows=1507, memory=8) (actual rows=385)
                     Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3],l_partkey[4]
                     Filter: n_regionkey[5]=r_regionkey[0]
                     -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1)
                         Output: r_regionkey[0]
                         Filter: r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=35317, cost=10299, rows=7536, memory=1450) (actual rows=1810)
+                    -> PhysicHashJoin  (inccost=35316, cost=10299, rows=7536, memory=1450) (actual rows=1810)
                         Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],n_name (as nation)[0],l_partkey[4],n_regionkey[5]
                         Filter: s_nationkey[6]=n_nationkey[1]
                         -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25) (actual rows=25)
                             Output: n_name (as nation)[1],n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=24993, cost=5448, rows=2714, memory=160) (actual rows=1810)
+                        -> PhysicHashJoin  (inccost=24992, cost=5447, rows=2713, memory=160) (actual rows=1810)
                             Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[5],s_nationkey[0]
                             Filter: s_suppkey[1]=l_suppkey[6]
                             -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=10)

--- a/test/regress/expect/tpch0001/q21.txt
+++ b/test/regress/expect/tpch0001/q21.txt
@@ -38,29 +38,29 @@ order by
 	numwait desc,
 	s_name
 limit 100
-Total cost: 38044918.02, memory=6744
-PhysicLimit (100) (inccost=38044918.02, cost=100, rows=100) (actual rows=0)
+Total cost: 38044950.02, memory=6744
+PhysicLimit (100) (inccost=38044950.02, cost=100, rows=100) (actual rows=0)
     Output: s_name[0],{count(*)(0)}[1]
-    -> PhysicOrder  (inccost=38044818.02, cost=24.02, rows=10, memory=290) (actual rows=0)
+    -> PhysicOrder  (inccost=38044850.02, cost=24.02, rows=10, memory=290) (actual rows=0)
         Output: s_name[0],{count(*)(0)}[1]
         Order by: {count(*)(0)}[1], s_name[0]
-        -> PhysicHashAgg  (inccost=38044794, cost=6025, rows=10, memory=580) (actual rows=0)
+        -> PhysicHashAgg  (inccost=38044826, cost=6025, rows=10, memory=580) (actual rows=0)
             Output: {s_name}[0],{count(*)(0)}[1]
             Aggregates: count(*)(0)
             Group by: s_name[0]
-            -> PhysicFilter  (inccost=38038769, cost=6005, rows=6005) (actual rows=0)
+            -> PhysicFilter  (inccost=38038801, cost=6005, rows=6005) (actual rows=0)
                 Output: s_name[1]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=38032764, cost=36060025, rows=6005) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=38032796, cost=36060025, rows=6005) (actual rows=0)
                     Output: #marker,s_name[0]
                     Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
-                    -> PhysicFilter  (inccost=1966734, cost=6005, rows=6005) (actual rows=0)
+                    -> PhysicFilter  (inccost=1966766, cost=6005, rows=6005) (actual rows=0)
                         Output: s_name[1],l_orderkey[2],l_suppkey[3]
                         Filter: {#marker}[0]
-                        -> PhysicMarkJoin Left (inccost=1960729, cost=1933610, rows=6005) (actual rows=0)
+                        -> PhysicMarkJoin Left (inccost=1960761, cost=1933610, rows=6005) (actual rows=0)
                             Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
                             Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
-                            -> PhysicHashJoin  (inccost=21114, cost=3198, rows=290, memory=58) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=21146, cost=3230, rows=322, memory=58) (actual rows=0)
                                 Output: s_name[0],l_orderkey[2],l_suppkey[3]
                                 Filter: s_suppkey[1]=l_suppkey[3]
                                 -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0)

--- a/test/regress/expect/tpch1/q08.txt
+++ b/test/regress/expect/tpch1/q08.txt
@@ -35,34 +35,34 @@ group by
 	o_year
 order by
 	o_year
-Total cost: 34516292.1, memory=24462778
-PhysicOrder  (inccost=34516292.1, cost=0.1, rows=1, memory=16)
+Total cost: 34516293.1, memory=24462778
+PhysicOrder  (inccost=34516293.1, cost=0.1, rows=1, memory=16)
     Output: o_year[0],{sum(case with 1)/sum(volume)(as mkt_share)}[1]
     Order by: o_year[0]
-    -> PhysicHashAgg  (inccost=34516292, cost=4, rows=1, memory=32)
+    -> PhysicHashAgg  (inccost=34516293, cost=4, rows=1, memory=32)
         Output: {o_year}[0],{sum(case with 1)}[1]/{sum(volume)}[2](as mkt_share)
         Aggregates: sum(case with 1), sum(volume[5])
         Group by: o_year[0]
-        -> PhysicFromQuery <all_nations> (inccost=34516288, cost=2, rows=2)
+        -> PhysicFromQuery <all_nations> (inccost=34516289, cost=2, rows=2)
             Output: o_year[0],case with 1,nation[2]='BRAZIL',nation[2],'BRAZIL',volume[1],0
-            -> PhysicHashJoin  (inccost=34516286, cost=547636, rows=2, memory=8)
+            -> PhysicHashJoin  (inccost=34516287, cost=547636, rows=2, memory=8)
                 Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3]
                 Filter: p_partkey[0]=l_partkey[4]
                 -> PhysicScanTable part (inccost=200000, cost=200000, rows=1)
                     Output: p_partkey[0]
                     Filter: p_type[4]='ECONOMY ANODIZED STEEL'
-                -> PhysicHashJoin  (inccost=33768650, cost=3285797, rows=547632, memory=8)
+                -> PhysicHashJoin  (inccost=33768651, cost=3285797, rows=547632, memory=8)
                     Output: {year(o_orderdate)}[1],{l_extendedprice*1-l_discount(as volume)}[2],n_name (as nation)[3],l_partkey[4]
                     Filter: n_regionkey[5]=r_regionkey[0]
                     -> PhysicScanTable region (inccost=5, cost=5, rows=1)
                         Output: r_regionkey[0]
                         Filter: r_name[1]='AMERICA'
-                    -> PhysicHashJoin  (inccost=30482848, cost=5476376, rows=2738163, memory=1450)
+                    -> PhysicHashJoin  (inccost=30482849, cost=5476376, rows=2738163, memory=1450)
                         Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],n_name (as nation)[0],l_partkey[4],n_regionkey[5]
                         Filter: s_nationkey[6]=n_nationkey[1]
                         -> PhysicScanTable nation as n2 (inccost=25, cost=25, rows=25)
                             Output: n_name (as nation)[1],n_nationkey[0]
-                        -> PhysicHashJoin  (inccost=25006447, cost=5496324, rows=2738162, memory=160000)
+                        -> PhysicHashJoin  (inccost=25006448, cost=5496325, rows=2738163, memory=160000)
                             Output: {year(o_orderdate)}[2],{l_extendedprice*1-l_discount(as volume)}[3],l_partkey[4],n_regionkey[5],s_nationkey[0]
                             Filter: s_suppkey[1]=l_suppkey[6]
                             -> PhysicScanTable supplier (inccost=10000, cost=10000, rows=10000)


### PR DESCRIPTION
Expressions in the same group logically shall have the same cardinality. This is not guaranteed however if we compute CE for both AxBxC and AxCxB - because the join CE formula does guarantee association. To fix this, we compute the first expression in the group and set all others to this value. This is not perfect though, as the order of expression in the group actually decides the cardinality.