### PR TITLE
modify gather for loop and enable some tpch dist test

### DIFF
--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -405,8 +405,7 @@ namespace qpmodel.unittest
             string expect_dir_fn = $"../../../../test/regress/expect/tpch{scale}_d";
             
             ExplainOption.show_tablename_ = false;
-            var badQueries = new string[] { "q02", "q04", "q07", "q08", "q09", "q13", "q14", "q15", "q17",
-                                            "q18", "q20", "q21", "q22" };
+            var badQueries = new string[] { "q07", "q08", "q09", "q13", "q15", "q18", "q20", "q22" };
 
             try
             {

--- a/test/regress/expect/tpch0001_d/q02.txt
+++ b/test/regress/expect/tpch0001_d/q02.txt
@@ -1,0 +1,116 @@
+select
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+from
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+where
+	p_partkey = ps_partkey
+	and s_suppkey = ps_suppkey
+	and p_size = 15
+	and p_type like '%BRASS'
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'EUROPE'
+	and ps_supplycost = (
+		select
+			min(ps_supplycost)
+		from
+			partsupp,
+			supplier,
+			nation,
+			region
+		where
+			p_partkey = ps_partkey
+			and s_suppkey = ps_suppkey
+			and s_nationkey = n_nationkey
+			and n_regionkey = r_regionkey
+			and r_name = 'EUROPE'
+	)
+order by
+	s_acctbal desc,
+	n_name,
+	s_name,
+	p_partkey
+limit 100
+Total cost: 11642.58, memory=10674
+PhysicLimit (100) (inccost=11642.58, cost=100, rows=100) (actual rows=0)
+    Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
+    -> PhysicOrder  (inccost=11542.58, cost=1.58, rows=2, memory=486) (actual rows=0)
+        Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
+        Order by: s_acctbal[0], n_name[2], s_name[1], p_partkey[3]
+        -> PhysicFilter  (inccost=11541, cost=2, rows=2) (actual rows=0)
+            Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
+            Filter: ps_supplycost[8]={min(ps_supplycost)}[9]
+            -> PhysicHashJoin Left (inccost=11539, cost=206, rows=2, memory=1004) (actual rows=0)
+                Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
+                Filter: p_partkey[3]=ps_partkey[10]
+                -> PhysicGather 1 : 10 (inccost=4416, cost=20, rows=2) (actual rows=0)
+                    Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
+                    -> PhysicHashJoin  (inccost=4396, cost=448, rows=2, memory=58) (actual rows=0)
+                        Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
+                        Filter: p_partkey[0]=ps_partkey[9]
+                        -> PhysicBroadcast  (inccost=202, cost=2, rows=1) (actual rows=0)
+                            Output: p_partkey[0],p_mfgr[2]
+                            -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                                Output: p_partkey[0],p_mfgr[2]
+                                Filter: p_size[5]=15 and p_type[4]like'%BRASS'
+                        -> PhysicHashJoin  (inccost=3746, cost=1254, rows=444, memory=290) (actual rows=0)
+                            Output: s_acctbal[2],s_name[3],n_name[0],s_address[4],s_phone[5],s_comment[6],ps_supplycost[7],ps_partkey[8]
+                            Filter: s_nationkey[9]=n_nationkey[1]
+                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=0)
+                                Output: n_name[1],n_nationkey[2]
+                                Filter: n_regionkey[3]=r_regionkey[0]
+                                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=0)
+                                    Output: r_regionkey[0]
+                                    Filter: r_name[1]='EUROPE'
+                                -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
+                                    Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                            -> PhysicHashJoin  (inccost=2430, cost=1620, rows=800, memory=3940) (actual rows=0)
+                                Output: s_acctbal[0],s_name[1],s_address[2],s_phone[3],s_comment[4],ps_supplycost[7],ps_partkey[8],s_nationkey[5]
+                                Filter: s_suppkey[6]=ps_suppkey[9]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                    Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
+                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                                    Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
+
+Emulated 10 machines distributed run with 20 threads
+                -> PhysicHashAgg  (inccost=6917, cost=800, rows=200, memory=4800) (actual rows=0)
+                    Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
+                    Aggregates: min(ps_supplycost[1])
+                    Group by: ps_partkey[0]
+                    -> PhysicGather 1 : 10 (inccost=6117, cost=4000, rows=400) (actual rows=0)
+                        Output: ps_partkey[1],ps_supplycost[2]
+                        -> PhysicHashJoin  (inccost=2117, cost=1210, rows=400, memory=40) (actual rows=0)
+                            Output: ps_partkey[1],ps_supplycost[2]
+                            Filter: s_suppkey[0]=ps_suppkey[3]
+                            -> PhysicRedistribute  (inccost=107, cost=10, rows=5) (actual rows=0)
+                                Output: s_suppkey[0]
+                                -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=40) (actual rows=0)
+                                    Output: s_suppkey[1]
+                                    Filter: s_nationkey[2]=n_nationkey[0]
+                                    -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=0)
+                                        Output: n_nationkey[1]
+                                        Filter: n_regionkey[2]=r_regionkey[0]
+                                        -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=0)
+                                            Output: r_regionkey[0]
+                                            Filter: r_name[1]='EUROPE'
+                                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=0)
+                                            Output: n_nationkey[0],n_regionkey[2]
+                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=0)
+                                        Output: s_suppkey[0],s_nationkey[3]
+                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                                Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
+
+Emulated 10 machines distributed run with 20 threads
+
+

--- a/test/regress/expect/tpch0001_d/q04.txt
+++ b/test/regress/expect/tpch0001_d/q04.txt
@@ -1,0 +1,55 @@
+select
+	o_orderpriority,
+	count(*) as order_count
+from
+	orders
+where
+	o_orderdate >= date '1993-07-01'
+	and o_orderdate < date '1993-07-01' + interval '3' month
+	and exists (
+		select
+			*
+		from
+			lineitem
+		where
+			l_orderkey = o_orderkey
+			and l_commitdate < l_receiptdate
+	)
+group by
+	o_orderpriority
+order by
+	o_orderpriority
+Total cost: 374746.54, memory=285
+PhysicOrder  (inccost=374746.54, cost=8.54, rows=5, memory=95) (actual rows=5)
+    Output: o_orderpriority[0],{count(*)(0)}[1]
+    Order by: o_orderpriority[0]
+    -> PhysicHashAgg  (inccost=374738, cost=214, rows=5, memory=190) (actual rows=5)
+        Output: {o_orderpriority}[0],{count(*)(0)}[1]
+        Aggregates: count(*)(0)
+        Group by: o_orderpriority[0]
+        -> PhysicFilter  (inccost=374524, cost=204, rows=204) (actual rows=44)
+            Output: o_orderpriority[1]
+            Filter: {#marker}[0]
+            -> PhysicMarkJoin Left (inccost=374320, cost=306255, rows=204) (actual rows=48)
+                Output: #marker,o_orderpriority[0]
+                Filter: l_orderkey[2]=o_orderkey[1]
+                -> PhysicGather 1 : 10 (inccost=2010, cost=510, rows=51) (actual rows=48)
+                    Output: o_orderpriority[5],o_orderkey[0]
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=51) (actual rows=0)
+                        Output: o_orderpriority[5],o_orderkey[0]
+                        Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'
+
+Emulated 10 machines distributed run with 10 threads
+                -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=3752, loops=48)
+                    Output: l_orderkey[0]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l_orderkey[0]
+                        Filter: l_commitdate[11]<l_receiptdate[12]
+
+Emulated 10 machines distributed run with 10 threads
+1-URGENT,9
+2-HIGH,7
+3-MEDIUM,9
+4-NOT SPECIFIED,7
+5-LOW,12
+

--- a/test/regress/expect/tpch0001_d/q14.txt
+++ b/test/regress/expect/tpch0001_d/q14.txt
@@ -1,0 +1,33 @@
+select
+	100.00 * sum(case
+		when p_type like 'PROMO%'
+			then l_extendedprice * (1 - l_discount)
+		else 0
+	end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+	lineitem,
+	part
+where
+	l_partkey = p_partkey
+	and l_shipdate >= date '1995-09-01'
+	and l_shipdate < date '1995-09-01' + interval '1' month
+Total cost: 7719, memory=8544
+PhysicHashAgg  (inccost=7719, cost=84, rows=1, memory=16) (actual rows=1)
+    Output: 100*{sum(case with 1)}[0]/{sum(l_extendedprice*1-l_discount)}[1](as promo_revenue)
+    Aggregates: sum(case with 1), sum(l_extendedprice[5]*1-l_discount[8])
+    -> PhysicGather 1 : 10 (inccost=7635, cost=820, rows=82) (actual rows=84)
+        Output: case with 1,{p_typelike'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*1-l_discount}[3],l_extendedprice[0],{1-l_discount}[4],1,l_discount[1],0
+        -> PhysicHashJoin  (inccost=6815, cost=446, rows=82, memory=8528) (actual rows=0)
+            Output: case with 1,{p_typelike'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*1-l_discount}[3],l_extendedprice[0],{1-l_discount}[4],1,l_discount[1],0
+            Filter: l_partkey[7]=p_partkey[10]
+            -> PhysicRedistribute  (inccost=6169, cost=164, rows=82) (actual rows=0)
+                Output: l_extendedprice[0],l_discount[1],{'PROMO%'}[2],{l_extendedprice*1-l_discount}[3],{1-l_discount}[4],{1}[5],{0}[6],l_partkey[7]
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=82) (actual rows=0)
+                    Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,0,l_partkey[1]
+                    Filter: l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM'
+            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
+                Output: p_type[4],p_type[4]like'PROMO%',p_partkey[0]
+
+Emulated 10 machines distributed run with 20 threads
+15.2302
+

--- a/test/regress/expect/tpch0001_d/q17.txt
+++ b/test/regress/expect/tpch0001_d/q17.txt
@@ -1,0 +1,53 @@
+select
+	sum(l_extendedprice) / 7.0 as avg_yearly
+from
+	lineitem,
+	part
+where
+	p_partkey = l_partkey
+	and p_brand = 'Brand#23'
+	and p_container = 'MED BOX'
+	and l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p_partkey
+	)
+Total cost: 85356, memory=6024
+PhysicHashAgg  (inccost=85356, cost=32, rows=1, memory=16) (actual rows=1)
+    Output: {sum(l_extendedprice)}[0]/7(as avg_yearly)
+    Aggregates: sum(l_extendedprice[0])
+    -> PhysicFilter  (inccost=85324, cost=30, rows=30) (actual rows=0)
+        Output: l_extendedprice[0]
+        Filter: l_quantity[1]<0.2*{avg(l_quantity)}[2]
+        -> PhysicHashJoin Left (inccost=85294, cost=290, rows=30, memory=1200) (actual rows=0)
+            Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
+            Filter: l_partkey[4]=p_partkey[2]
+            -> PhysicGather 1 : 10 (inccost=12544, cost=300, rows=30) (actual rows=0)
+                Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
+                -> PhysicHashJoin  (inccost=12244, cost=6037, rows=30, memory=8) (actual rows=0)
+                    Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
+                    Filter: p_partkey[0]=l_partkey[3]
+                    -> PhysicBroadcast  (inccost=202, cost=2, rows=1) (actual rows=0)
+                        Output: p_partkey[0]
+                        -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0)
+                            Output: p_partkey[0]
+                            Filter: p_container[6]='MED BOX' and p_brand[3]='Brand#23'
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
+
+Emulated 10 machines distributed run with 20 threads
+            -> PhysicHashAgg  (inccost=72460, cost=6405, rows=200, memory=4800) (actual rows=0)
+                Output: {avg(l_quantity)}[1],{l_partkey}[0]
+                Aggregates: avg(l_quantity[1])
+                Group by: l_partkey[0]
+                -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                    Output: l_partkey[1],l_quantity[4]
+                    -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                        Output: l_partkey[1],l_quantity[4]
+
+Emulated 10 machines distributed run with 10 threads
+
+

--- a/test/regress/expect/tpch0001_d/q19.txt
+++ b/test/regress/expect/tpch0001_d/q19.txt
@@ -46,7 +46,7 @@ PhysicHashAgg  (inccost=2532407, cost=1201002, rows=1, memory=16) (actual rows=1
                 Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
 
 Emulated 10 machines distributed run with 10 threads
-        -> PhysicGather 1 : 10 (inccost=2200, cost=2000, rows=200) (actual rows=0, loops=6005)
+        -> PhysicGather 1 : 10 (inccost=2200, cost=2000, rows=200) (actual rows=200, loops=6005)
             Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
             -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
                 Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]

--- a/test/regress/expect/tpch0001_d/q21.txt
+++ b/test/regress/expect/tpch0001_d/q21.txt
@@ -1,0 +1,103 @@
+select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'SAUDI ARABIA'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+limit 100
+Total cost: 38168272.02, memory=6744
+PhysicLimit (100) (inccost=38168272.02, cost=100, rows=100) (actual rows=0)
+    Output: s_name[0],{count(*)(0)}[1]
+    -> PhysicOrder  (inccost=38168172.02, cost=24.02, rows=10, memory=290) (actual rows=0)
+        Output: s_name[0],{count(*)(0)}[1]
+        Order by: {count(*)(0)}[1], s_name[0]
+        -> PhysicHashAgg  (inccost=38168148, cost=6025, rows=10, memory=580) (actual rows=0)
+            Output: {s_name}[0],{count(*)(0)}[1]
+            Aggregates: count(*)(0)
+            Group by: s_name[0]
+            -> PhysicFilter  (inccost=38162123, cost=6005, rows=6005) (actual rows=0)
+                Output: s_name[1]
+                Filter: {#marker}[0]
+                -> PhysicMarkJoin Left (inccost=38156118, cost=36060025, rows=6005) (actual rows=0)
+                    Output: #marker,s_name[0]
+                    Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
+                    -> PhysicFilter  (inccost=2030038, cost=6005, rows=6005) (actual rows=0)
+                        Output: s_name[1],l_orderkey[2],l_suppkey[3]
+                        Filter: {#marker}[0]
+                        -> PhysicMarkJoin Left (inccost=2024033, cost=1933610, rows=6005) (actual rows=0)
+                            Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
+                            Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
+                            -> PhysicGather 1 : 10 (inccost=24368, cost=3220, rows=322) (actual rows=0)
+                                Output: s_name[0],l_orderkey[2],l_suppkey[3]
+                                -> PhysicHashJoin  (inccost=21148, cost=3230, rows=322, memory=58) (actual rows=0)
+                                    Output: s_name[0],l_orderkey[2],l_suppkey[3]
+                                    Filter: s_suppkey[1]=l_suppkey[3]
+                                    -> PhysicBroadcast  (inccost=50, cost=2, rows=1) (actual rows=0)
+                                        Output: s_name[1],s_suppkey[2]
+                                        -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0)
+                                            Output: s_name[1],s_suppkey[2]
+                                            Filter: s_nationkey[3]=n_nationkey[0]
+                                            -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=0)
+                                                Output: n_nationkey[0]
+                                                Filter: n_name[1]='SAUDI ARABIA'
+                                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                                Output: s_name[1],s_suppkey[0],s_nationkey[3]
+                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906, memory=5808) (actual rows=0)
+                                        Output: l_orderkey[1],l_suppkey[2]
+                                        Filter: o_orderkey[0]=l_orderkey[1]
+                                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=0)
+                                            Output: o_orderkey[0]
+                                            Filter: o_orderstatus[2]='F'
+                                        -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                            Output: l_orderkey[0],l_suppkey[2]
+                                            Filter: l_receiptdate[12]>l_commitdate[11]
+
+Emulated 10 machines distributed run with 20 threads
+                            -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                                Output: l_orderkey[0],l_suppkey[2]
+                                -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                    Output: l_orderkey[0],l_suppkey[2]
+                                    Filter: l_receiptdate[12]>l_commitdate[11]
+
+Emulated 10 machines distributed run with 10 threads
+                    -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                        Output: l_orderkey[0],l_suppkey[2]
+                        -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                            Output: l_orderkey[0],l_suppkey[2]
+
+Emulated 10 machines distributed run with 10 threads
+
+


### PR DESCRIPTION
Previously, gather can only be run once, leaving the execution in another loop to return empty. This may happen for nested loops like NLJoin and MarkJoin. Now the results are cached to make sure every run returns the same result. This modification does slow down the execution but it can ensure correct and consistent outputs. After this fix distributed tpch q04 can be run.

Some other tpch tests are able to run after the distribution property change.