### PR TITLE
Add exploration rule for global aggregate split

### DIFF
--- a/qpmodel/Expr.cs
+++ b/qpmodel/Expr.cs
@@ -694,6 +694,12 @@ namespace qpmodel.expr
             return object.Equals(_, n._) && tableRefs_.SequenceEqual(n.tableRefs_) &&
                 children_.SequenceEqual(n.children_);
         }
+        public bool IDEquals(object obj)
+        {
+            if (!(obj is Expr))
+                return false;
+            return object.Equals(_, (obj as Expr)._);
+        }
 
         public List<TableRef> ResetAggregateTableRefs()
         {

--- a/qpmodel/Expr.cs
+++ b/qpmodel/Expr.cs
@@ -727,6 +727,11 @@ namespace qpmodel.expr
             // register the expression in the search table
             ExprSearch.table_.Add(_, this);
         }
+        internal void dummyBind()
+        {
+            markBounded();
+            type_ = new BoolType();
+        }
 
         public virtual void Bind(BindContext context)
         {

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1119,8 +1119,6 @@ namespace qpmodel.physic
 
         protected override double EstimateCost()
         {
-            //if (logic_.isDerived_)
-            //    return 0.1;
             return (child_().Card() * 1.0) + (logic_.Card() * 2.0);
         }
 

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -1119,6 +1119,8 @@ namespace qpmodel.physic
 
         protected override double EstimateCost()
         {
+            //if (logic_.isDerived_)
+            //    return 0.1;
             return (child_().Card() * 1.0) + (logic_.Card() * 2.0);
         }
 
@@ -1130,6 +1132,15 @@ namespace qpmodel.physic
             {
                 listChildReqs.Add(new ChildrenRequirement { DistrProperty.Singleton_ });
                 return true;
+            }
+            // is the aggregation is local, it can be for any distribution
+            if (DistrProperty.AnyDistributed_.IsSuppliedBy(required))
+            {
+                if ((logic_ as LogicAgg).is_local_)
+                {
+                    listChildReqs.Add(new ChildrenRequirement { required });
+                    return true;
+                }
             }
             listChildReqs = null;
             return false;
@@ -1149,7 +1160,8 @@ namespace qpmodel.physic
         {
             ExecContext context = context_;
             var logic = logic_ as LogicAgg;
-            var aggrcore = logic.aggrFns_;
+            List<AggFunc> aggrcore = new List<AggFunc>();
+            logic.aggrFns_.ForEach(x => aggrcore.Add(x.Clone() as AggFunc));
             var hm = new Dictionary<KeyList, Row>();
 
             // aggregation is working on aggCore targets

--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -201,13 +201,13 @@ namespace qpmodel
                 goto doit;
             }
 
-            if (false)
+            if (true)
             {
-                Tpch.CreateTables();
+                Tpch.CreateTables(true);
                 Tpch.LoadTables("0001");
                 //Tpch.CreateIndexes();
                 Tpch.AnalyzeTables();
-                sql = File.ReadAllText("../../../../tpch/q20.sql");
+                sql = File.ReadAllText("../../../../tpch/q10.sql");
                 goto doit;
             }
 

--- a/qpmodel/Program.cs
+++ b/qpmodel/Program.cs
@@ -201,13 +201,13 @@ namespace qpmodel
                 goto doit;
             }
 
-            if (true)
+            if (false)
             {
-                Tpch.CreateTables(true);
+                Tpch.CreateTables();
                 Tpch.LoadTables("0001");
                 //Tpch.CreateIndexes();
                 Tpch.AnalyzeTables();
-                sql = File.ReadAllText("../../../../tpch/q10.sql");
+                sql = File.ReadAllText("../../../../tpch/q20.sql");
                 goto doit;
             }
 

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -85,7 +85,8 @@ namespace qpmodel.optimizer
             switch (distribution_.disttype)
             {
                 case DistrType.AnyDistributed:
-                    return testeeType == DistrType.Distributed;
+                    return testeeType == DistrType.Distributed
+                        || testeeType == DistrType.AnyDistributed;
                 case DistrType.Singleton:
                     return testeeType == DistrType.Singleton;
                 // distribution expr list must match to be considered supplied

--- a/qpmodel/subquery.cs
+++ b/qpmodel/subquery.cs
@@ -60,8 +60,7 @@ namespace qpmodel.logic
         public MarkerExpr()
         {
             Debug.Assert(Equals(Clone()));
-            type_ = new BoolType();
-            markBounded();
+            dummyBind();
         }
 
         public override Value Exec(ExecContext context, Row input)

--- a/test/regress/expect/tpch0001_d/q01.txt
+++ b/test/regress/expect/tpch0001_d/q01.txt
@@ -19,19 +19,23 @@ group by
 order by
 	l_returnflag,
 	l_linestatus
-Total cost: 71071.35, memory=1116
-PhysicOrder  (inccost=71071.35, cost=11.35, rows=6, memory=372) (actual rows=4)
+Total cost: 12019.35, memory=996
+PhysicOrder  (inccost=12019.35, cost=11.35, rows=6, memory=372) (actual rows=4)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=71060, cost=5925, rows=6, memory=744) (actual rows=4)
-        Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
-        Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*(1-l_discount[7])), sum(l_extendedprice[3]*(1-l_discount[7])*(l_tax[10]+1)), avg(l_quantity[2]), avg(l_extendedprice[3]), avg(l_discount[7]), count(*)(0)
+    -> PhysicHashAgg  (inccost=12008, cost=18, rows=6, memory=120) (actual rows=4)
+        Output: {l_returnflag}[0],{l_linestatus}[1],{sum({sum(l_quantity)})}[2],{sum({sum(l_extendedprice)})}[3],{sum({sum(l_extendedprice*(1-l_discount))})}[4],{sum({sum(l_extendedprice*(1-l_discount)*(l_tax+1))})}[5],{sum({sum(l_quantity)})}[2]/{sum({count(l_quantity)})}[6],{sum({sum(l_extendedprice)})}[3]/{sum({count(l_extendedprice)})}[7],{sum({sum(l_discount)})}[8]/{sum({count(l_discount)})}[9],{sum({count(*)(0)})}[10]
+        Aggregates: sum({sum(l_quantity)}[2]), sum({sum(l_extendedprice)}[3]), sum({sum(l_extendedprice*(1-l_discount))}[4]), sum({sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5]), sum({count(l_quantity)}[6]), sum({count(l_extendedprice)}[7]), sum({sum(l_discount)}[8]), sum({count(l_discount)}[9]), sum({count(*)(0)}[10])
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicGather Threads: 10 (inccost=65135, cost=59130, rows=5913) (actual rows=5914)
-            Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,l_discount[6],l_extendedprice[5]*(1-l_discount[6])*(l_tax[7]+1),(l_tax[7]+1),l_tax[7]
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5913) (actual rows=591, loops=10)
-                Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,l_discount[6],l_extendedprice[5]*(1-l_discount[6])*(l_tax[7]+1),(l_tax[7]+1),l_tax[7]
-                Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
+        -> PhysicGather Threads: 10 (inccost=11990, cost=60, rows=6) (actual rows=39)
+            Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{count(l_quantity)}[6],{count(l_extendedprice)}[7],{sum(l_discount)}[8],{count(l_discount)}[9],{count(*)(0)}[10]
+            -> PhysicHashAgg  (inccost=11930, cost=5925, rows=6, memory=504) (actual rows=3, loops=10)
+                Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{count(l_quantity)}[6],{count(l_extendedprice)}[7],{sum(l_discount)}[8],{count(l_discount)}[9],{count(*)(0)}[10]
+                Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*(1-l_discount[7])), sum(l_extendedprice[3]*(1-l_discount[7])*(l_tax[10]+1)), count(l_quantity[2]), count(l_extendedprice[3]), sum(l_discount[7]), count(l_discount[7]), count(*)(0)
+                Group by: l_returnflag[0], l_linestatus[1]
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5913) (actual rows=591, loops=10)
+                    Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,l_discount[6],l_extendedprice[5]*(1-l_discount[6])*(l_tax[7]+1),(l_tax[7]+1),l_tax[7]
+                    Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
 A,F,37474,37569624.64,35676192.097,37101416.2224,25.3545,25419.2318,0.0509,1478
 N,F,1041,1041301.07,999060.898,1036450.8023,27.3947,27402.6597,0.0429,38
 N,O,75168,75384955.37,71653166.3034,74498798.1331,25.5587,25632.4228,0.0497,2941

--- a/test/regress/expect/tpch0001_d/q02.txt
+++ b/test/regress/expect/tpch0001_d/q02.txt
@@ -42,16 +42,16 @@ order by
 	s_name,
 	p_partkey
 limit 100
-Total cost: 11642.58, memory=10674
-PhysicLimit (100) (inccost=11642.58, cost=100, rows=100) (actual rows=0)
+Total cost: 10242.58, memory=12674
+PhysicLimit (100) (inccost=10242.58, cost=100, rows=100) (actual rows=0)
     Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
-    -> PhysicOrder  (inccost=11542.58, cost=1.58, rows=2, memory=486) (actual rows=0)
+    -> PhysicOrder  (inccost=10142.58, cost=1.58, rows=2, memory=486) (actual rows=0)
         Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
         Order by: s_acctbal[0], n_name[2], s_name[1], p_partkey[3]
-        -> PhysicFilter  (inccost=11541, cost=2, rows=2) (actual rows=0)
+        -> PhysicFilter  (inccost=10141, cost=2, rows=2) (actual rows=0)
             Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
             Filter: ps_supplycost[8]={min(ps_supplycost)}[9]
-            -> PhysicHashJoin Left (inccost=11539, cost=206, rows=2, memory=1004) (actual rows=0)
+            -> PhysicHashJoin Left (inccost=10139, cost=206, rows=2, memory=1004) (actual rows=0)
                 Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
                 Filter: p_partkey[3]=ps_partkey[10]
                 -> PhysicGather Threads: 20 (inccost=4416, cost=20, rows=2) (actual rows=0)
@@ -82,31 +82,35 @@ PhysicLimit (100) (inccost=11642.58, cost=100, rows=100) (actual rows=0)
                                     Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
                                 -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                                     Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
-                -> PhysicHashAgg  (inccost=6917, cost=800, rows=200, memory=4800) (actual rows=0)
-                    Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
-                    Aggregates: min(ps_supplycost[1])
+                -> PhysicHashAgg  (inccost=5517, cost=600, rows=200, memory=2000) (actual rows=0)
+                    Output: {min({min(ps_supplycost)})}[1],{ps_partkey}[0]
+                    Aggregates: min({min(ps_supplycost)}[1])
                     Group by: ps_partkey[0]
-                    -> PhysicGather Threads: 20 (inccost=6117, cost=4000, rows=400) (actual rows=0)
-                        Output: ps_partkey[1],ps_supplycost[2]
-                        -> PhysicHashJoin  (inccost=2117, cost=1210, rows=400, memory=40) (actual rows=8, loops=10)
-                            Output: ps_partkey[1],ps_supplycost[2]
-                            Filter: s_suppkey[0]=ps_suppkey[3]
-                            -> PhysicRedistribute  (inccost=107, cost=10, rows=5) (actual rows=0, loops=10)
-                                Output: s_suppkey[0]
-                                -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=40) (actual rows=0, loops=10)
-                                    Output: s_suppkey[1]
-                                    Filter: s_nationkey[2]=n_nationkey[0]
-                                    -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
-                                        Output: n_nationkey[1]
-                                        Filter: n_regionkey[2]=r_regionkey[0]
-                                        -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
-                                            Output: r_regionkey[0]
-                                            Filter: r_name[1]='EUROPE'
-                                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
-                                            Output: n_nationkey[0],n_regionkey[2]
-                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
-                                        Output: s_suppkey[0],s_nationkey[3]
-                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=80)
-                                Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
+                    -> PhysicGather Threads: 20 (inccost=4917, cost=2000, rows=200) (actual rows=0)
+                        Output: {ps_partkey}[0],{min(ps_supplycost)}[1]
+                        -> PhysicHashAgg  (inccost=2917, cost=800, rows=200, memory=4800) (actual rows=7, loops=10)
+                            Output: {ps_partkey}[0],{min(ps_supplycost)}[1]
+                            Aggregates: min(ps_supplycost[1])
+                            Group by: ps_partkey[0]
+                            -> PhysicHashJoin  (inccost=2117, cost=1210, rows=400, memory=40) (actual rows=8, loops=10)
+                                Output: ps_partkey[1],ps_supplycost[2]
+                                Filter: s_suppkey[0]=ps_suppkey[3]
+                                -> PhysicRedistribute  (inccost=107, cost=10, rows=5) (actual rows=0, loops=10)
+                                    Output: s_suppkey[0]
+                                    -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=40) (actual rows=0, loops=10)
+                                        Output: s_suppkey[1]
+                                        Filter: s_nationkey[2]=n_nationkey[0]
+                                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
+                                            Output: n_nationkey[1]
+                                            Filter: n_regionkey[2]=r_regionkey[0]
+                                            -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
+                                                Output: r_regionkey[0]
+                                                Filter: r_name[1]='EUROPE'
+                                            -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
+                                                Output: n_nationkey[0],n_regionkey[2]
+                                        -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                            Output: s_suppkey[0],s_nationkey[3]
+                                -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=80)
+                                    Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
 
 

--- a/test/regress/expect/tpch0001_d/q05.txt
+++ b/test/regress/expect/tpch0001_d/q05.txt
@@ -22,48 +22,52 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 18713.97, memory=10271
-PhysicOrder  (inccost=18713.97, cost=82.97, rows=25, memory=825) (actual rows=0)
+Total cost: 18218.97, memory=11571
+PhysicOrder  (inccost=18218.97, cost=82.97, rows=25, memory=825) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*(1-l_discount))}[1]
     Order by: {sum(l_extendedprice*(1-l_discount))}[1]
-    -> PhysicHashAgg  (inccost=18631, cost=132, rows=25, memory=1650) (actual rows=0)
-        Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
-        Aggregates: sum(l_extendedprice[2]*(1-l_discount[5]))
+    -> PhysicHashAgg  (inccost=18136, cost=75, rows=25, memory=1300) (actual rows=0)
+        Output: {n_name}[0],{sum({sum(l_extendedprice*(1-l_discount))})}[1]
+        Aggregates: sum({sum(l_extendedprice*(1-l_discount))}[1])
         Group by: n_name[0]
-        -> PhysicGather Threads: 30 (inccost=18499, cost=820, rows=82) (actual rows=0)
-            Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],{1}[0],l_discount[7]
-            -> PhysicHashJoin  (inccost=17679, cost=877, rows=82, memory=3600) (actual rows=0, loops=10)
-                Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],{1}[0],l_discount[7]
-                Filter: (c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9])
-                -> PhysicBroadcast  (inccost=450, cost=300, rows=150) (actual rows=150, loops=10)
-                    Output: 1,c_custkey[0],c_nationkey[3]
-                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
+        -> PhysicGather Threads: 30 (inccost=18061, cost=250, rows=25) (actual rows=0)
+            Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
+            -> PhysicHashAgg  (inccost=17811, cost=132, rows=25, memory=1650) (actual rows=0, loops=10)
+                Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
+                Aggregates: sum(l_extendedprice[2]*(1-l_discount[5]))
+                Group by: n_name[0]
+                -> PhysicHashJoin  (inccost=17679, cost=877, rows=82, memory=3600) (actual rows=0, loops=10)
+                    Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],{1}[0],l_discount[7]
+                    Filter: (c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9])
+                    -> PhysicBroadcast  (inccost=450, cost=300, rows=150) (actual rows=150, loops=10)
                         Output: 1,c_custkey[0],c_nationkey[3]
-                -> PhysicHashJoin  (inccost=16352, cost=1397, rows=495, memory=330) (actual rows=0, loops=10)
-                    Output: n_name[0],{l_extendedprice*(1-l_discount)}[3],l_extendedprice[4],{(1-l_discount)}[5],l_discount[6],o_custkey[7],s_nationkey[1]
-                    Filter: l_suppkey[8]=s_suppkey[2]
-                    -> PhysicBroadcast  (inccost=107, cost=10, rows=5) (actual rows=0, loops=10)
-                        Output: n_name[0],s_nationkey[2],s_suppkey[3]
-                        -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=290) (actual rows=0, loops=10)
+                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
+                            Output: 1,c_custkey[0],c_nationkey[3]
+                    -> PhysicHashJoin  (inccost=16352, cost=1397, rows=495, memory=330) (actual rows=0, loops=10)
+                        Output: n_name[0],{l_extendedprice*(1-l_discount)}[3],l_extendedprice[4],{(1-l_discount)}[5],l_discount[6],o_custkey[7],s_nationkey[1]
+                        Filter: l_suppkey[8]=s_suppkey[2]
+                        -> PhysicBroadcast  (inccost=107, cost=10, rows=5) (actual rows=0, loops=10)
                             Output: n_name[0],s_nationkey[2],s_suppkey[3]
-                            Filter: s_nationkey[2]=n_nationkey[1]
-                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
-                                Output: n_name[1],n_nationkey[2]
-                                Filter: n_regionkey[3]=r_regionkey[0]
-                                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
-                                    Output: r_regionkey[0]
-                                    Filter: r_name[1]='ASIA'
-                                -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
-                                    Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
-                                Output: s_nationkey[3],s_suppkey[0]
-                    -> PhysicHashJoin  (inccost=14848, cost=7343, rows=892, memory=3568) (actual rows=0)
-                        Output: {l_extendedprice*(1-l_discount)}[2],l_extendedprice[3],{(1-l_discount)}[4],l_discount[5],o_custkey[0],l_suppkey[6]
-                        Filter: l_orderkey[7]=o_orderkey[1]
-                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=223) (actual rows=0)
-                            Output: o_custkey[1],o_orderkey[0]
-                            Filter: (o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM')
-                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
-                            Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),l_discount[6],l_suppkey[2],l_orderkey[0]
+                            -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=290) (actual rows=0, loops=10)
+                                Output: n_name[0],s_nationkey[2],s_suppkey[3]
+                                Filter: s_nationkey[2]=n_nationkey[1]
+                                -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
+                                    Output: n_name[1],n_nationkey[2]
+                                    Filter: n_regionkey[3]=r_regionkey[0]
+                                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
+                                        Output: r_regionkey[0]
+                                        Filter: r_name[1]='ASIA'
+                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
+                                        Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                    Output: s_nationkey[3],s_suppkey[0]
+                        -> PhysicHashJoin  (inccost=14848, cost=7343, rows=892, memory=3568) (actual rows=0)
+                            Output: {l_extendedprice*(1-l_discount)}[2],l_extendedprice[3],{(1-l_discount)}[4],l_discount[5],o_custkey[0],l_suppkey[6]
+                            Filter: l_orderkey[7]=o_orderkey[1]
+                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=223) (actual rows=0)
+                                Output: o_custkey[1],o_orderkey[0]
+                                Filter: (o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM')
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),l_discount[6],l_suppkey[2],l_orderkey[0]
 
 

--- a/test/regress/expect/tpch0001_d/q06.txt
+++ b/test/regress/expect/tpch0001_d/q06.txt
@@ -7,14 +7,17 @@ where
 	and l_shipdate < date '1994-01-01' + interval '1' year
 	and l_discount between .06 - 0.01  and .06 + 0.01
 	and l_quantity < 24
-Total cost: 6887, memory=16
-PhysicHashAgg  (inccost=6887, cost=82, rows=1, memory=16) (actual rows=1)
-    Output: {sum(l_extendedprice*l_discount)}[0]
-    Aggregates: sum(l_extendedprice[1]*l_discount[2])
-    -> PhysicGather Threads: 10 (inccost=6805, cost=800, rows=80) (actual rows=74)
-        Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
-        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=80) (actual rows=7, loops=10)
-            Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
-            Filter: ((((l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM') and l_discount[6]>=0.05) and l_discount[6]<=0.07) and l_quantity[4]<24)
+Total cost: 6100, memory=18
+PhysicHashAgg  (inccost=6100, cost=3, rows=1, memory=2) (actual rows=1)
+    Output: {sum({sum(l_extendedprice*l_discount)})}[0]
+    Aggregates: sum({sum(l_extendedprice*l_discount)}[0])
+    -> PhysicGather Threads: 10 (inccost=6097, cost=10, rows=1) (actual rows=10)
+        Output: {sum(l_extendedprice*l_discount)}[0]
+        -> PhysicHashAgg  (inccost=6087, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
+            Output: {sum(l_extendedprice*l_discount)}[0]
+            Aggregates: sum(l_extendedprice[1]*l_discount[2])
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=80) (actual rows=7, loops=10)
+                Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
+                Filter: ((((l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM') and l_discount[6]>=0.05) and l_discount[6]<=0.07) and l_quantity[4]<24)
 48090.8586
 

--- a/test/regress/expect/tpch0001_d/q11.txt
+++ b/test/regress/expect/tpch0001_d/q11.txt
@@ -35,26 +35,29 @@ PhysicOrder  (inccost=3130.56, cost=358.56, rows=80, memory=960) (actual rows=0)
         Group by: ps_partkey[0]
         Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=2614, cost=82, rows=1, memory=16) (actual rows=0)
-                Output: {sum(ps_supplycost*ps_availqty)}[0]*0.0001
-                Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                -> PhysicGather Threads: 20 (inccost=2532, cost=800, rows=80) (actual rows=0)
-                    Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
-                    -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
-                        Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
-                        Filter: ps_suppkey[4]=s_suppkey[0]
-                        -> PhysicRedistribute  (inccost=50, cost=2, rows=1) (actual rows=0, loops=10)
-                            Output: s_suppkey[0]
-                            -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
-                                Output: s_suppkey[1]
-                                Filter: s_nationkey[2]=n_nationkey[0]
-                                -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=1, loops=10)
-                                    Output: n_nationkey[0]
-                                    Filter: n_name[1]='GERMANY'
-                                -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
-                                    Output: s_suppkey[0],s_nationkey[3]
-                        -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
-                            Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
+            -> PhysicHashAgg  (inccost=1827, cost=3, rows=1, memory=16) (actual rows=0)
+                Output: {sum({sum(ps_supplycost*ps_availqty)})}[0]*0.0001
+                Aggregates: sum({sum(ps_supplycost*ps_availqty)}[0])
+                -> PhysicGather Threads: 20 (inccost=1824, cost=10, rows=1) (actual rows=0)
+                    Output: {sum(ps_supplycost*ps_availqty)}[0]
+                    -> PhysicHashAgg  (inccost=1814, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
+                        Output: {sum(ps_supplycost*ps_availqty)}[0]
+                        Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
+                        -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
+                            Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
+                            Filter: ps_suppkey[4]=s_suppkey[0]
+                            -> PhysicRedistribute  (inccost=50, cost=2, rows=1) (actual rows=0, loops=10)
+                                Output: s_suppkey[0]
+                                -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
+                                    Output: s_suppkey[1]
+                                    Filter: s_nationkey[2]=n_nationkey[0]
+                                    -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=1, loops=10)
+                                        Output: n_nationkey[0]
+                                        Filter: n_name[1]='GERMANY'
+                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                        Output: s_suppkey[0],s_nationkey[3]
+                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                                Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
         -> PhysicGather Threads: 20 (inccost=2532, cost=800, rows=80) (actual rows=0)
             Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
             -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0, loops=10)

--- a/test/regress/expect/tpch0001_d/q12.txt
+++ b/test/regress/expect/tpch0001_d/q12.txt
@@ -26,24 +26,28 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 12575.32, memory=20618
-PhysicOrder  (inccost=12575.32, cost=14.32, rows=7, memory=126) (actual rows=2)
+Total cost: 10136.32, memory=20786
+PhysicOrder  (inccost=10136.32, cost=14.32, rows=7, memory=126) (actual rows=2)
     Output: l_shipmode[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=12561, cost=267, rows=7, memory=252) (actual rows=2)
-        Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
-        Aggregates: sum(case with 0|1|1), sum(case with 0|1|1)
+    -> PhysicHashAgg  (inccost=10122, cost=21, rows=7, memory=168) (actual rows=2)
+        Output: {l_shipmode}[0],{sum({sum(case with 0|1|1)})}[1],{sum({sum(case with 0|1|1)})}[2]
+        Aggregates: sum({sum(case with 0|1|1)}[1]), sum({sum(case with 0|1|1)}[2])
         Group by: l_shipmode[0]
-        -> PhysicGather Threads: 10 (inccost=12294, cost=2530, rows=253) (actual rows=25)
-            Output: l_shipmode[0],{case with 0|1|1}[6],{(o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH')}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 0|1|1}[11],{(o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH')}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
-            -> PhysicHashJoin  (inccost=9764, cost=2259, rows=253, memory=20240) (actual rows=2, loops=10)
-                Output: l_shipmode[0],{case with 0|1|1}[6],{(o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH')}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 0|1|1}[11],{(o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH')}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
-                Filter: o_orderkey[15]=l_orderkey[5]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=253) (actual rows=2, loops=10)
-                    Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
-                    Filter: ((((l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12]) and l_shipdate[10]<l_commitdate[11]) and l_receiptdate[12]>='1994-01-01') and l_receiptdate[12]<'1/1/1995 12:00:00 AM')
-                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=150, loops=10)
-                    Output: case with 0|1|1,(o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH'),o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 0|1|1,(o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH'),o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
+        -> PhysicGather Threads: 10 (inccost=10101, cost=70, rows=7) (actual rows=16)
+            Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
+            -> PhysicHashAgg  (inccost=10031, cost=267, rows=7, memory=252) (actual rows=1, loops=10)
+                Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
+                Aggregates: sum(case with 0|1|1), sum(case with 0|1|1)
+                Group by: l_shipmode[0]
+                -> PhysicHashJoin  (inccost=9764, cost=2259, rows=253, memory=20240) (actual rows=2, loops=10)
+                    Output: l_shipmode[0],{case with 0|1|1}[6],{(o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH')}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 0|1|1}[11],{(o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH')}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
+                    Filter: o_orderkey[15]=l_orderkey[5]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=253) (actual rows=2, loops=10)
+                        Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
+                        Filter: ((((l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12]) and l_shipdate[10]<l_commitdate[11]) and l_receiptdate[12]>='1994-01-01') and l_receiptdate[12]<'1/1/1995 12:00:00 AM')
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=150, loops=10)
+                        Output: case with 0|1|1,(o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH'),o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 0|1|1,(o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH'),o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
 MAIL,5,5
 SHIP,5,10
 

--- a/test/regress/expect/tpch0001_d/q14.txt
+++ b/test/regress/expect/tpch0001_d/q14.txt
@@ -11,21 +11,24 @@ where
 	l_partkey = p_partkey
 	and l_shipdate >= date '1995-09-01'
 	and l_shipdate < date '1995-09-01' + interval '1' month
-Total cost: 7655, memory=8128
-PhysicHashAgg  (inccost=7655, cost=80, rows=1, memory=16) (actual rows=1)
-    Output: {sum(case with 0|1|1)}[0]*100/{sum(l_extendedprice*(1-l_discount))}[1](as promo_revenue)
-    Aggregates: sum(case with 0|1|1), sum(l_extendedprice[5]*(1-l_discount[8]))
-    -> PhysicGather Threads: 20 (inccost=7575, cost=780, rows=78) (actual rows=84)
-        Output: case with 0|1|1,{p_type like 'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*(1-l_discount)}[3],l_extendedprice[0],{(1-l_discount)}[4],1,l_discount[1],0
-        -> PhysicHashJoin  (inccost=6795, cost=434, rows=78, memory=8112) (actual rows=8, loops=10)
-            Output: case with 0|1|1,{p_type like 'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*(1-l_discount)}[3],l_extendedprice[0],{(1-l_discount)}[4],1,l_discount[1],0
-            Filter: l_partkey[7]=p_partkey[10]
-            -> PhysicRedistribute  (inccost=6161, cost=156, rows=78) (actual rows=8, loops=10)
-                Output: l_extendedprice[0],l_discount[1],{'PROMO%'}[2],{l_extendedprice*(1-l_discount)}[3],{(1-l_discount)}[4],{1}[5],{0}[6],l_partkey[7]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=78) (actual rows=8, loops=10)
-                    Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,0,l_partkey[1]
-                    Filter: (l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM')
-            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=20, loops=10)
-                Output: p_type[4],p_type[4] like 'PROMO%',p_partkey[0]
+Total cost: 6888, memory=8160
+PhysicHashAgg  (inccost=6888, cost=3, rows=1, memory=16) (actual rows=1)
+    Output: {sum({sum(case with 0|1|1)})}[0]*100/{sum({sum(l_extendedprice*(1-l_discount))})}[1](as promo_revenue)
+    Aggregates: sum({sum(case with 0|1|1)}[0]), sum({sum(l_extendedprice*(1-l_discount))}[1])
+    -> PhysicGather Threads: 20 (inccost=6885, cost=10, rows=1) (actual rows=10)
+        Output: {sum(case with 0|1|1)}[0],{sum(l_extendedprice*(1-l_discount))}[1]
+        -> PhysicHashAgg  (inccost=6875, cost=80, rows=1, memory=32) (actual rows=1, loops=10)
+            Output: {sum(case with 0|1|1)}[0],{sum(l_extendedprice*(1-l_discount))}[1]
+            Aggregates: sum(case with 0|1|1), sum(l_extendedprice[5]*(1-l_discount[8]))
+            -> PhysicHashJoin  (inccost=6795, cost=434, rows=78, memory=8112) (actual rows=8, loops=10)
+                Output: case with 0|1|1,{p_type like 'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*(1-l_discount)}[3],l_extendedprice[0],{(1-l_discount)}[4],1,l_discount[1],0
+                Filter: l_partkey[7]=p_partkey[10]
+                -> PhysicRedistribute  (inccost=6161, cost=156, rows=78) (actual rows=8, loops=10)
+                    Output: l_extendedprice[0],l_discount[1],{'PROMO%'}[2],{l_extendedprice*(1-l_discount)}[3],{(1-l_discount)}[4],{1}[5],{0}[6],l_partkey[7]
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=78) (actual rows=8, loops=10)
+                        Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,0,l_partkey[1]
+                        Filter: (l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM')
+                -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=20, loops=10)
+                    Output: p_type[4],p_type[4] like 'PROMO%',p_partkey[0]
 15.2302
 

--- a/test/regress/expect/tpch0001_d/q17.txt
+++ b/test/regress/expect/tpch0001_d/q17.txt
@@ -15,14 +15,14 @@ where
 		where
 			l_partkey = p_partkey
 	)
-Total cost: 85356, memory=6024
-PhysicHashAgg  (inccost=85356, cost=32, rows=1, memory=16) (actual rows=1)
+Total cost: 27906, memory=5624
+PhysicHashAgg  (inccost=27906, cost=32, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice)}[0]/7(as avg_yearly)
     Aggregates: sum(l_extendedprice[0])
-    -> PhysicFilter  (inccost=85324, cost=30, rows=30) (actual rows=0)
+    -> PhysicFilter  (inccost=27874, cost=30, rows=30) (actual rows=0)
         Output: l_extendedprice[0]
         Filter: l_quantity[1]<{avg(l_quantity)}[2]*0.2
-        -> PhysicHashJoin Left (inccost=85294, cost=290, rows=30, memory=1200) (actual rows=0)
+        -> PhysicHashJoin Left (inccost=27844, cost=290, rows=30, memory=1200) (actual rows=0)
             Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
             Filter: l_partkey[4]=p_partkey[2]
             -> PhysicGather Threads: 20 (inccost=12544, cost=300, rows=30) (actual rows=0)
@@ -37,13 +37,17 @@ PhysicHashAgg  (inccost=85356, cost=32, rows=1, memory=16) (actual rows=1)
                             Filter: (p_container[6]='MED BOX' and p_brand[3]='Brand#23')
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                         Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
-            -> PhysicHashAgg  (inccost=72460, cost=6405, rows=200, memory=4800) (actual rows=0)
-                Output: {avg(l_quantity)}[1],{l_partkey}[0]
-                Aggregates: avg(l_quantity[1])
+            -> PhysicHashAgg  (inccost=15010, cost=600, rows=200, memory=2000) (actual rows=0)
+                Output: {sum({sum(l_quantity)})}[1]/{sum({count(l_quantity)})}[2],{l_partkey}[0]
+                Aggregates: sum({sum(l_quantity)}[1]), sum({count(l_quantity)}[2])
                 Group by: l_partkey[0]
-                -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
-                    Output: l_partkey[1],l_quantity[4]
-                    -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
-                        Output: l_partkey[1],l_quantity[4]
+                -> PhysicGather Threads: 10 (inccost=14410, cost=2000, rows=200) (actual rows=0)
+                    Output: {l_partkey}[0],{sum(l_quantity)}[1],{count(l_quantity)}[2]
+                    -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200, memory=2400) (actual rows=189, loops=10)
+                        Output: {l_partkey}[0],{sum(l_quantity)}[1],{count(l_quantity)}[2]
+                        Aggregates: sum(l_quantity[1]), count(l_quantity[1])
+                        Group by: l_partkey[0]
+                        -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
+                            Output: l_partkey[1],l_quantity[4]
 
 

--- a/test/regress/expect/tpch0001_d/q18.txt
+++ b/test/regress/expect/tpch0001_d/q18.txt
@@ -57,15 +57,19 @@ PhysicLimit (100) (inccost=209564.25, cost=100, rows=100) (actual rows=0)
                             Output: o_orderkey[0],o_orderdate[4],o_totalprice[3],o_custkey[1]
                             Filter: o_orderkey[0] in @1
                             <InSubqueryExpr> cached 1
-                                -> PhysicHashAgg  (inccost=75060, cost=9005, rows=1500, memory=12000) (actual rows=0)
+                                -> PhysicHashAgg  (inccost=34510, cost=4500, rows=1500, memory=12000) (actual rows=0)
                                     Output: {l_orderkey}[0]
-                                    Aggregates: sum(l_quantity[1])
+                                    Aggregates: sum({sum(l_quantity)}[1])
                                     Group by: l_orderkey[0]
-                                    Filter: {sum(l_quantity)}[1]>300
-                                    -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=6005)
-                                        Output: l_orderkey[0],l_quantity[4]
-                                        -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
-                                            Output: l_orderkey[0],l_quantity[4]
+                                    Filter: {sum({sum(l_quantity)})}[1]>300
+                                    -> PhysicGather Threads: 10 (inccost=30010, cost=15000, rows=1500) (actual rows=1500)
+                                        Output: {l_orderkey}[0],{sum(l_quantity)}[1]
+                                        -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500, memory=36000) (actual rows=150, loops=10)
+                                            Output: {l_orderkey}[0],{sum(l_quantity)}[1]
+                                            Aggregates: sum(l_quantity[1])
+                                            Group by: l_orderkey[0]
+                                            -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
+                                                Output: l_orderkey[0],l_quantity[4]
                         -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                             Output: l_quantity[4],l_orderkey[0]
 


### PR DESCRIPTION
Based on the assumption that aggregation cannot increase the cardinality, or that the cardinality is less or the same as before the aggregation. Therefore, it can be assumed that it is likely to be better to split the aggregate into a pair of global agg and local agg. The default of all aggregation is global aggregation, which only accept serialized data stream.
A exploration transformation rule is introduced to account for this situation. For a global aggregation that cannot be directly turned into local aggregation, it will be turned into two aggregation, a global on top of a local. The new global logic node will be placed in the same group as the original global aggregation, with its child, the new local logic node placed in a new group, and its child is the same child group as the original global aggregation.
For global aggregation, since it should be placed in the same group, the signature is forced to be the same as the original aggregate. Meanwhile, the newly created local agg node will have different signature and thus will be in its own memo group. (#143)

The aggregation functions are transformed as listed below: _(e represents some expression)_
sum(e) = sum(sum(e))
min(e) = min(min(e))
max(e) = max(max(e))
count(e) = sum(count(e))
count(*) = sum(count(*)
avg(e) = sum(sum(e)) / sum(count(e))

For groupby attribute, the local and global should use the same groupby as the original aggregate.
For having constrain, it needs to be separated, the expression involving aggregate function will be placed on the global aggregate node, while the others are place on the local aggregate node. For example, having count(a1) > 1 can only be determined after the whole aggregate process is complete, thus must be on the global node. Meanwhile, having a1 > 1 is just a local constraint that can be acted on rows, so it can be placed just on local node.

Another critical fix is that previously the aggrcore in PhysicHashAgg.Exec() is shared among threads (different copy of the phyiscal node). Now, new copy of logic_aggrFns_ is created for each thread.
<code>List<AggFunc> aggrcore = new List<AggFunc>();
logic.aggrFns_.ForEach(x => aggrcore.Add(x.Clone() as AggFunc));</code>
(line 1161 of PhysicNode.cs)

TODOs:
Stddev is not implemented in this patch, therefore query like
`select a3/2*2, sum(a3), count(a3), stddev_samp(a3) from a group by 1;`
cannot be successfully executed.
Also,
`select d1, sum(d2) from (select c1/2, sum(c1) from (select b1, count(*) as a1 from b group by b1)c(c1, c2) group by c1/2) d(d1, d2) group by d1;`
(both queries mentioned above are from TestAggregation unit test)
