### PR TITLE
[bug] parser silently truncate unrecognized part #200

### DIFF
--- a/qpmodel/SQLParser.cs
+++ b/qpmodel/SQLParser.cs
@@ -672,6 +672,8 @@ namespace qpmodel.sqlparser
 
         public override object VisitParse([NotNull] SQLiteParser.ParseContext context)
         {
+            if (context.sql_stmt_list().Length == 0)
+                throw new AntlrParserException("empty SQL statements.");
             return Visit(context.sql_stmt_list(0)) as StatementList;
         }
     }

--- a/qpmodel/SQLite.g4
+++ b/qpmodel/SQLite.g4
@@ -282,7 +282,7 @@ join_clause
  ;
 
 join_operator
-: K_NATURAL? ( K_LEFT K_OUTER? | K_RIGHT K_OUTER? | K_FULL K_OUTER? | K_INNER | K_CROSS )? K_JOIN
+ : K_NATURAL? ( K_LEFT K_OUTER? | K_RIGHT K_OUTER? | K_FULL K_OUTER? | K_INNER | K_CROSS )? K_JOIN
  ;
 
 join_constraint

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -3012,9 +3012,7 @@ namespace qpmodel.unittest
         [ExpectedException(typeof(AntlrParserException))]
         public void TestParseError()
         {
-            string sql = null;
-
-            sql = "this is not a SQL statements.";
+            string sql = "this is not a SQL statements.";
             RawParser.ParseSqlStatements(sql);
         }
 
@@ -3022,9 +3020,7 @@ namespace qpmodel.unittest
         [ExpectedException(typeof(AntlrParserException))]
         public void TestOuterError()
         {
-            string sql = null;
-
-            sql = "select * from a outer join b on(a1 <> b1) where 100 > null;";
+            string sql = "select * from a outer join b on(a1 <> b1) where 100 > null;";
             RawParser.ParseSqlStatements(sql);
         }
 
@@ -3032,9 +3028,15 @@ namespace qpmodel.unittest
         [ExpectedException(typeof(AntlrParserException))]
         public void TestInnerError()
         {
-            string sql = null;
+            string sql = "select * from a left inner join b on(a1 <> b1) where 100 > null;";
+            RawParser.ParseSqlStatements(sql);
+        }
 
-            sql = "select * from a left inner join b on(a1 <> b1) where 100 > null;";
+        [TestMethod]
+        [ExpectedException(typeof(AntlrParserException))]
+        public void TestEmptyError()
+        {
+            string sql = "";
             RawParser.ParseSqlStatements(sql);
         }
     }

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -3039,5 +3039,13 @@ namespace qpmodel.unittest
             string sql = "";
             RawParser.ParseSqlStatements(sql);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(AntlrParserException))]
+        public void TestParenthesisError()
+        {
+            string sql = "select * from a inner join b on(a1 <> b1 where 100 > null;";
+            RawParser.ParseSqlStatements(sql);
+        }
     }
 }

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -3004,4 +3004,38 @@ namespace qpmodel.unittest
             Assert.IsNull(hist);
         }
     }
+
+    [TestClass]
+    public class SyntaxError
+    {
+        [TestMethod]
+        [ExpectedException(typeof(AntlrParserException))]
+        public void TestParseError()
+        {
+            string sql = null;
+
+            sql = "this is not a SQL statements.";
+            RawParser.ParseSqlStatements(sql);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(AntlrParserException))]
+        public void TestOuterError()
+        {
+            string sql = null;
+
+            sql = "select * from a outer join b on(a1 <> b1) where 100 > null;";
+            RawParser.ParseSqlStatements(sql);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(AntlrParserException))]
+        public void TestInnerError()
+        {
+            string sql = null;
+
+            sql = "select * from a left inner join b on(a1 <> b1) where 100 > null;";
+            RawParser.ParseSqlStatements(sql);
+        }
+    }
 }

--- a/tpcds/q82.sql
+++ b/tpcds/q82.sql
@@ -6,7 +6,7 @@ select  i_item_id
  where i_current_price between 58  and 58+30
  and inv_item_sk = i_item_sk
  and d_date_sk=inv_date_sk
- and d_date between (cast ('2001-01-13' as date)  and (cast('2001-01-13' as date) +  60 days)
+ and d_date between (cast ('2001-01-13' as date)) and (cast('2001-01-13' as date) +  60 days)
  and i_manufact_id in (259,559,580,485)
  and inv_quantity_on_hand between 100  and 500
  and ss_item_sk = i_item_sk


### PR DESCRIPTION
add @SyntaxErrorListener to @SQLiteParser to catch error from syntax tree.
add unit test for syntax error.
fix syntax error of q82.sql.