### PR TITLE
move threads count emulation information to stay with logic GATHER

### DIFF
--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -1277,7 +1277,19 @@ namespace qpmodel.logic
         }
         public override string ToString() => $"Gather({child_()})";
 
-        public override string ExplainInlineDetails() => $"1 : {producerIds_.Count}";
+        int countAllParallelFragments()
+        {
+            int nthreads = QueryOption.num_machines_;
+            int nshuffle = 0;
+            VisitEach(x =>
+            {
+                if (x is LogicRedistribute || x is LogicBroadcast)
+                    nshuffle++;
+            });
+            return nthreads * (1 + nshuffle);
+        }
+
+        public override string ExplainInlineDetails() => $"Threads: {countAllParallelFragments()}";
     }
 
     public class LogicBroadcast : LogicRemoteExchange

--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -235,19 +235,6 @@ namespace qpmodel.logic
                     children_.ForEach(x => r += x.Explain(option, depth));
             }
 
-            // details of distributed query emulation
-            if (this is PhysicGather)
-            {
-                int nthreads = QueryOption.num_machines_;
-                int nshuffle = 0;
-                VisitEach(x =>
-                {
-                    if (x is PhysicRedistribute || x is PhysicBroadcast)
-                        nshuffle++;
-                });
-                r += $"\nEmulated {QueryOption.num_machines_} machines distributed run " +
-                     $"with {nthreads * (1 + nshuffle)} threads\n";
-            }
             return r;
         }
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2283,8 +2283,8 @@ namespace qpmodel.unittest
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
                 Assert.AreEqual(enable_bc ? 0 : 4, TU.CountStr(phyplan, "Redistribute"));
                 Assert.AreEqual(enable_bc ? 3 : 0, TU.CountStr(phyplan, "Broadcast"));
-                Assert.AreEqual(enable_bc ? 0 : 1, TU.CountStr(phyplan, "50 threads"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "40 threads"));
+                Assert.AreEqual(enable_bc ? 0 : 1, TU.CountStr(phyplan, "threads: 50"));
+                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "threads: 40"));
 
                 // ensure redistribution can shuffle by expression
                 sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";

--- a/test/regress/expect/tpch0001_d/q01.txt
+++ b/test/regress/expect/tpch0001_d/q01.txt
@@ -27,13 +27,11 @@ PhysicOrder  (inccost=71071.35, cost=11.35, rows=6, memory=372) (actual rows=4)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*1-l_discount)}[4],{sum(l_extendedprice*1-l_discount*1+l_tax)}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
         Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*1-l_discount[7]), sum(l_extendedprice[3]*1-l_discount[7]*1+l_tax[10]), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicGather 1 : 10 (inccost=65135, cost=59130, rows=5913) (actual rows=5914)
+        -> PhysicGather Threads: 10 (inccost=65135, cost=59130, rows=5913) (actual rows=5914)
             Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
             -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5913) (actual rows=0)
                 Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*1-l_discount[6],1-l_discount[6],1,l_discount[6],l_extendedprice[5]*1-l_discount[6]*1+l_tax[7],1+l_tax[7],l_tax[7]
                 Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
-
-Emulated 10 machines distributed run with 10 threads
 A,F,37474,37569624.64,35676192.097,37101416.2224,25.3545,25419.2318,0.0509,1478
 N,F,1041,1041301.07,999060.898,1036450.8023,27.3947,27402.6597,0.0429,38
 N,O,75168,75384955.37,71653166.3034,74498798.1331,25.5587,25632.4228,0.0497,2941

--- a/test/regress/expect/tpch0001_d/q02.txt
+++ b/test/regress/expect/tpch0001_d/q02.txt
@@ -54,7 +54,7 @@ PhysicLimit (100) (inccost=11642.58, cost=100, rows=100) (actual rows=0)
             -> PhysicHashJoin Left (inccost=11539, cost=206, rows=2, memory=1004) (actual rows=0)
                 Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
                 Filter: p_partkey[3]=ps_partkey[10]
-                -> PhysicGather 1 : 10 (inccost=4416, cost=20, rows=2) (actual rows=0)
+                -> PhysicGather Threads: 20 (inccost=4416, cost=20, rows=2) (actual rows=0)
                     Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
                     -> PhysicHashJoin  (inccost=4396, cost=448, rows=2, memory=58) (actual rows=0)
                         Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
@@ -82,13 +82,11 @@ PhysicLimit (100) (inccost=11642.58, cost=100, rows=100) (actual rows=0)
                                     Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
                                 -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                                     Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
-
-Emulated 10 machines distributed run with 20 threads
                 -> PhysicHashAgg  (inccost=6917, cost=800, rows=200, memory=4800) (actual rows=0)
                     Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
                     Aggregates: min(ps_supplycost[1])
                     Group by: ps_partkey[0]
-                    -> PhysicGather 1 : 10 (inccost=6117, cost=4000, rows=400) (actual rows=0)
+                    -> PhysicGather Threads: 20 (inccost=6117, cost=4000, rows=400) (actual rows=0)
                         Output: ps_partkey[1],ps_supplycost[2]
                         -> PhysicHashJoin  (inccost=2117, cost=1210, rows=400, memory=40) (actual rows=0)
                             Output: ps_partkey[1],ps_supplycost[2]
@@ -110,7 +108,5 @@ Emulated 10 machines distributed run with 20 threads
                                         Output: s_suppkey[0],s_nationkey[3]
                             -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
                                 Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
-
-Emulated 10 machines distributed run with 20 threads
 
 

--- a/test/regress/expect/tpch0001_d/q03.txt
+++ b/test/regress/expect/tpch0001_d/q03.txt
@@ -31,7 +31,7 @@ PhysicLimit (10) (inccost=24918.9, cost=10, rows=10) (actual rows=8)
             Output: {l_orderkey}[0],{sum(l_extendedprice*1-l_discount)}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*1-l_discount[7])
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicGather 1 : 10 (inccost=20683, cost=4580, rows=458) (actual rows=14)
+            -> PhysicGather Threads: 20 (inccost=20683, cost=4580, rows=458) (actual rows=14)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
                 -> PhysicHashJoin  (inccost=16103, cost=2097, rows=458, memory=464) (actual rows=0)
                     Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*1-l_discount}[5],l_extendedprice[6],{1-l_discount}[7],{1}[0],l_discount[8]
@@ -50,8 +50,6 @@ PhysicLimit (10) (inccost=24918.9, cost=10, rows=10) (actual rows=8)
                         -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3254) (actual rows=0)
                             Output: l_orderkey[0],l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6]
                             Filter: l_shipdate[10]>'1995-03-15'
-
-Emulated 10 machines distributed run with 20 threads
 1637,164224.9253,2/8/1995 12:00:00 AM,0
 5191,49378.3094,12/11/1994 12:00:00 AM,0
 742,43728.048,12/23/1994 12:00:00 AM,0

--- a/test/regress/expect/tpch0001_d/q04.txt
+++ b/test/regress/expect/tpch0001_d/q04.txt
@@ -33,20 +33,16 @@ PhysicOrder  (inccost=374746.54, cost=8.54, rows=5, memory=95) (actual rows=5)
             -> PhysicMarkJoin Left (inccost=374320, cost=306255, rows=204) (actual rows=48)
                 Output: #marker,o_orderpriority[0]
                 Filter: l_orderkey[2]=o_orderkey[1]
-                -> PhysicGather 1 : 10 (inccost=2010, cost=510, rows=51) (actual rows=48)
+                -> PhysicGather Threads: 10 (inccost=2010, cost=510, rows=51) (actual rows=48)
                     Output: o_orderpriority[5],o_orderkey[0]
                     -> PhysicScanTable orders (inccost=1500, cost=1500, rows=51) (actual rows=0)
                         Output: o_orderpriority[5],o_orderkey[0]
                         Filter: o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM'
-
-Emulated 10 machines distributed run with 10 threads
-                -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=3752, loops=48)
+                -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=3752, loops=48)
                     Output: l_orderkey[0]
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                         Output: l_orderkey[0]
                         Filter: l_commitdate[11]<l_receiptdate[12]
-
-Emulated 10 machines distributed run with 10 threads
 1-URGENT,9
 2-HIGH,7
 3-MEDIUM,9

--- a/test/regress/expect/tpch0001_d/q05.txt
+++ b/test/regress/expect/tpch0001_d/q05.txt
@@ -30,7 +30,7 @@ PhysicOrder  (inccost=18755.97, cost=82.97, rows=25, memory=825) (actual rows=0)
         Output: {n_name}[0],{sum(l_extendedprice*1-l_discount)}[1]
         Aggregates: sum(l_extendedprice[2]*1-l_discount[5])
         Group by: n_name[0]
-        -> PhysicGather 1 : 10 (inccost=18540, cost=830, rows=83) (actual rows=0)
+        -> PhysicGather Threads: 30 (inccost=18540, cost=830, rows=83) (actual rows=0)
             Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
             -> PhysicHashJoin  (inccost=17710, cost=883, rows=83, memory=3600) (actual rows=0)
                 Output: n_name[3],{l_extendedprice*1-l_discount}[4],l_extendedprice[5],{1-l_discount}[6],{1}[0],l_discount[7]
@@ -65,7 +65,5 @@ PhysicOrder  (inccost=18755.97, cost=82.97, rows=25, memory=825) (actual rows=0)
                             Filter: o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM'
                         -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                             Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],l_discount[6],l_suppkey[2],l_orderkey[0]
-
-Emulated 10 machines distributed run with 30 threads
 
 

--- a/test/regress/expect/tpch0001_d/q06.txt
+++ b/test/regress/expect/tpch0001_d/q06.txt
@@ -11,12 +11,10 @@ Total cost: 6887, memory=16
 PhysicHashAgg  (inccost=6887, cost=82, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice*l_discount)}[0]
     Aggregates: sum(l_extendedprice[1]*l_discount[2])
-    -> PhysicGather 1 : 10 (inccost=6805, cost=800, rows=80) (actual rows=74)
+    -> PhysicGather Threads: 10 (inccost=6805, cost=800, rows=80) (actual rows=74)
         Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
         -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=80) (actual rows=0)
             Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
             Filter: l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM' and l_discount[6]>=0.05 and l_discount[6]<=0.07 and l_quantity[4]<24
-
-Emulated 10 machines distributed run with 10 threads
 48090.8586
 

--- a/test/regress/expect/tpch0001_d/q10.txt
+++ b/test/regress/expect/tpch0001_d/q10.txt
@@ -40,7 +40,7 @@ PhysicLimit (20) (inccost=11634.98, cost=20, rows=20) (actual rows=20)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*1-l_discount)}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*1-l_discount[11])
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicGather 1 : 10 (inccost=10931, cost=900, rows=90) (actual rows=140)
+            -> PhysicGather Threads: 20 (inccost=10931, cost=900, rows=90) (actual rows=140)
                 Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
                 -> PhysicHashJoin  (inccost=10031, cost=230, rows=90, memory=1650) (actual rows=0)
                     Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*1-l_discount}[9],l_extendedprice[10],{1-l_discount}[11],{1}[1],l_discount[12]
@@ -63,8 +63,6 @@ PhysicLimit (20) (inccost=11634.98, cost=20, rows=20) (actual rows=20)
                                     Filter: l_returnflag[8]='R'
                         -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=0)
                             Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
-
-Emulated 10 machines distributed run with 20 threads
 121,Customer#000000121,282635.1719,6428.32,PERU,tv nCR2YKupGN73mQudO,27-411-990-2959,uriously stealthy ideas. carefully final courts use carefully
 124,Customer#000000124,222182.5188,1842.49,CHINA,aTbyVAW5tCd,v09O,28-183-750-7809,le fluffily even dependencies. quietly s
 106,Customer#000000106,190241.3334,3288.42,ARGENTINA,xGCOEAUjUNG,11-751-989-4627,lose slyly. ironic accounts along the evenly regular theodolites wake about the special, final gifts.

--- a/test/regress/expect/tpch0001_d/q11.txt
+++ b/test/regress/expect/tpch0001_d/q11.txt
@@ -38,7 +38,7 @@ PhysicOrder  (inccost=3130.56, cost=358.56, rows=80, memory=960) (actual rows=0)
             -> PhysicHashAgg  (inccost=2614, cost=82, rows=1, memory=16) (actual rows=0)
                 Output: {sum(ps_supplycost*ps_availqty)}[0]*0.0001
                 Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                -> PhysicGather 1 : 10 (inccost=2532, cost=800, rows=80) (actual rows=0)
+                -> PhysicGather Threads: 20 (inccost=2532, cost=800, rows=80) (actual rows=0)
                     Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
                     -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0)
                         Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
@@ -55,9 +55,7 @@ PhysicOrder  (inccost=3130.56, cost=358.56, rows=80, memory=960) (actual rows=0)
                                     Output: s_suppkey[0],s_nationkey[3]
                         -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
                             Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-
-Emulated 10 machines distributed run with 20 threads
-        -> PhysicGather 1 : 10 (inccost=2532, cost=800, rows=80) (actual rows=0)
+        -> PhysicGather Threads: 20 (inccost=2532, cost=800, rows=80) (actual rows=0)
             Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
             -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0)
                 Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
@@ -74,7 +72,5 @@ Emulated 10 machines distributed run with 20 threads
                             Output: s_suppkey[0],s_nationkey[3]
                 -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                     Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-
-Emulated 10 machines distributed run with 20 threads
 
 

--- a/test/regress/expect/tpch0001_d/q12.txt
+++ b/test/regress/expect/tpch0001_d/q12.txt
@@ -34,7 +34,7 @@ PhysicOrder  (inccost=12547.32, cost=14.32, rows=7, memory=126) (actual rows=2)
         Output: {l_shipmode}[0],{sum(case with 1)}[1],{sum(case with 1)}[2]
         Aggregates: sum(case with 1), sum(case with 1)
         Group by: l_shipmode[0]
-        -> PhysicGather 1 : 10 (inccost=12268, cost=2510, rows=251) (actual rows=25)
+        -> PhysicGather Threads: 10 (inccost=12268, cost=2510, rows=251) (actual rows=25)
             Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
             -> PhysicHashJoin  (inccost=9758, cost=2253, rows=251, memory=20080) (actual rows=0)
                 Output: l_shipmode[0],{case with 1}[6],{o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH'}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 1}[11],{o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH'}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
@@ -44,8 +44,6 @@ PhysicOrder  (inccost=12547.32, cost=14.32, rows=7, memory=126) (actual rows=2)
                     Filter: l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12] and l_shipdate[10]<l_commitdate[11] and l_receiptdate[12]>='1994-01-01' and l_receiptdate[12]<'1/1/1995 12:00:00 AM'
                 -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0)
                     Output: case with 1,o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH',o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 1,o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH',o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
-
-Emulated 10 machines distributed run with 10 threads
 MAIL,5,5
 SHIP,5,10
 

--- a/test/regress/expect/tpch0001_d/q14.txt
+++ b/test/regress/expect/tpch0001_d/q14.txt
@@ -15,7 +15,7 @@ Total cost: 7719, memory=8544
 PhysicHashAgg  (inccost=7719, cost=84, rows=1, memory=16) (actual rows=1)
     Output: 100*{sum(case with 1)}[0]/{sum(l_extendedprice*1-l_discount)}[1](as promo_revenue)
     Aggregates: sum(case with 1), sum(l_extendedprice[5]*1-l_discount[8])
-    -> PhysicGather 1 : 10 (inccost=7635, cost=820, rows=82) (actual rows=84)
+    -> PhysicGather Threads: 20 (inccost=7635, cost=820, rows=82) (actual rows=84)
         Output: case with 1,{p_typelike'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*1-l_discount}[3],l_extendedprice[0],{1-l_discount}[4],1,l_discount[1],0
         -> PhysicHashJoin  (inccost=6815, cost=446, rows=82, memory=8528) (actual rows=0)
             Output: case with 1,{p_typelike'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*1-l_discount}[3],l_extendedprice[0],{1-l_discount}[4],1,l_discount[1],0
@@ -27,7 +27,5 @@ PhysicHashAgg  (inccost=7719, cost=84, rows=1, memory=16) (actual rows=1)
                     Filter: l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM'
             -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
                 Output: p_type[4],p_type[4]like'PROMO%',p_partkey[0]
-
-Emulated 10 machines distributed run with 20 threads
 15.2302
 

--- a/test/regress/expect/tpch0001_d/q16.txt
+++ b/test/regress/expect/tpch0001_d/q16.txt
@@ -36,7 +36,7 @@ PhysicOrder  (inccost=4774.38, cost=754.38, rows=148, memory=6364) (actual rows=
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicGather 1 : 10 (inccost=3576, cost=1480, rows=148) (actual rows=0)
+        -> PhysicGather Threads: 20 (inccost=3576, cost=1480, rows=148) (actual rows=0)
             Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
             -> PhysicHashJoin  (inccost=2096, cost=1022, rows=148, memory=3182) (actual rows=0)
                 Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
@@ -50,14 +50,10 @@ PhysicOrder  (inccost=4774.38, cost=754.38, rows=148, memory=6364) (actual rows=
                     Output: ps_suppkey[1],ps_partkey[0]
                     Filter: ps_suppkey[1] in @1
                     <InSubqueryExpr> cached 1
-                        -> PhysicGather 1 : 10 (inccost=20, cost=10, rows=1) (actual rows=0)
+                        -> PhysicGather Threads: 10 (inccost=20, cost=10, rows=1) (actual rows=0)
                             Output: s_suppkey[0]
                             -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
                                 Output: s_suppkey[0]
                                 Filter: s_comment[6]like'%Customer%Complaints%'
-
-Emulated 10 machines distributed run with 10 threads
-
-Emulated 10 machines distributed run with 20 threads
 
 

--- a/test/regress/expect/tpch0001_d/q17.txt
+++ b/test/regress/expect/tpch0001_d/q17.txt
@@ -25,7 +25,7 @@ PhysicHashAgg  (inccost=85356, cost=32, rows=1, memory=16) (actual rows=1)
         -> PhysicHashJoin Left (inccost=85294, cost=290, rows=30, memory=1200) (actual rows=0)
             Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
             Filter: l_partkey[4]=p_partkey[2]
-            -> PhysicGather 1 : 10 (inccost=12544, cost=300, rows=30) (actual rows=0)
+            -> PhysicGather Threads: 20 (inccost=12544, cost=300, rows=30) (actual rows=0)
                 Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
                 -> PhysicHashJoin  (inccost=12244, cost=6037, rows=30, memory=8) (actual rows=0)
                     Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
@@ -37,17 +37,13 @@ PhysicHashAgg  (inccost=85356, cost=32, rows=1, memory=16) (actual rows=1)
                             Filter: p_container[6]='MED BOX' and p_brand[3]='Brand#23'
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                         Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
-
-Emulated 10 machines distributed run with 20 threads
             -> PhysicHashAgg  (inccost=72460, cost=6405, rows=200, memory=4800) (actual rows=0)
                 Output: {avg(l_quantity)}[1],{l_partkey}[0]
                 Aggregates: avg(l_quantity[1])
                 Group by: l_partkey[0]
-                -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
                     Output: l_partkey[1],l_quantity[4]
                     -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                         Output: l_partkey[1],l_quantity[4]
-
-Emulated 10 machines distributed run with 10 threads
 
 

--- a/test/regress/expect/tpch0001_d/q19.txt
+++ b/test/regress/expect/tpch0001_d/q19.txt
@@ -40,17 +40,13 @@ PhysicHashAgg  (inccost=2532407, cost=1201002, rows=1, memory=16) (actual rows=1
     -> PhysicNLJoin  (inccost=1331405, cost=1263150, rows=1201000) (actual rows=0)
         Output: {l_extendedprice*1-l_discount}[0],l_extendedprice[1],{1-l_discount}[2],{1}[3],l_discount[4]
         Filter: p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12' and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG') and l_quantity[6]>=1 and l_quantity[6]<=11 and p_size[12]>=1 and p_size[12]<=5 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23' and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK') and l_quantity[6]>=10 and l_quantity[6]<=20 and p_size[12]>=1 and p_size[12]<=10 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON' or p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34' and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG') and l_quantity[6]>=20 and l_quantity[6]<=30 and p_size[12]>=1 and p_size[12]<=15 and l_shipmode[7] in ('AIR','AIR REG') and l_shipinstruct[8]='DELIVER IN PERSON'
-        -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=6005)
+        -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=6005)
             Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
             -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                 Output: l_extendedprice[5]*1-l_discount[6],l_extendedprice[5],1-l_discount[6],1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
-
-Emulated 10 machines distributed run with 10 threads
-        -> PhysicGather 1 : 10 (inccost=2200, cost=2000, rows=200) (actual rows=200, loops=6005)
+        -> PhysicGather Threads: 10 (inccost=2200, cost=2000, rows=200) (actual rows=200, loops=6005)
             Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
             -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=0)
                 Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
-
-Emulated 10 machines distributed run with 10 threads
 
 

--- a/test/regress/expect/tpch0001_d/q21.txt
+++ b/test/regress/expect/tpch0001_d/q21.txt
@@ -60,7 +60,7 @@ PhysicLimit (100) (inccost=38168272.02, cost=100, rows=100) (actual rows=0)
                         -> PhysicMarkJoin Left (inccost=2024033, cost=1933610, rows=6005) (actual rows=0)
                             Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
                             Filter: l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2]
-                            -> PhysicGather 1 : 10 (inccost=24368, cost=3220, rows=322) (actual rows=0)
+                            -> PhysicGather Threads: 20 (inccost=24368, cost=3220, rows=322) (actual rows=0)
                                 Output: s_name[0],l_orderkey[2],l_suppkey[3]
                                 -> PhysicHashJoin  (inccost=21148, cost=3230, rows=322, memory=58) (actual rows=0)
                                     Output: s_name[0],l_orderkey[2],l_suppkey[3]
@@ -84,20 +84,14 @@ PhysicLimit (100) (inccost=38168272.02, cost=100, rows=100) (actual rows=0)
                                         -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                                             Output: l_orderkey[0],l_suppkey[2]
                                             Filter: l_receiptdate[12]>l_commitdate[11]
-
-Emulated 10 machines distributed run with 20 threads
-                            -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                            -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
                                 Output: l_orderkey[0],l_suppkey[2]
                                 -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                                     Output: l_orderkey[0],l_suppkey[2]
                                     Filter: l_receiptdate[12]>l_commitdate[11]
-
-Emulated 10 machines distributed run with 10 threads
-                    -> PhysicGather 1 : 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                    -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
                         Output: l_orderkey[0],l_suppkey[2]
                         -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                             Output: l_orderkey[0],l_suppkey[2]
-
-Emulated 10 machines distributed run with 10 threads
 
 


### PR DESCRIPTION
Current output scattered the plan, now we move the information stay with logic GATHER.