### PR TITLE
Change cardinality calculation for distributed plan and fix bugs

### DIFF
--- a/qpmodel/PhysicalExec.cs
+++ b/qpmodel/PhysicalExec.cs
@@ -805,7 +805,7 @@ namespace qpmodel.physic
         protected override double EstimateCost()
         {
             // penalize gather to discourage serialization at bottom
-            return child_().Card() * 1.0 + Card() * 1.0;
+            return (child_().Card() * 1.0) + (Card() * 1.0);
         }
     }
 

--- a/qpmodel/PhysicalExec.cs
+++ b/qpmodel/PhysicalExec.cs
@@ -805,7 +805,7 @@ namespace qpmodel.physic
         protected override double EstimateCost()
         {
             // penalize gather to discourage serialization at bottom
-            return child_().Card() * 10.0;
+            return child_().Card() * 1.0 + Card() * 1.0;
         }
     }
 
@@ -826,7 +826,7 @@ namespace qpmodel.physic
 
         protected override double EstimateCost()
         {
-            return child_().Card() * 2.0;
+            return Card() * 1.0;
         }
     }
 
@@ -864,7 +864,7 @@ namespace qpmodel.physic
 
         protected override double EstimateCost()
         {
-            return child_().Card() * 2.0;
+            return Card() * 1.0;
         }
     }
 }

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -149,7 +149,7 @@ namespace qpmodel.physic
         }
 
         #region optimizer
-        public ulong Card() => (ulong)Math.Ceiling( (double)logic_.Card() / logic_.machinecount_);
+        public ulong Card() => (ulong)Math.Ceiling( (double)logic_.Card() / logic_.distrcount_);
         public double Cost()
         {
             if (double.IsNaN(cost_))

--- a/qpmodel/PhysicalNode.cs
+++ b/qpmodel/PhysicalNode.cs
@@ -149,7 +149,7 @@ namespace qpmodel.physic
         }
 
         #region optimizer
-        public ulong Card() => logic_.Card();
+        public ulong Card() => (ulong)Math.Ceiling( (double)logic_.Card() / logic_.machinecount_);
         public double Cost()
         {
             if (double.IsNaN(cost_))
@@ -420,7 +420,8 @@ namespace qpmodel.physic
                     else
                         return false;
                 case DistrType.AnyDistributed:
-                    if (tableref.Table().distMethod_ != TableDef.DistributionMethod.Replicated)
+                    if (tableref.Table().distMethod_ == TableDef.DistributionMethod.Distributed ||
+                        tableref.Table().distMethod_ == TableDef.DistributionMethod.Roundrobin)
                         return true;
                     else
                         return false;
@@ -1499,7 +1500,7 @@ namespace qpmodel.physic
 
         protected override double EstimateCost()
         {
-            var rowstosort = child_().Card() * 1.0;
+            var rowstosort = Card() * 1.0;
             double cost = rowstosort * (0.1 + Math.Log(rowstosort));
             return cost;
         }

--- a/qpmodel/Plan.cs
+++ b/qpmodel/Plan.cs
@@ -195,7 +195,7 @@ namespace qpmodel.logic
                         var memory = phynode.Memory();
                         if (memory != 0)
                             memorycost = $", memory={memory}";
-                        r += $" (inccost={incCost}, cost={cost}, rows={phynode.logic_.Card()}{memorycost})";
+                        r += $" (inccost={incCost}, cost={cost}, rows={phynode.Card()}{memorycost})";
                     }
                     if (exp_showactual)
                     {

--- a/qpmodel/RulesTrans.cs
+++ b/qpmodel/RulesTrans.cs
@@ -254,7 +254,9 @@ namespace qpmodel.optimizer
             List<AggFunc> aggfns = new List<AggFunc>();
             origAggNode.aggrFns_.ForEach(x => aggfns.Add(x.Clone() as AggFunc));
             // need to make aggrFns_ back to null list
+            // and having_ back to original
             origAggNode.aggrFns_ = new List<AggFunc>();
+            origAggNode.having_ = having?.Clone();
 
             var globalfns = new List<Expr>();
             var localfns = new List<Expr>();

--- a/qpmodel/optimizer.cs
+++ b/qpmodel/optimizer.cs
@@ -478,8 +478,10 @@ namespace qpmodel.optimizer
                     return minMember_[PhysicProperty.NullProperty_].cost;
                 else if (minMember_.ContainsKey(PhysicProperty.NullProperty_))
                     return minMember_[DistrProperty.Singleton_].cost;
-                else
+                else if (minMember_.Count > 0)
                     return minMember_[minMember_.Keys.ToList()[0]].cost;
+                else
+                    return double.NaN;
             }
         }
 
@@ -751,7 +753,7 @@ namespace qpmodel.optimizer
             return optmember;
         }
         public CGroupMember CalculateMinInclusiveCostMember()
-            => CalculateMinInclusiveCostMember(PhysicProperty.NullProperty_);
+            => CalculateMinInclusiveCostMember(DistrProperty.Singleton_);
 
         public PhysicNode CopyOutMinLogicPhysicPlan(PhysicProperty property, PhysicNode knownMinPhysic = null)
         {
@@ -786,7 +788,7 @@ namespace qpmodel.optimizer
                         PhysicProperty subprop;
                         if (minmember != null && minmember.propertyPairs_.ContainsKey(property))
                             subprop = minmember.propertyPairs_[property][i];
-                        else subprop = PhysicProperty.NullProperty_;
+                        else subprop = DistrProperty.Singleton_;
                         phychild = g.CopyOutMinLogicPhysicPlan(subprop);
                     }
                     else

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2822,6 +2822,7 @@ namespace qpmodel.unittest
         public void Redistribute()
         {
             var option = new QueryOption();
+            option.optimize_.memo_disable_crossjoin_ = false;
 
             for (int i = 0; i < 3; i++)
             {
@@ -2842,34 +2843,34 @@ namespace qpmodel.unittest
                 sql = "select a2,b2,c2 from ad, bd, cd where a2=b2 and c2 = b2 order by c2";
                 TU.ExecuteSQL(sql, "1,1,1;2,2,2;3,3,3", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 3, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 2 : 0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(3, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
                 sql = "select a2,b2,c2,d2 from ad, bd, cd, dd where a2=b2 and c2 = b2 and c2=d2 order by b2";
                 TU.ExecuteSQL(sql, "1,1,1,1;2,2,2,2;2,2,2,2;3,3,3,3", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 4, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 3 : 0, TU.CountStr(phyplan, "Broadcast"));
-                Assert.AreEqual(enable_bc ? 0 : 1, TU.CountStr(phyplan, "threads: 50"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "threads: 40"));
+                Assert.AreEqual(4, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "threads: 50"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "threads: 40"));
 
                 // ensure redistribution can shuffle by expression
                 sql = "select a2, b2 from ad, bd where a2*2+a1=b2 order by a2;";
                 TU.ExecuteSQL(sql, "1,2", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 2, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
 
                 // no output if by previous r[0] method for redistribution
                 sql = "select d2, a1 from ad, dd where d3=a1 order by d2;";
                 TU.ExecuteSQL(sql, "1,2", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 1, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(1, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
                 sql = "select d2, a2 from ad, dd where d4=a2 order by d2;";
                 TU.ExecuteSQL(sql, "1,3", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 2, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
 
                 // mixed with replicated table
                 sql = "select a1,b1 from ad, br where a1=b1 order by a1;";
@@ -2893,13 +2894,13 @@ namespace qpmodel.unittest
                 sql = "select a1,b1 from ad, brb where a2=b2 order by a1;";
                 TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 2, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
                 sql = "select a1,b1 from arb, brb where a2=b2 order by a1;";
                 TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));
-                Assert.AreEqual(enable_bc ? 0 : 2, TU.CountStr(phyplan, "Redistribute"));
-                Assert.AreEqual(enable_bc ? 1 : 0, TU.CountStr(phyplan, "Broadcast"));
+                Assert.AreEqual(2, TU.CountStr(phyplan, "Redistribute"));
+                Assert.AreEqual(0, TU.CountStr(phyplan, "Broadcast"));
                 sql = "select a1,b1 from ar, brb where a2=b2 order by a1;";
                 TU.ExecuteSQL(sql, "0,0;1,1;2,2", out phyplan, option);
                 Assert.AreEqual(1, TU.CountStr(phyplan, "Gather"));

--- a/test/regress/expect/tpch0001_d/q01.txt
+++ b/test/regress/expect/tpch0001_d/q01.txt
@@ -19,15 +19,15 @@ group by
 order by
 	l_returnflag,
 	l_linestatus
-Total cost: 12019.35, memory=996
-PhysicOrder  (inccost=12019.35, cost=11.35, rows=6, memory=372) (actual rows=4)
+Total cost: 11971.35, memory=996
+PhysicOrder  (inccost=11971.35, cost=11.35, rows=6, memory=372) (actual rows=4)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=12008, cost=18, rows=6, memory=120) (actual rows=4)
+    -> PhysicHashAgg  (inccost=11960, cost=18, rows=6, memory=120) (actual rows=4)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum({sum(l_quantity)})}[2],{sum({sum(l_extendedprice)})}[3],{sum({sum(l_extendedprice*(1-l_discount))})}[4],{sum({sum(l_extendedprice*(1-l_discount)*(l_tax+1))})}[5],{sum({sum(l_quantity)})}[2]/{sum({count(l_quantity)})}[6],{sum({sum(l_extendedprice)})}[3]/{sum({count(l_extendedprice)})}[7],{sum({sum(l_discount)})}[8]/{sum({count(l_discount)})}[9],{sum({count(*)(0)})}[10]
         Aggregates: sum({sum(l_quantity)}[2]), sum({sum(l_extendedprice)}[3]), sum({sum(l_extendedprice*(1-l_discount))}[4]), sum({sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5]), sum({count(l_quantity)}[6]), sum({count(l_extendedprice)}[7]), sum({sum(l_discount)}[8]), sum({count(l_discount)}[9]), sum({count(*)(0)}[10])
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicGather Threads: 10 (inccost=11990, cost=60, rows=6) (actual rows=39)
+        -> PhysicGather Threads: 10 (inccost=11942, cost=12, rows=6) (actual rows=39)
             Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{count(l_quantity)}[6],{count(l_extendedprice)}[7],{sum(l_discount)}[8],{count(l_discount)}[9],{count(*)(0)}[10]
             -> PhysicHashAgg  (inccost=11930, cost=5925, rows=6, memory=504) (actual rows=3, loops=10)
                 Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{count(l_quantity)}[6],{count(l_extendedprice)}[7],{sum(l_discount)}[8],{count(l_discount)}[9],{count(*)(0)}[10]

--- a/test/regress/expect/tpch0001_d/q01.txt
+++ b/test/regress/expect/tpch0001_d/q01.txt
@@ -19,21 +19,21 @@ group by
 order by
 	l_returnflag,
 	l_linestatus
-Total cost: 11971.35, memory=996
-PhysicOrder  (inccost=11971.35, cost=11.35, rows=6, memory=372) (actual rows=4)
+Total cost: 6640.35, memory=576
+PhysicOrder  (inccost=6640.35, cost=11.35, rows=6, memory=372) (actual rows=4)
     Output: l_returnflag[0],l_linestatus[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{avg(l_quantity)}[6],{avg(l_extendedprice)}[7],{avg(l_discount)}[8],{count(*)(0)}[9]
     Order by: l_returnflag[0], l_linestatus[1]
-    -> PhysicHashAgg  (inccost=11960, cost=18, rows=6, memory=120) (actual rows=4)
+    -> PhysicHashAgg  (inccost=6629, cost=13, rows=6, memory=120) (actual rows=4)
         Output: {l_returnflag}[0],{l_linestatus}[1],{sum({sum(l_quantity)})}[2],{sum({sum(l_extendedprice)})}[3],{sum({sum(l_extendedprice*(1-l_discount))})}[4],{sum({sum(l_extendedprice*(1-l_discount)*(l_tax+1))})}[5],{sum({sum(l_quantity)})}[2]/{sum({count(l_quantity)})}[6],{sum({sum(l_extendedprice)})}[3]/{sum({count(l_extendedprice)})}[7],{sum({sum(l_discount)})}[8]/{sum({count(l_discount)})}[9],{sum({count(*)(0)})}[10]
         Aggregates: sum({sum(l_quantity)}[2]), sum({sum(l_extendedprice)}[3]), sum({sum(l_extendedprice*(1-l_discount))}[4]), sum({sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5]), sum({count(l_quantity)}[6]), sum({count(l_extendedprice)}[7]), sum({sum(l_discount)}[8]), sum({count(l_discount)}[9]), sum({count(*)(0)}[10])
         Group by: l_returnflag[0], l_linestatus[1]
-        -> PhysicGather Threads: 10 (inccost=11942, cost=12, rows=6) (actual rows=39)
+        -> PhysicGather Threads: 10 (inccost=6616, cost=7, rows=6) (actual rows=39)
             Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{count(l_quantity)}[6],{count(l_extendedprice)}[7],{sum(l_discount)}[8],{count(l_discount)}[9],{count(*)(0)}[10]
-            -> PhysicHashAgg  (inccost=11930, cost=5925, rows=6, memory=504) (actual rows=3, loops=10)
+            -> PhysicHashAgg  (inccost=6609, cost=604, rows=1, memory=84) (actual rows=3, loops=10)
                 Output: {l_returnflag}[0],{l_linestatus}[1],{sum(l_quantity)}[2],{sum(l_extendedprice)}[3],{sum(l_extendedprice*(1-l_discount))}[4],{sum(l_extendedprice*(1-l_discount)*(l_tax+1))}[5],{count(l_quantity)}[6],{count(l_extendedprice)}[7],{sum(l_discount)}[8],{count(l_discount)}[9],{count(*)(0)}[10]
                 Aggregates: sum(l_quantity[2]), sum(l_extendedprice[3]), sum(l_extendedprice[3]*(1-l_discount[7])), sum(l_extendedprice[3]*(1-l_discount[7])*(l_tax[10]+1)), count(l_quantity[2]), count(l_extendedprice[3]), sum(l_discount[7]), count(l_discount[7]), count(*)(0)
                 Group by: l_returnflag[0], l_linestatus[1]
-                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=5913) (actual rows=591, loops=10)
+                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=592) (actual rows=591, loops=10)
                     Output: l_returnflag[8],l_linestatus[9],l_quantity[4],l_extendedprice[5],l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,l_discount[6],l_extendedprice[5]*(1-l_discount[6])*(l_tax[7]+1),(l_tax[7]+1),l_tax[7]
                     Filter: l_shipdate[10]<='9/2/1998 12:00:00 AM'
 A,F,37474,37569624.64,35676192.097,37101416.2224,25.3545,25419.2318,0.0509,1478

--- a/test/regress/expect/tpch0001_d/q02.txt
+++ b/test/regress/expect/tpch0001_d/q02.txt
@@ -42,21 +42,21 @@ order by
 	s_name,
 	p_partkey
 limit 100
-Total cost: 8416.58, memory=7096
-PhysicLimit (100) (inccost=8416.58, cost=100, rows=100) (actual rows=0)
+Total cost: 5098.58, memory=7096
+PhysicLimit (100) (inccost=5098.58, cost=100, rows=100) (actual rows=0)
     Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
-    -> PhysicOrder  (inccost=8316.58, cost=1.58, rows=2, memory=486) (actual rows=0)
+    -> PhysicOrder  (inccost=4998.58, cost=1.58, rows=2, memory=486) (actual rows=0)
         Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
         Order by: s_acctbal[0], n_name[2], s_name[1], p_partkey[3]
-        -> PhysicFilter  (inccost=8315, cost=2, rows=2) (actual rows=0)
+        -> PhysicFilter  (inccost=4997, cost=1, rows=2) (actual rows=0)
             Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
             Filter: ps_supplycost[8]={min(ps_supplycost)}[9]
-            -> PhysicHashJoin Left (inccost=8313, cost=206, rows=2, memory=1004) (actual rows=0)
+            -> PhysicHashJoin Left (inccost=4996, cost=204, rows=1, memory=1004) (actual rows=0)
                 Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
                 Filter: p_partkey[3]=ps_partkey[10]
-                -> PhysicGather Threads: 20 (inccost=4399, cost=4, rows=2) (actual rows=0)
+                -> PhysicGather Threads: 20 (inccost=2541, cost=3, rows=2) (actual rows=0)
                     Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
-                    -> PhysicHashJoin  (inccost=4395, cost=448, rows=2, memory=58) (actual rows=0, loops=10)
+                    -> PhysicHashJoin  (inccost=2538, cost=49, rows=1, memory=58) (actual rows=0, loops=10)
                         Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
                         Filter: p_partkey[0]=ps_partkey[9]
                         -> PhysicBroadcast  (inccost=201, cost=1, rows=1) (actual rows=0, loops=10)
@@ -64,7 +64,7 @@ PhysicLimit (100) (inccost=8416.58, cost=100, rows=100) (actual rows=0)
                             -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0, loops=10)
                                 Output: p_partkey[0],p_mfgr[2]
                                 Filter: (p_size[5]=15 and p_type[4] like '%BRASS')
-                        -> PhysicHashJoin  (inccost=3746, cost=1254, rows=444, memory=290) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=2288, cost=534, rows=444, memory=290) (actual rows=0)
                             Output: s_acctbal[2],s_name[3],n_name[0],s_address[4],s_phone[5],s_comment[6],ps_supplycost[7],ps_partkey[8]
                             Filter: s_nationkey[9]=n_nationkey[1]
                             -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=0)
@@ -75,25 +75,25 @@ PhysicLimit (100) (inccost=8416.58, cost=100, rows=100) (actual rows=0)
                                     Filter: r_name[1]='EUROPE'
                                 -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
                                     Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                            -> PhysicHashJoin  (inccost=2430, cost=1620, rows=800, memory=394) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=1692, cost=882, rows=800, memory=394) (actual rows=0)
                                 Output: s_acctbal[0],s_name[1],s_address[2],s_phone[3],s_comment[4],ps_supplycost[7],ps_partkey[8],s_nationkey[5]
                                 Filter: s_suppkey[6]=ps_suppkey[9]
-                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0)
                                     Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
-                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=80) (actual rows=0)
                                     Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
-                -> PhysicHashAgg  (inccost=3708, cost=800, rows=200, memory=4800) (actual rows=0)
+                -> PhysicHashAgg  (inccost=2251, cost=440, rows=200, memory=4800) (actual rows=0)
                     Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
                     Aggregates: min(ps_supplycost[1])
                     Group by: ps_partkey[0]
-                    -> PhysicGather Threads: 20 (inccost=2908, cost=800, rows=400) (actual rows=0)
+                    -> PhysicGather Threads: 20 (inccost=1811, cost=440, rows=400) (actual rows=0)
                         Output: ps_partkey[1],ps_supplycost[2]
-                        -> PhysicHashJoin  (inccost=2108, cost=1210, rows=400, memory=8) (actual rows=8, loops=10)
+                        -> PhysicHashJoin  (inccost=1371, cost=482, rows=400, memory=8) (actual rows=8, loops=10)
                             Output: ps_partkey[1],ps_supplycost[2]
                             Filter: s_suppkey[0]=ps_suppkey[3]
-                            -> PhysicRedistribute  (inccost=98, cost=1, rows=5) (actual rows=0, loops=10)
+                            -> PhysicRedistribute  (inccost=89, cost=1, rows=1) (actual rows=0, loops=10)
                                 Output: s_suppkey[0]
-                                -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=40) (actual rows=0, loops=10)
+                                -> PhysicHashJoin  (inccost=88, cost=16, rows=5, memory=40) (actual rows=0, loops=10)
                                     Output: s_suppkey[1]
                                     Filter: s_nationkey[2]=n_nationkey[0]
                                     -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
@@ -104,9 +104,9 @@ PhysicLimit (100) (inccost=8416.58, cost=100, rows=100) (actual rows=0)
                                             Filter: r_name[1]='EUROPE'
                                         -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
                                             Output: n_nationkey[0],n_regionkey[2]
-                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=1) (actual rows=1, loops=10)
                                         Output: s_suppkey[0],s_nationkey[3]
-                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=80)
+                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=80) (actual rows=80)
                                 Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
 
 

--- a/test/regress/expect/tpch0001_d/q02.txt
+++ b/test/regress/expect/tpch0001_d/q02.txt
@@ -42,24 +42,24 @@ order by
 	s_name,
 	p_partkey
 limit 100
-Total cost: 10242.58, memory=12674
-PhysicLimit (100) (inccost=10242.58, cost=100, rows=100) (actual rows=0)
+Total cost: 8416.58, memory=7096
+PhysicLimit (100) (inccost=8416.58, cost=100, rows=100) (actual rows=0)
     Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
-    -> PhysicOrder  (inccost=10142.58, cost=1.58, rows=2, memory=486) (actual rows=0)
+    -> PhysicOrder  (inccost=8316.58, cost=1.58, rows=2, memory=486) (actual rows=0)
         Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
         Order by: s_acctbal[0], n_name[2], s_name[1], p_partkey[3]
-        -> PhysicFilter  (inccost=10141, cost=2, rows=2) (actual rows=0)
+        -> PhysicFilter  (inccost=8315, cost=2, rows=2) (actual rows=0)
             Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7]
             Filter: ps_supplycost[8]={min(ps_supplycost)}[9]
-            -> PhysicHashJoin Left (inccost=10139, cost=206, rows=2, memory=1004) (actual rows=0)
+            -> PhysicHashJoin Left (inccost=8313, cost=206, rows=2, memory=1004) (actual rows=0)
                 Output: s_acctbal[0],s_name[1],n_name[2],p_partkey[3],p_mfgr[4],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8],{min(ps_supplycost)}[9]
                 Filter: p_partkey[3]=ps_partkey[10]
-                -> PhysicGather Threads: 20 (inccost=4416, cost=20, rows=2) (actual rows=0)
+                -> PhysicGather Threads: 20 (inccost=4399, cost=4, rows=2) (actual rows=0)
                     Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
-                    -> PhysicHashJoin  (inccost=4396, cost=448, rows=2, memory=58) (actual rows=0, loops=10)
+                    -> PhysicHashJoin  (inccost=4395, cost=448, rows=2, memory=58) (actual rows=0, loops=10)
                         Output: s_acctbal[2],s_name[3],n_name[4],p_partkey[0],p_mfgr[1],s_address[5],s_phone[6],s_comment[7],ps_supplycost[8]
                         Filter: p_partkey[0]=ps_partkey[9]
-                        -> PhysicBroadcast  (inccost=202, cost=2, rows=1) (actual rows=0, loops=10)
+                        -> PhysicBroadcast  (inccost=201, cost=1, rows=1) (actual rows=0, loops=10)
                             Output: p_partkey[0],p_mfgr[2]
                             -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0, loops=10)
                                 Output: p_partkey[0],p_mfgr[2]
@@ -75,42 +75,38 @@ PhysicLimit (100) (inccost=10242.58, cost=100, rows=100) (actual rows=0)
                                     Filter: r_name[1]='EUROPE'
                                 -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=0)
                                     Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                            -> PhysicHashJoin  (inccost=2430, cost=1620, rows=800, memory=3940) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=2430, cost=1620, rows=800, memory=394) (actual rows=0)
                                 Output: s_acctbal[0],s_name[1],s_address[2],s_phone[3],s_comment[4],ps_supplycost[7],ps_partkey[8],s_nationkey[5]
                                 Filter: s_suppkey[6]=ps_suppkey[9]
                                 -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=0)
                                     Output: s_acctbal[5],s_name[1],s_address[2],s_phone[4],s_comment[6],s_nationkey[3],s_suppkey[0]
                                 -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
                                     Output: ps_supplycost[3],ps_partkey[0],ps_suppkey[1]
-                -> PhysicHashAgg  (inccost=5517, cost=600, rows=200, memory=2000) (actual rows=0)
-                    Output: {min({min(ps_supplycost)})}[1],{ps_partkey}[0]
-                    Aggregates: min({min(ps_supplycost)}[1])
+                -> PhysicHashAgg  (inccost=3708, cost=800, rows=200, memory=4800) (actual rows=0)
+                    Output: {min(ps_supplycost)}[1],{ps_partkey}[0]
+                    Aggregates: min(ps_supplycost[1])
                     Group by: ps_partkey[0]
-                    -> PhysicGather Threads: 20 (inccost=4917, cost=2000, rows=200) (actual rows=0)
-                        Output: {ps_partkey}[0],{min(ps_supplycost)}[1]
-                        -> PhysicHashAgg  (inccost=2917, cost=800, rows=200, memory=4800) (actual rows=7, loops=10)
-                            Output: {ps_partkey}[0],{min(ps_supplycost)}[1]
-                            Aggregates: min(ps_supplycost[1])
-                            Group by: ps_partkey[0]
-                            -> PhysicHashJoin  (inccost=2117, cost=1210, rows=400, memory=40) (actual rows=8, loops=10)
-                                Output: ps_partkey[1],ps_supplycost[2]
-                                Filter: s_suppkey[0]=ps_suppkey[3]
-                                -> PhysicRedistribute  (inccost=107, cost=10, rows=5) (actual rows=0, loops=10)
-                                    Output: s_suppkey[0]
-                                    -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=40) (actual rows=0, loops=10)
-                                        Output: s_suppkey[1]
-                                        Filter: s_nationkey[2]=n_nationkey[0]
-                                        -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
-                                            Output: n_nationkey[1]
-                                            Filter: n_regionkey[2]=r_regionkey[0]
-                                            -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
-                                                Output: r_regionkey[0]
-                                                Filter: r_name[1]='EUROPE'
-                                            -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
-                                                Output: n_nationkey[0],n_regionkey[2]
-                                        -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
-                                            Output: s_suppkey[0],s_nationkey[3]
-                                -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=80)
-                                    Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
+                    -> PhysicGather Threads: 20 (inccost=2908, cost=800, rows=400) (actual rows=0)
+                        Output: ps_partkey[1],ps_supplycost[2]
+                        -> PhysicHashJoin  (inccost=2108, cost=1210, rows=400, memory=8) (actual rows=8, loops=10)
+                            Output: ps_partkey[1],ps_supplycost[2]
+                            Filter: s_suppkey[0]=ps_suppkey[3]
+                            -> PhysicRedistribute  (inccost=98, cost=1, rows=5) (actual rows=0, loops=10)
+                                Output: s_suppkey[0]
+                                -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=40) (actual rows=0, loops=10)
+                                    Output: s_suppkey[1]
+                                    Filter: s_nationkey[2]=n_nationkey[0]
+                                    -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
+                                        Output: n_nationkey[1]
+                                        Filter: n_regionkey[2]=r_regionkey[0]
+                                        -> PhysicScanTable region as region__1 (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
+                                            Output: r_regionkey[0]
+                                            Filter: r_name[1]='EUROPE'
+                                        -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
+                                            Output: n_nationkey[0],n_regionkey[2]
+                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                        Output: s_suppkey[0],s_nationkey[3]
+                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=80)
+                                Output: ps_partkey[0],ps_supplycost[3],ps_suppkey[1]
 
 

--- a/test/regress/expect/tpch0001_d/q03.txt
+++ b/test/regress/expect/tpch0001_d/q03.txt
@@ -21,33 +21,33 @@ order by
 	revenue desc,
 	o_orderdate
 limit 10
-Total cost: 21225.9, memory=36360
-PhysicLimit (10) (inccost=21225.9, cost=10, rows=10) (actual rows=8)
+Total cost: 14685.9, memory=36360
+PhysicLimit (10) (inccost=14685.9, cost=10, rows=10) (actual rows=8)
     Output: l_orderkey[0],{sum(l_extendedprice*(1-l_discount))}[1],o_orderdate[2],o_shippriority[3]
-    -> PhysicOrder  (inccost=21215.9, cost=2851.9, rows=458, memory=10992) (actual rows=8)
+    -> PhysicOrder  (inccost=14675.9, cost=2851.9, rows=458, memory=10992) (actual rows=8)
         Output: l_orderkey[0],{sum(l_extendedprice*(1-l_discount))}[1],o_orderdate[2],o_shippriority[3]
         Order by: {sum(l_extendedprice*(1-l_discount))}[1], o_orderdate[2]
-        -> PhysicHashAgg  (inccost=18364, cost=1374, rows=458, memory=21984) (actual rows=8)
+        -> PhysicHashAgg  (inccost=11824, cost=962, rows=458, memory=21984) (actual rows=8)
             Output: {l_orderkey}[0],{sum(l_extendedprice*(1-l_discount))}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*(1-l_discount[7]))
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicGather Threads: 20 (inccost=16990, cost=916, rows=458) (actual rows=14)
+            -> PhysicGather Threads: 20 (inccost=10862, cost=504, rows=458) (actual rows=14)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*(1-l_discount)}[5],l_extendedprice[6],{(1-l_discount)}[7],{1}[0],l_discount[8]
-                -> PhysicHashJoin  (inccost=16074, cost=2096, rows=458, memory=464) (actual rows=1, loops=10)
+                -> PhysicHashJoin  (inccost=10358, cost=622, rows=46, memory=464) (actual rows=1, loops=10)
                     Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*(1-l_discount)}[5],l_extendedprice[6],{(1-l_discount)}[7],{1}[0],l_discount[8]
                     Filter: c_custkey[1]=o_custkey[9]
                     -> PhysicBroadcast  (inccost=179, cost=29, rows=29) (actual rows=29, loops=10)
                         Output: 1,c_custkey[0]
-                        -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=2, loops=10)
+                        -> PhysicScanTable customer (inccost=150, cost=150, rows=3) (actual rows=2, loops=10)
                             Output: 1,c_custkey[0]
                             Filter: c_mktsegment[6]='BUILDING'
-                    -> PhysicHashJoin  (inccost=13799, cost=6294, rows=1580, memory=2920) (actual rows=13, loops=10)
+                    -> PhysicHashJoin  (inccost=9557, cost=2052, rows=1580, memory=2920) (actual rows=13, loops=10)
                         Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*(1-l_discount)}[5],l_extendedprice[6],{(1-l_discount)}[7],l_discount[8],o_custkey[2]
                         Filter: l_orderkey[4]=o_orderkey[3]
-                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=727) (actual rows=72, loops=10)
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=73) (actual rows=72, loops=10)
                             Output: o_orderdate[4],o_shippriority[7],o_custkey[1],o_orderkey[0]
                             Filter: o_orderdate[4]<'1995-03-15'
-                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=3260) (actual rows=325, loops=10)
+                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=326) (actual rows=325, loops=10)
                             Output: l_orderkey[0],l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),l_discount[6]
                             Filter: l_shipdate[10]>'1995-03-15'
 1637,164224.9253,2/8/1995 12:00:00 AM,0

--- a/test/regress/expect/tpch0001_d/q03.txt
+++ b/test/regress/expect/tpch0001_d/q03.txt
@@ -21,27 +21,27 @@ order by
 	revenue desc,
 	o_orderdate
 limit 10
-Total cost: 24918.9, memory=62520
-PhysicLimit (10) (inccost=24918.9, cost=10, rows=10) (actual rows=8)
+Total cost: 21225.9, memory=36360
+PhysicLimit (10) (inccost=21225.9, cost=10, rows=10) (actual rows=8)
     Output: l_orderkey[0],{sum(l_extendedprice*(1-l_discount))}[1],o_orderdate[2],o_shippriority[3]
-    -> PhysicOrder  (inccost=24908.9, cost=2851.9, rows=458, memory=10992) (actual rows=8)
+    -> PhysicOrder  (inccost=21215.9, cost=2851.9, rows=458, memory=10992) (actual rows=8)
         Output: l_orderkey[0],{sum(l_extendedprice*(1-l_discount))}[1],o_orderdate[2],o_shippriority[3]
         Order by: {sum(l_extendedprice*(1-l_discount))}[1], o_orderdate[2]
-        -> PhysicHashAgg  (inccost=22057, cost=1374, rows=458, memory=21984) (actual rows=8)
+        -> PhysicHashAgg  (inccost=18364, cost=1374, rows=458, memory=21984) (actual rows=8)
             Output: {l_orderkey}[0],{sum(l_extendedprice*(1-l_discount))}[3],{o_orderdate}[1],{o_shippriority}[2]
             Aggregates: sum(l_extendedprice[4]*(1-l_discount[7]))
             Group by: l_orderkey[0], o_orderdate[1], o_shippriority[2]
-            -> PhysicGather Threads: 20 (inccost=20683, cost=4580, rows=458) (actual rows=14)
+            -> PhysicGather Threads: 20 (inccost=16990, cost=916, rows=458) (actual rows=14)
                 Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*(1-l_discount)}[5],l_extendedprice[6],{(1-l_discount)}[7],{1}[0],l_discount[8]
-                -> PhysicHashJoin  (inccost=16103, cost=2096, rows=458, memory=464) (actual rows=1, loops=10)
+                -> PhysicHashJoin  (inccost=16074, cost=2096, rows=458, memory=464) (actual rows=1, loops=10)
                     Output: l_orderkey[2],o_orderdate[3],o_shippriority[4],{l_extendedprice*(1-l_discount)}[5],l_extendedprice[6],{(1-l_discount)}[7],{1}[0],l_discount[8]
                     Filter: c_custkey[1]=o_custkey[9]
-                    -> PhysicBroadcast  (inccost=208, cost=58, rows=29) (actual rows=29, loops=10)
+                    -> PhysicBroadcast  (inccost=179, cost=29, rows=29) (actual rows=29, loops=10)
                         Output: 1,c_custkey[0]
                         -> PhysicScanTable customer (inccost=150, cost=150, rows=29) (actual rows=2, loops=10)
                             Output: 1,c_custkey[0]
                             Filter: c_mktsegment[6]='BUILDING'
-                    -> PhysicHashJoin  (inccost=13799, cost=6294, rows=1580, memory=29080) (actual rows=13, loops=10)
+                    -> PhysicHashJoin  (inccost=13799, cost=6294, rows=1580, memory=2920) (actual rows=13, loops=10)
                         Output: l_orderkey[4],o_orderdate[0],o_shippriority[1],{l_extendedprice*(1-l_discount)}[5],l_extendedprice[6],{(1-l_discount)}[7],l_discount[8],o_custkey[2]
                         Filter: l_orderkey[4]=o_orderkey[3]
                         -> PhysicScanTable orders (inccost=1500, cost=1500, rows=727) (actual rows=72, loops=10)

--- a/test/regress/expect/tpch0001_d/q04.txt
+++ b/test/regress/expect/tpch0001_d/q04.txt
@@ -19,28 +19,28 @@ group by
 	o_orderpriority
 order by
 	o_orderpriority
-Total cost: 314268.54, memory=285
-PhysicOrder  (inccost=314268.54, cost=8.54, rows=5, memory=95) (actual rows=5)
+Total cost: 17404.54, memory=285
+PhysicOrder  (inccost=17404.54, cost=8.54, rows=5, memory=95) (actual rows=5)
     Output: o_orderpriority[0],{count(*)(0)}[1]
     Order by: o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=314260, cost=206, rows=5, memory=190) (actual rows=5)
+    -> PhysicHashAgg  (inccost=17396, cost=206, rows=5, memory=190) (actual rows=5)
         Output: {o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: o_orderpriority[0]
-        -> PhysicFilter  (inccost=314054, cost=196, rows=196) (actual rows=44)
+        -> PhysicFilter  (inccost=17190, cost=20, rows=196) (actual rows=44)
             Output: o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=313858, cost=294245, rows=196) (actual rows=48)
+            -> PhysicMarkJoin Left (inccost=17170, cost=3005, rows=20) (actual rows=48)
                 Output: #marker,o_orderpriority[0]
                 Filter: l_orderkey[2]=o_orderkey[1]
-                -> PhysicGather Threads: 10 (inccost=1598, cost=98, rows=49) (actual rows=48)
+                -> PhysicGather Threads: 10 (inccost=1554, cost=54, rows=49) (actual rows=48)
                     Output: o_orderpriority[5],o_orderkey[0]
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=49) (actual rows=4, loops=10)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=5) (actual rows=4, loops=10)
                         Output: o_orderpriority[5],o_orderkey[0]
                         Filter: (o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM')
-                -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=3752, loops=48)
+                -> PhysicGather Threads: 10 (inccost=12611, cost=6606, rows=6005) (actual rows=3752, loops=48)
                     Output: l_orderkey[0]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=375, loops=10)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=601) (actual rows=375, loops=10)
                         Output: l_orderkey[0]
                         Filter: l_commitdate[11]<l_receiptdate[12]
 1-URGENT,9

--- a/test/regress/expect/tpch0001_d/q04.txt
+++ b/test/regress/expect/tpch0001_d/q04.txt
@@ -19,26 +19,26 @@ group by
 	o_orderpriority
 order by
 	o_orderpriority
-Total cost: 362700.54, memory=285
-PhysicOrder  (inccost=362700.54, cost=8.54, rows=5, memory=95) (actual rows=5)
+Total cost: 314268.54, memory=285
+PhysicOrder  (inccost=314268.54, cost=8.54, rows=5, memory=95) (actual rows=5)
     Output: o_orderpriority[0],{count(*)(0)}[1]
     Order by: o_orderpriority[0]
-    -> PhysicHashAgg  (inccost=362692, cost=206, rows=5, memory=190) (actual rows=5)
+    -> PhysicHashAgg  (inccost=314260, cost=206, rows=5, memory=190) (actual rows=5)
         Output: {o_orderpriority}[0],{count(*)(0)}[1]
         Aggregates: count(*)(0)
         Group by: o_orderpriority[0]
-        -> PhysicFilter  (inccost=362486, cost=196, rows=196) (actual rows=44)
+        -> PhysicFilter  (inccost=314054, cost=196, rows=196) (actual rows=44)
             Output: o_orderpriority[1]
             Filter: {#marker}[0]
-            -> PhysicMarkJoin Left (inccost=362290, cost=294245, rows=196) (actual rows=48)
+            -> PhysicMarkJoin Left (inccost=313858, cost=294245, rows=196) (actual rows=48)
                 Output: #marker,o_orderpriority[0]
                 Filter: l_orderkey[2]=o_orderkey[1]
-                -> PhysicGather Threads: 10 (inccost=1990, cost=490, rows=49) (actual rows=48)
+                -> PhysicGather Threads: 10 (inccost=1598, cost=98, rows=49) (actual rows=48)
                     Output: o_orderpriority[5],o_orderkey[0]
                     -> PhysicScanTable orders (inccost=1500, cost=1500, rows=49) (actual rows=4, loops=10)
                         Output: o_orderpriority[5],o_orderkey[0]
                         Filter: (o_orderdate[4]>='1993-07-01' and o_orderdate[4]<'9/29/1993 12:00:00 AM')
-                -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=3752, loops=48)
+                -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=3752, loops=48)
                     Output: l_orderkey[0]
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=375, loops=10)
                         Output: l_orderkey[0]

--- a/test/regress/expect/tpch0001_d/q05.txt
+++ b/test/regress/expect/tpch0001_d/q05.txt
@@ -22,31 +22,29 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 18218.97, memory=11571
-PhysicOrder  (inccost=18218.97, cost=82.97, rows=25, memory=825) (actual rows=0)
+Total cost: 17817.97, memory=3831
+PhysicOrder  (inccost=17817.97, cost=82.97, rows=25, memory=825) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*(1-l_discount))}[1]
     Order by: {sum(l_extendedprice*(1-l_discount))}[1]
-    -> PhysicHashAgg  (inccost=18136, cost=75, rows=25, memory=1300) (actual rows=0)
-        Output: {n_name}[0],{sum({sum(l_extendedprice*(1-l_discount))})}[1]
-        Aggregates: sum({sum(l_extendedprice*(1-l_discount))}[1])
+    -> PhysicHashAgg  (inccost=17735, cost=132, rows=25, memory=1650) (actual rows=0)
+        Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
+        Aggregates: sum(l_extendedprice[2]*(1-l_discount[5]))
         Group by: n_name[0]
-        -> PhysicGather Threads: 30 (inccost=18061, cost=250, rows=25) (actual rows=0)
-            Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
-            -> PhysicHashAgg  (inccost=17811, cost=132, rows=25, memory=1650) (actual rows=0, loops=10)
-                Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
-                Aggregates: sum(l_extendedprice[2]*(1-l_discount[5]))
-                Group by: n_name[0]
-                -> PhysicHashJoin  (inccost=17679, cost=877, rows=82, memory=3600) (actual rows=0, loops=10)
-                    Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],{1}[0],l_discount[7]
-                    Filter: (c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9])
-                    -> PhysicBroadcast  (inccost=450, cost=300, rows=150) (actual rows=150, loops=10)
+        -> PhysicGather Threads: 40 (inccost=17603, cost=164, rows=82) (actual rows=0)
+            Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],1,l_discount[7]
+            -> PhysicHashJoin  (inccost=17439, cost=877, rows=82, memory=360) (actual rows=0, loops=10)
+                Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],1,l_discount[7]
+                Filter: (c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9])
+                -> PhysicRedistribute  (inccost=165, cost=15, rows=150) (actual rows=15, loops=10)
+                    Output: {1}[0],c_custkey[1],c_nationkey[2]
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
                         Output: 1,c_custkey[0],c_nationkey[3]
-                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
-                            Output: 1,c_custkey[0],c_nationkey[3]
-                    -> PhysicHashJoin  (inccost=16352, cost=1397, rows=495, memory=330) (actual rows=0, loops=10)
+                -> PhysicRedistribute  (inccost=16397, cost=50, rows=495) (actual rows=0, loops=10)
+                    Output: n_name[0],{l_extendedprice*(1-l_discount)}[1],l_extendedprice[2],{(1-l_discount)}[3],l_discount[4],o_custkey[5],s_nationkey[6]
+                    -> PhysicHashJoin  (inccost=16347, cost=1397, rows=495, memory=330) (actual rows=0, loops=10)
                         Output: n_name[0],{l_extendedprice*(1-l_discount)}[3],l_extendedprice[4],{(1-l_discount)}[5],l_discount[6],o_custkey[7],s_nationkey[1]
                         Filter: l_suppkey[8]=s_suppkey[2]
-                        -> PhysicBroadcast  (inccost=107, cost=10, rows=5) (actual rows=0, loops=10)
+                        -> PhysicBroadcast  (inccost=102, cost=5, rows=5) (actual rows=0, loops=10)
                             Output: n_name[0],s_nationkey[2],s_suppkey[3]
                             -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=290) (actual rows=0, loops=10)
                                 Output: n_name[0],s_nationkey[2],s_suppkey[3]
@@ -61,7 +59,7 @@ PhysicOrder  (inccost=18218.97, cost=82.97, rows=25, memory=825) (actual rows=0)
                                         Output: n_name[1],n_nationkey[0],n_regionkey[2]
                                 -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
                                     Output: s_nationkey[3],s_suppkey[0]
-                        -> PhysicHashJoin  (inccost=14848, cost=7343, rows=892, memory=3568) (actual rows=0)
+                        -> PhysicHashJoin  (inccost=14848, cost=7343, rows=892, memory=368) (actual rows=0)
                             Output: {l_extendedprice*(1-l_discount)}[2],l_extendedprice[3],{(1-l_discount)}[4],l_discount[5],o_custkey[0],l_suppkey[6]
                             Filter: l_orderkey[7]=o_orderkey[1]
                             -> PhysicScanTable orders (inccost=1500, cost=1500, rows=223) (actual rows=0)

--- a/test/regress/expect/tpch0001_d/q05.txt
+++ b/test/regress/expect/tpch0001_d/q05.txt
@@ -22,50 +22,50 @@ group by
 	n_name
 order by
 	revenue desc
-Total cost: 17817.97, memory=3831
-PhysicOrder  (inccost=17817.97, cost=82.97, rows=25, memory=825) (actual rows=0)
+Total cost: 10334.97, memory=3701
+PhysicOrder  (inccost=10334.97, cost=82.97, rows=25, memory=825) (actual rows=0)
     Output: n_name[0],{sum(l_extendedprice*(1-l_discount))}[1]
     Order by: {sum(l_extendedprice*(1-l_discount))}[1]
-    -> PhysicHashAgg  (inccost=17735, cost=132, rows=25, memory=1650) (actual rows=0)
+    -> PhysicHashAgg  (inccost=10252, cost=59, rows=25, memory=1650) (actual rows=0)
         Output: {n_name}[0],{sum(l_extendedprice*(1-l_discount))}[1]
         Aggregates: sum(l_extendedprice[2]*(1-l_discount[5]))
         Group by: n_name[0]
-        -> PhysicGather Threads: 40 (inccost=17603, cost=164, rows=82) (actual rows=0)
+        -> PhysicGather Threads: 40 (inccost=10193, cost=91, rows=82) (actual rows=0)
             Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],1,l_discount[7]
-            -> PhysicHashJoin  (inccost=17439, cost=877, rows=82, memory=360) (actual rows=0, loops=10)
+            -> PhysicHashJoin  (inccost=10102, cost=162, rows=9, memory=360) (actual rows=0, loops=10)
                 Output: n_name[3],{l_extendedprice*(1-l_discount)}[4],l_extendedprice[5],{(1-l_discount)}[6],1,l_discount[7]
                 Filter: (c_custkey[1]=o_custkey[8] and c_nationkey[2]=s_nationkey[9])
-                -> PhysicRedistribute  (inccost=165, cost=15, rows=150) (actual rows=15, loops=10)
+                -> PhysicRedistribute  (inccost=165, cost=15, rows=15) (actual rows=15, loops=10)
                     Output: {1}[0],c_custkey[1],c_nationkey[2]
-                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=15) (actual rows=15, loops=10)
                         Output: 1,c_custkey[0],c_nationkey[3]
-                -> PhysicRedistribute  (inccost=16397, cost=50, rows=495) (actual rows=0, loops=10)
+                -> PhysicRedistribute  (inccost=9775, cost=50, rows=50) (actual rows=0, loops=10)
                     Output: n_name[0],{l_extendedprice*(1-l_discount)}[1],l_extendedprice[2],{(1-l_discount)}[3],l_discount[4],o_custkey[5],s_nationkey[6]
-                    -> PhysicHashJoin  (inccost=16347, cost=1397, rows=495, memory=330) (actual rows=0, loops=10)
+                    -> PhysicHashJoin  (inccost=9725, cost=587, rows=495, memory=330) (actual rows=0, loops=10)
                         Output: n_name[0],{l_extendedprice*(1-l_discount)}[3],l_extendedprice[4],{(1-l_discount)}[5],l_discount[6],o_custkey[7],s_nationkey[1]
                         Filter: l_suppkey[8]=s_suppkey[2]
-                        -> PhysicBroadcast  (inccost=102, cost=5, rows=5) (actual rows=0, loops=10)
-                            Output: n_name[0],s_nationkey[2],s_suppkey[3]
-                            -> PhysicHashJoin  (inccost=97, cost=25, rows=5, memory=290) (actual rows=0, loops=10)
-                                Output: n_name[0],s_nationkey[2],s_suppkey[3]
-                                Filter: s_nationkey[2]=n_nationkey[1]
-                                -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
-                                    Output: n_name[1],n_nationkey[2]
-                                    Filter: n_regionkey[3]=r_regionkey[0]
-                                    -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
-                                        Output: r_regionkey[0]
-                                        Filter: r_name[1]='ASIA'
-                                    -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
-                                        Output: n_name[1],n_nationkey[0],n_regionkey[2]
-                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                        -> PhysicHashJoin  (inccost=94, cost=12, rows=5, memory=160) (actual rows=0, loops=10)
+                            Output: n_name[2],s_nationkey[0],s_suppkey[1]
+                            Filter: s_nationkey[0]=n_nationkey[3]
+                            -> PhysicBroadcast  (inccost=20, cost=10, rows=10) (actual rows=10, loops=10)
+                                Output: s_nationkey[3],s_suppkey[0]
+                                -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=1, loops=10)
                                     Output: s_nationkey[3],s_suppkey[0]
-                        -> PhysicHashJoin  (inccost=14848, cost=7343, rows=892, memory=368) (actual rows=0)
+                            -> PhysicHashJoin  (inccost=62, cost=32, rows=5, memory=8) (actual rows=5, loops=10)
+                                Output: n_name[1],n_nationkey[2]
+                                Filter: n_regionkey[3]=r_regionkey[0]
+                                -> PhysicScanTable region (inccost=5, cost=5, rows=1) (actual rows=1, loops=10)
+                                    Output: r_regionkey[0]
+                                    Filter: r_name[1]='ASIA'
+                                -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
+                                    Output: n_name[1],n_nationkey[0],n_regionkey[2]
+                        -> PhysicHashJoin  (inccost=9044, cost=1539, rows=892, memory=368) (actual rows=0)
                             Output: {l_extendedprice*(1-l_discount)}[2],l_extendedprice[3],{(1-l_discount)}[4],l_discount[5],o_custkey[0],l_suppkey[6]
                             Filter: l_orderkey[7]=o_orderkey[1]
-                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=223) (actual rows=0)
+                            -> PhysicScanTable orders (inccost=1500, cost=1500, rows=23) (actual rows=0)
                                 Output: o_custkey[1],o_orderkey[0]
                                 Filter: (o_orderdate[4]>='1994-01-01' and o_orderdate[4]<'1/1/1995 12:00:00 AM')
-                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=601) (actual rows=0)
                                 Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),l_discount[6],l_suppkey[2],l_orderkey[0]
 
 

--- a/test/regress/expect/tpch0001_d/q06.txt
+++ b/test/regress/expect/tpch0001_d/q06.txt
@@ -7,11 +7,11 @@ where
 	and l_shipdate < date '1994-01-01' + interval '1' year
 	and l_discount between .06 - 0.01  and .06 + 0.01
 	and l_quantity < 24
-Total cost: 6100, memory=18
-PhysicHashAgg  (inccost=6100, cost=3, rows=1, memory=2) (actual rows=1)
+Total cost: 6092, memory=18
+PhysicHashAgg  (inccost=6092, cost=3, rows=1, memory=2) (actual rows=1)
     Output: {sum({sum(l_extendedprice*l_discount)})}[0]
     Aggregates: sum({sum(l_extendedprice*l_discount)}[0])
-    -> PhysicGather Threads: 10 (inccost=6097, cost=10, rows=1) (actual rows=10)
+    -> PhysicGather Threads: 10 (inccost=6089, cost=2, rows=1) (actual rows=10)
         Output: {sum(l_extendedprice*l_discount)}[0]
         -> PhysicHashAgg  (inccost=6087, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
             Output: {sum(l_extendedprice*l_discount)}[0]

--- a/test/regress/expect/tpch0001_d/q06.txt
+++ b/test/regress/expect/tpch0001_d/q06.txt
@@ -7,16 +7,16 @@ where
 	and l_shipdate < date '1994-01-01' + interval '1' year
 	and l_discount between .06 - 0.01  and .06 + 0.01
 	and l_quantity < 24
-Total cost: 6092, memory=18
-PhysicHashAgg  (inccost=6092, cost=3, rows=1, memory=2) (actual rows=1)
+Total cost: 6020, memory=18
+PhysicHashAgg  (inccost=6020, cost=3, rows=1, memory=2) (actual rows=1)
     Output: {sum({sum(l_extendedprice*l_discount)})}[0]
     Aggregates: sum({sum(l_extendedprice*l_discount)}[0])
-    -> PhysicGather Threads: 10 (inccost=6089, cost=2, rows=1) (actual rows=10)
+    -> PhysicGather Threads: 10 (inccost=6017, cost=2, rows=1) (actual rows=10)
         Output: {sum(l_extendedprice*l_discount)}[0]
-        -> PhysicHashAgg  (inccost=6087, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
+        -> PhysicHashAgg  (inccost=6015, cost=10, rows=1, memory=16) (actual rows=1, loops=10)
             Output: {sum(l_extendedprice*l_discount)}[0]
             Aggregates: sum(l_extendedprice[1]*l_discount[2])
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=80) (actual rows=7, loops=10)
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=8) (actual rows=7, loops=10)
                 Output: l_extendedprice[5]*l_discount[6],l_extendedprice[5],l_discount[6]
                 Filter: ((((l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM') and l_discount[6]>=0.05) and l_discount[6]<=0.07) and l_quantity[4]<24)
 48090.8586

--- a/test/regress/expect/tpch0001_d/q10.txt
+++ b/test/regress/expect/tpch0001_d/q10.txt
@@ -30,29 +30,29 @@ group by
 order by
 	revenue desc
 limit 20
-Total cost: 11713.83, memory=74656
-PhysicLimit (20) (inccost=11713.83, cost=20, rows=20) (actual rows=20)
+Total cost: 10852.83, memory=69784
+PhysicLimit (20) (inccost=10852.83, cost=20, rows=20) (actual rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*(1-l_discount))}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=11693.83, cost=430.83, rows=93, memory=22506) (actual rows=20)
+    -> PhysicOrder  (inccost=10832.83, cost=430.83, rows=93, memory=22506) (actual rows=20)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*(1-l_discount))}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*(1-l_discount))}[2]
-        -> PhysicHashAgg  (inccost=11263, cost=279, rows=93, memory=45012) (actual rows=43)
+        -> PhysicHashAgg  (inccost=10402, cost=279, rows=93, memory=45012) (actual rows=43)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*(1-l_discount))}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*(1-l_discount[11]))
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicGather Threads: 20 (inccost=10984, cost=930, rows=93) (actual rows=140)
+            -> PhysicGather Threads: 20 (inccost=10123, cost=186, rows=93) (actual rows=140)
                 Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*(1-l_discount)}[9],l_extendedprice[10],{(1-l_discount)}[11],{1}[1],l_discount[12]
-                -> PhysicHashJoin  (inccost=10054, cost=236, rows=93, memory=1650) (actual rows=14, loops=10)
+                -> PhysicHashJoin  (inccost=9937, cost=236, rows=93, memory=1650) (actual rows=14, loops=10)
                     Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*(1-l_discount)}[9],l_extendedprice[10],{(1-l_discount)}[11],{1}[1],l_discount[12]
                     Filter: c_nationkey[13]=n_nationkey[2]
                     -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
                         Output: n_name[1],1,n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=9793, cost=367, rows=93, memory=4464) (actual rows=14, loops=10)
+                    -> PhysicHashJoin  (inccost=9676, cost=367, rows=93, memory=504) (actual rows=14, loops=10)
                         Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*(1-l_discount)}[0],l_extendedprice[1],{(1-l_discount)}[2],l_discount[3],c_nationkey[11]
                         Filter: c_custkey[5]=o_custkey[4]
-                        -> PhysicRedistribute  (inccost=9276, cost=124, rows=62) (actual rows=14, loops=10)
+                        -> PhysicRedistribute  (inccost=9159, cost=7, rows=62) (actual rows=14, loops=10)
                             Output: {l_extendedprice*(1-l_discount)}[0],l_extendedprice[1],{(1-l_discount)}[2],l_discount[3],o_custkey[4]
-                            -> PhysicHashJoin  (inccost=9152, cost=1647, rows=62, memory=1024) (actual rows=14, loops=10)
+                            -> PhysicHashJoin  (inccost=9152, cost=1647, rows=62, memory=112) (actual rows=14, loops=10)
                                 Output: {l_extendedprice*(1-l_discount)}[2],l_extendedprice[3],{(1-l_discount)}[4],l_discount[5],o_custkey[0]
                                 Filter: l_orderkey[6]=o_orderkey[1]
                                 -> PhysicScanTable orders (inccost=1500, cost=1500, rows=64) (actual rows=6, loops=10)

--- a/test/regress/expect/tpch0001_d/q10.txt
+++ b/test/regress/expect/tpch0001_d/q10.txt
@@ -30,38 +30,38 @@ group by
 order by
 	revenue desc
 limit 20
-Total cost: 10852.83, memory=69784
-PhysicLimit (20) (inccost=10852.83, cost=20, rows=20) (actual rows=20)
+Total cost: 8933.83, memory=69784
+PhysicLimit (20) (inccost=8933.83, cost=20, rows=20) (actual rows=20)
     Output: c_custkey[0],c_name[1],{sum(l_extendedprice*(1-l_discount))}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
-    -> PhysicOrder  (inccost=10832.83, cost=430.83, rows=93, memory=22506) (actual rows=20)
+    -> PhysicOrder  (inccost=8913.83, cost=430.83, rows=93, memory=22506) (actual rows=20)
         Output: c_custkey[0],c_name[1],{sum(l_extendedprice*(1-l_discount))}[2],c_acctbal[3],n_name[4],c_address[5],c_phone[6],c_comment[7]
         Order by: {sum(l_extendedprice*(1-l_discount))}[2]
-        -> PhysicHashAgg  (inccost=10402, cost=279, rows=93, memory=45012) (actual rows=43)
+        -> PhysicHashAgg  (inccost=8483, cost=196, rows=93, memory=45012) (actual rows=43)
             Output: {c_custkey}[0],{c_name}[1],{sum(l_extendedprice*(1-l_discount))}[7],{c_acctbal}[2],{n_name}[4],{c_address}[5],{c_phone}[3],{c_comment}[6]
             Aggregates: sum(l_extendedprice[8]*(1-l_discount[11]))
             Group by: c_custkey[0], c_name[1], c_acctbal[2], c_phone[5], n_name[3], c_address[4], c_comment[6]
-            -> PhysicGather Threads: 20 (inccost=10123, cost=186, rows=93) (actual rows=140)
+            -> PhysicGather Threads: 20 (inccost=8287, cost=103, rows=93) (actual rows=140)
                 Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*(1-l_discount)}[9],l_extendedprice[10],{(1-l_discount)}[11],{1}[1],l_discount[12]
-                -> PhysicHashJoin  (inccost=9937, cost=236, rows=93, memory=1650) (actual rows=14, loops=10)
+                -> PhysicHashJoin  (inccost=8184, cost=153, rows=93, memory=1650) (actual rows=14, loops=10)
                     Output: c_custkey[3],c_name[4],c_acctbal[5],n_name[0],c_address[6],c_phone[7],c_comment[8],{l_extendedprice*(1-l_discount)}[9],l_extendedprice[10],{(1-l_discount)}[11],{1}[1],l_discount[12]
                     Filter: c_nationkey[13]=n_nationkey[2]
                     -> PhysicScanTable nation (inccost=25, cost=25, rows=25) (actual rows=25, loops=10)
                         Output: n_name[1],1,n_nationkey[0]
-                    -> PhysicHashJoin  (inccost=9676, cost=367, rows=93, memory=504) (actual rows=14, loops=10)
+                    -> PhysicHashJoin  (inccost=8006, cost=122, rows=10, memory=504) (actual rows=14, loops=10)
                         Output: c_custkey[5],c_name[6],c_acctbal[7],c_address[8],c_phone[9],c_comment[10],{l_extendedprice*(1-l_discount)}[0],l_extendedprice[1],{(1-l_discount)}[2],l_discount[3],c_nationkey[11]
                         Filter: c_custkey[5]=o_custkey[4]
-                        -> PhysicRedistribute  (inccost=9159, cost=7, rows=62) (actual rows=14, loops=10)
+                        -> PhysicRedistribute  (inccost=7734, cost=7, rows=7) (actual rows=14, loops=10)
                             Output: {l_extendedprice*(1-l_discount)}[0],l_extendedprice[1],{(1-l_discount)}[2],l_discount[3],o_custkey[4]
-                            -> PhysicHashJoin  (inccost=9152, cost=1647, rows=62, memory=112) (actual rows=14, loops=10)
+                            -> PhysicHashJoin  (inccost=7727, cost=222, rows=62, memory=112) (actual rows=14, loops=10)
                                 Output: {l_extendedprice*(1-l_discount)}[2],l_extendedprice[3],{(1-l_discount)}[4],l_discount[5],o_custkey[0]
                                 Filter: l_orderkey[6]=o_orderkey[1]
-                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=64) (actual rows=6, loops=10)
+                                -> PhysicScanTable orders (inccost=1500, cost=1500, rows=7) (actual rows=6, loops=10)
                                     Output: o_custkey[1],o_orderkey[0]
                                     Filter: (o_orderdate[4]>='1993-10-01' and o_orderdate[4]<'12/30/1993 12:00:00 AM')
-                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=1457) (actual rows=145, loops=10)
+                                -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=146) (actual rows=145, loops=10)
                                     Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),l_discount[6],l_orderkey[0]
                                     Filter: l_returnflag[8]='R'
-                        -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=9)
+                        -> PhysicScanTable customer (inccost=150, cost=150, rows=15) (actual rows=15, loops=9)
                             Output: c_custkey[0],c_name[1],c_acctbal[5],c_address[2],c_phone[4],c_comment[7],c_nationkey[3]
 121,Customer#000000121,282635.1719,6428.32,PERU,tv nCR2YKupGN73mQudO,27-411-990-2959,uriously stealthy ideas. carefully final courts use carefully
 124,Customer#000000124,222182.5188,1842.49,CHINA,aTbyVAW5tCd,v09O,28-183-750-7809,le fluffily even dependencies. quietly s

--- a/test/regress/expect/tpch0001_d/q11.txt
+++ b/test/regress/expect/tpch0001_d/q11.txt
@@ -25,28 +25,28 @@ group by
 		)
 order by
 	value desc
-Total cost: 3130.56, memory=2896
-PhysicOrder  (inccost=3130.56, cost=358.56, rows=80, memory=960) (actual rows=0)
+Total cost: 2489.56, memory=2896
+PhysicOrder  (inccost=2489.56, cost=358.56, rows=80, memory=960) (actual rows=0)
     Output: ps_partkey[0],{sum(ps_supplycost*ps_availqty)}[1]
     Order by: {sum(ps_supplycost*ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=2772, cost=240, rows=80, memory=1920) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2131, cost=240, rows=80, memory=1920) (actual rows=0)
         Output: {ps_partkey}[0],{sum(ps_supplycost*ps_availqty)}[1]
         Aggregates: sum(ps_supplycost[2]*ps_availqty[3])
         Group by: ps_partkey[0]
         Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=1827, cost=3, rows=1, memory=16) (actual rows=0)
+            -> PhysicHashAgg  (inccost=1818, cost=3, rows=1, memory=16) (actual rows=0)
                 Output: {sum({sum(ps_supplycost*ps_availqty)})}[0]*0.0001
                 Aggregates: sum({sum(ps_supplycost*ps_availqty)}[0])
-                -> PhysicGather Threads: 20 (inccost=1824, cost=10, rows=1) (actual rows=0)
+                -> PhysicGather Threads: 20 (inccost=1815, cost=2, rows=1) (actual rows=0)
                     Output: {sum(ps_supplycost*ps_availqty)}[0]
-                    -> PhysicHashAgg  (inccost=1814, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
+                    -> PhysicHashAgg  (inccost=1813, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
                         Output: {sum(ps_supplycost*ps_availqty)}[0]
                         Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                        -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
+                        -> PhysicHashJoin  (inccost=1731, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
                             Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
                             Filter: ps_suppkey[4]=s_suppkey[0]
-                            -> PhysicRedistribute  (inccost=50, cost=2, rows=1) (actual rows=0, loops=10)
+                            -> PhysicRedistribute  (inccost=49, cost=1, rows=1) (actual rows=0, loops=10)
                                 Output: s_suppkey[0]
                                 -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
                                     Output: s_suppkey[1]
@@ -58,12 +58,12 @@ PhysicOrder  (inccost=3130.56, cost=358.56, rows=80, memory=960) (actual rows=0)
                                         Output: s_suppkey[0],s_nationkey[3]
                             -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
                                 Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-        -> PhysicGather Threads: 20 (inccost=2532, cost=800, rows=80) (actual rows=0)
+        -> PhysicGather Threads: 20 (inccost=1891, cost=160, rows=80) (actual rows=0)
             Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
-            -> PhysicHashJoin  (inccost=1732, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
+            -> PhysicHashJoin  (inccost=1731, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
                 Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
                 Filter: ps_suppkey[5]=s_suppkey[0]
-                -> PhysicRedistribute  (inccost=50, cost=2, rows=1) (actual rows=0, loops=10)
+                -> PhysicRedistribute  (inccost=49, cost=1, rows=1) (actual rows=0, loops=10)
                     Output: s_suppkey[0]
                     -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
                         Output: s_suppkey[1]

--- a/test/regress/expect/tpch0001_d/q11.txt
+++ b/test/regress/expect/tpch0001_d/q11.txt
@@ -25,55 +25,55 @@ group by
 		)
 order by
 	value desc
-Total cost: 2489.56, memory=2896
-PhysicOrder  (inccost=2489.56, cost=358.56, rows=80, memory=960) (actual rows=0)
+Total cost: 1616.56, memory=2896
+PhysicOrder  (inccost=1616.56, cost=358.56, rows=80, memory=960) (actual rows=0)
     Output: ps_partkey[0],{sum(ps_supplycost*ps_availqty)}[1]
     Order by: {sum(ps_supplycost*ps_availqty)}[1]
-    -> PhysicHashAgg  (inccost=2131, cost=240, rows=80, memory=1920) (actual rows=0)
+    -> PhysicHashAgg  (inccost=1258, cost=168, rows=80, memory=1920) (actual rows=0)
         Output: {ps_partkey}[0],{sum(ps_supplycost*ps_availqty)}[1]
         Aggregates: sum(ps_supplycost[2]*ps_availqty[3])
         Group by: ps_partkey[0]
         Filter: {sum(ps_supplycost*ps_availqty)}[1]>@1
         <ScalarSubqueryExpr> cached 1
-            -> PhysicHashAgg  (inccost=1818, cost=3, rows=1, memory=16) (actual rows=0)
+            -> PhysicHashAgg  (inccost=1017, cost=3, rows=1, memory=16) (actual rows=0)
                 Output: {sum({sum(ps_supplycost*ps_availqty)})}[0]*0.0001
                 Aggregates: sum({sum(ps_supplycost*ps_availqty)}[0])
-                -> PhysicGather Threads: 20 (inccost=1815, cost=2, rows=1) (actual rows=0)
+                -> PhysicGather Threads: 20 (inccost=1014, cost=2, rows=1) (actual rows=0)
                     Output: {sum(ps_supplycost*ps_availqty)}[0]
-                    -> PhysicHashAgg  (inccost=1813, cost=82, rows=1, memory=16) (actual rows=1, loops=10)
+                    -> PhysicHashAgg  (inccost=1012, cost=10, rows=1, memory=16) (actual rows=1, loops=10)
                         Output: {sum(ps_supplycost*ps_availqty)}[0]
                         Aggregates: sum(ps_supplycost[1]*ps_availqty[2])
-                        -> PhysicHashJoin  (inccost=1731, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
+                        -> PhysicHashJoin  (inccost=1002, cost=162, rows=80, memory=8) (actual rows=0, loops=10)
                             Output: {ps_supplycost*ps_availqty}[1],ps_supplycost[2],ps_availqty[3]
                             Filter: ps_suppkey[4]=s_suppkey[0]
-                            -> PhysicRedistribute  (inccost=49, cost=1, rows=1) (actual rows=0, loops=10)
+                            -> PhysicRedistribute  (inccost=40, cost=1, rows=1) (actual rows=0, loops=10)
                                 Output: s_suppkey[0]
-                                -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
+                                -> PhysicHashJoin  (inccost=39, cost=4, rows=1, memory=8) (actual rows=0, loops=10)
                                     Output: s_suppkey[1]
                                     Filter: s_nationkey[2]=n_nationkey[0]
                                     -> PhysicScanTable nation as nation__1 (inccost=25, cost=25, rows=1) (actual rows=1, loops=10)
                                         Output: n_nationkey[0]
                                         Filter: n_name[1]='GERMANY'
-                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                    -> PhysicScanTable supplier as supplier__1 (inccost=10, cost=10, rows=1) (actual rows=1, loops=10)
                                         Output: s_suppkey[0],s_nationkey[3]
-                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=800) (actual rows=0)
+                            -> PhysicScanTable partsupp as partsupp__1 (inccost=800, cost=800, rows=80) (actual rows=0)
                                 Output: ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
-        -> PhysicGather Threads: 20 (inccost=1891, cost=160, rows=80) (actual rows=0)
+        -> PhysicGather Threads: 20 (inccost=1090, cost=88, rows=80) (actual rows=0)
             Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
-            -> PhysicHashJoin  (inccost=1731, cost=882, rows=80, memory=8) (actual rows=0, loops=10)
+            -> PhysicHashJoin  (inccost=1002, cost=162, rows=80, memory=8) (actual rows=0, loops=10)
                 Output: ps_partkey[1],{ps_supplycost*ps_availqty}[2],ps_supplycost[3],ps_availqty[4]
                 Filter: ps_suppkey[5]=s_suppkey[0]
-                -> PhysicRedistribute  (inccost=49, cost=1, rows=1) (actual rows=0, loops=10)
+                -> PhysicRedistribute  (inccost=40, cost=1, rows=1) (actual rows=0, loops=10)
                     Output: s_suppkey[0]
-                    -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
+                    -> PhysicHashJoin  (inccost=39, cost=4, rows=1, memory=8) (actual rows=0, loops=10)
                         Output: s_suppkey[1]
                         Filter: s_nationkey[2]=n_nationkey[0]
                         -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1, loops=10)
                             Output: n_nationkey[0]
                             Filter: n_name[1]='GERMANY'
-                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                        -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=1, loops=10)
                             Output: s_suppkey[0],s_nationkey[3]
-                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0)
+                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=80) (actual rows=0)
                     Output: ps_partkey[0],ps_supplycost[3]*ps_availqty[2],ps_supplycost[3],ps_availqty[2],ps_suppkey[1]
 
 

--- a/test/regress/expect/tpch0001_d/q12.txt
+++ b/test/regress/expect/tpch0001_d/q12.txt
@@ -26,21 +26,21 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 10136.32, memory=20786
-PhysicOrder  (inccost=10136.32, cost=14.32, rows=7, memory=126) (actual rows=2)
+Total cost: 10080.32, memory=2626
+PhysicOrder  (inccost=10080.32, cost=14.32, rows=7, memory=126) (actual rows=2)
     Output: l_shipmode[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=10122, cost=21, rows=7, memory=168) (actual rows=2)
+    -> PhysicHashAgg  (inccost=10066, cost=21, rows=7, memory=168) (actual rows=2)
         Output: {l_shipmode}[0],{sum({sum(case with 0|1|1)})}[1],{sum({sum(case with 0|1|1)})}[2]
         Aggregates: sum({sum(case with 0|1|1)}[1]), sum({sum(case with 0|1|1)}[2])
         Group by: l_shipmode[0]
-        -> PhysicGather Threads: 10 (inccost=10101, cost=70, rows=7) (actual rows=16)
+        -> PhysicGather Threads: 10 (inccost=10045, cost=14, rows=7) (actual rows=16)
             Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
             -> PhysicHashAgg  (inccost=10031, cost=267, rows=7, memory=252) (actual rows=1, loops=10)
                 Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
                 Aggregates: sum(case with 0|1|1), sum(case with 0|1|1)
                 Group by: l_shipmode[0]
-                -> PhysicHashJoin  (inccost=9764, cost=2259, rows=253, memory=20240) (actual rows=2, loops=10)
+                -> PhysicHashJoin  (inccost=9764, cost=2259, rows=253, memory=2080) (actual rows=2, loops=10)
                     Output: l_shipmode[0],{case with 0|1|1}[6],{(o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH')}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 0|1|1}[11],{(o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH')}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
                     Filter: o_orderkey[15]=l_orderkey[5]
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=253) (actual rows=2, loops=10)

--- a/test/regress/expect/tpch0001_d/q12.txt
+++ b/test/regress/expect/tpch0001_d/q12.txt
@@ -26,27 +26,27 @@ group by
 	l_shipmode
 order by
 	l_shipmode
-Total cost: 10080.32, memory=2626
-PhysicOrder  (inccost=10080.32, cost=14.32, rows=7, memory=126) (actual rows=2)
+Total cost: 8037.32, memory=2410
+PhysicOrder  (inccost=8037.32, cost=14.32, rows=7, memory=126) (actual rows=2)
     Output: l_shipmode[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
     Order by: l_shipmode[0]
-    -> PhysicHashAgg  (inccost=10066, cost=21, rows=7, memory=168) (actual rows=2)
+    -> PhysicHashAgg  (inccost=8023, cost=15, rows=7, memory=168) (actual rows=2)
         Output: {l_shipmode}[0],{sum({sum(case with 0|1|1)})}[1],{sum({sum(case with 0|1|1)})}[2]
         Aggregates: sum({sum(case with 0|1|1)}[1]), sum({sum(case with 0|1|1)}[2])
         Group by: l_shipmode[0]
-        -> PhysicGather Threads: 10 (inccost=10045, cost=14, rows=7) (actual rows=16)
+        -> PhysicGather Threads: 10 (inccost=8008, cost=8, rows=7) (actual rows=16)
             Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
-            -> PhysicHashAgg  (inccost=10031, cost=267, rows=7, memory=252) (actual rows=1, loops=10)
+            -> PhysicHashAgg  (inccost=8000, cost=40, rows=1, memory=36) (actual rows=1, loops=10)
                 Output: {l_shipmode}[0],{sum(case with 0|1|1)}[1],{sum(case with 0|1|1)}[2]
                 Aggregates: sum(case with 0|1|1), sum(case with 0|1|1)
                 Group by: l_shipmode[0]
-                -> PhysicHashJoin  (inccost=9764, cost=2259, rows=253, memory=2080) (actual rows=2, loops=10)
+                -> PhysicHashJoin  (inccost=7960, cost=455, rows=253, memory=2080) (actual rows=2, loops=10)
                     Output: l_shipmode[0],{case with 0|1|1}[6],{(o_orderpriority='1-URGENT' or o_orderpriority='2-HIGH')}[7],{o_orderpriority='1-URGENT'}[8],o_orderpriority[9],{'1-URGENT'}[1],{o_orderpriority='2-HIGH'}[10],{'2-HIGH'}[2],{1}[3],{0}[4],{case with 0|1|1}[11],{(o_orderpriority<>'1-URGENT' and o_orderpriority<>'2-HIGH')}[12],{o_orderpriority<>'1-URGENT'}[13],{o_orderpriority<>'2-HIGH'}[14]
                     Filter: o_orderkey[15]=l_orderkey[5]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=253) (actual rows=2, loops=10)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=26) (actual rows=2, loops=10)
                         Output: l_shipmode[14],'1-URGENT','2-HIGH',1,0,l_orderkey[0]
                         Filter: ((((l_shipmode[14] in ('MAIL','SHIP') and l_commitdate[11]<l_receiptdate[12]) and l_shipdate[10]<l_commitdate[11]) and l_receiptdate[12]>='1994-01-01') and l_receiptdate[12]<'1/1/1995 12:00:00 AM')
-                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=150, loops=10)
+                    -> PhysicScanTable orders (inccost=1500, cost=1500, rows=150) (actual rows=150, loops=10)
                         Output: case with 0|1|1,(o_orderpriority[5]='1-URGENT' or o_orderpriority[5]='2-HIGH'),o_orderpriority[5]='1-URGENT',o_orderpriority[5],o_orderpriority[5]='2-HIGH',case with 0|1|1,(o_orderpriority[5]<>'1-URGENT' and o_orderpriority[5]<>'2-HIGH'),o_orderpriority[5]<>'1-URGENT',o_orderpriority[5]<>'2-HIGH',o_orderkey[0]
 MAIL,5,5
 SHIP,5,10

--- a/test/regress/expect/tpch0001_d/q14.txt
+++ b/test/regress/expect/tpch0001_d/q14.txt
@@ -11,19 +11,19 @@ where
 	l_partkey = p_partkey
 	and l_shipdate >= date '1995-09-01'
 	and l_shipdate < date '1995-09-01' + interval '1' month
-Total cost: 6888, memory=8160
-PhysicHashAgg  (inccost=6888, cost=3, rows=1, memory=16) (actual rows=1)
+Total cost: 6732, memory=880
+PhysicHashAgg  (inccost=6732, cost=3, rows=1, memory=16) (actual rows=1)
     Output: {sum({sum(case with 0|1|1)})}[0]*100/{sum({sum(l_extendedprice*(1-l_discount))})}[1](as promo_revenue)
     Aggregates: sum({sum(case with 0|1|1)}[0]), sum({sum(l_extendedprice*(1-l_discount))}[1])
-    -> PhysicGather Threads: 20 (inccost=6885, cost=10, rows=1) (actual rows=10)
+    -> PhysicGather Threads: 20 (inccost=6729, cost=2, rows=1) (actual rows=10)
         Output: {sum(case with 0|1|1)}[0],{sum(l_extendedprice*(1-l_discount))}[1]
-        -> PhysicHashAgg  (inccost=6875, cost=80, rows=1, memory=32) (actual rows=1, loops=10)
+        -> PhysicHashAgg  (inccost=6727, cost=80, rows=1, memory=32) (actual rows=1, loops=10)
             Output: {sum(case with 0|1|1)}[0],{sum(l_extendedprice*(1-l_discount))}[1]
             Aggregates: sum(case with 0|1|1), sum(l_extendedprice[5]*(1-l_discount[8]))
-            -> PhysicHashJoin  (inccost=6795, cost=434, rows=78, memory=8112) (actual rows=8, loops=10)
+            -> PhysicHashJoin  (inccost=6647, cost=434, rows=78, memory=832) (actual rows=8, loops=10)
                 Output: case with 0|1|1,{p_type like 'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*(1-l_discount)}[3],l_extendedprice[0],{(1-l_discount)}[4],1,l_discount[1],0
                 Filter: l_partkey[7]=p_partkey[10]
-                -> PhysicRedistribute  (inccost=6161, cost=156, rows=78) (actual rows=8, loops=10)
+                -> PhysicRedistribute  (inccost=6013, cost=8, rows=78) (actual rows=8, loops=10)
                     Output: l_extendedprice[0],l_discount[1],{'PROMO%'}[2],{l_extendedprice*(1-l_discount)}[3],{(1-l_discount)}[4],{1}[5],{0}[6],l_partkey[7]
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=78) (actual rows=8, loops=10)
                         Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,0,l_partkey[1]

--- a/test/regress/expect/tpch0001_d/q14.txt
+++ b/test/regress/expect/tpch0001_d/q14.txt
@@ -11,24 +11,24 @@ where
 	l_partkey = p_partkey
 	and l_shipdate >= date '1995-09-01'
 	and l_shipdate < date '1995-09-01' + interval '1' month
-Total cost: 6732, memory=880
-PhysicHashAgg  (inccost=6732, cost=3, rows=1, memory=16) (actual rows=1)
+Total cost: 6342, memory=880
+PhysicHashAgg  (inccost=6342, cost=3, rows=1, memory=16) (actual rows=1)
     Output: {sum({sum(case with 0|1|1)})}[0]*100/{sum({sum(l_extendedprice*(1-l_discount))})}[1](as promo_revenue)
     Aggregates: sum({sum(case with 0|1|1)}[0]), sum({sum(l_extendedprice*(1-l_discount))}[1])
-    -> PhysicGather Threads: 20 (inccost=6729, cost=2, rows=1) (actual rows=10)
+    -> PhysicGather Threads: 20 (inccost=6339, cost=2, rows=1) (actual rows=10)
         Output: {sum(case with 0|1|1)}[0],{sum(l_extendedprice*(1-l_discount))}[1]
-        -> PhysicHashAgg  (inccost=6727, cost=80, rows=1, memory=32) (actual rows=1, loops=10)
+        -> PhysicHashAgg  (inccost=6337, cost=10, rows=1, memory=32) (actual rows=1, loops=10)
             Output: {sum(case with 0|1|1)}[0],{sum(l_extendedprice*(1-l_discount))}[1]
             Aggregates: sum(case with 0|1|1), sum(l_extendedprice[5]*(1-l_discount[8]))
-            -> PhysicHashJoin  (inccost=6647, cost=434, rows=78, memory=832) (actual rows=8, loops=10)
+            -> PhysicHashJoin  (inccost=6327, cost=114, rows=8, memory=832) (actual rows=8, loops=10)
                 Output: case with 0|1|1,{p_type like 'PROMO%'}[9],p_type[8],'PROMO%',{l_extendedprice*(1-l_discount)}[3],l_extendedprice[0],{(1-l_discount)}[4],1,l_discount[1],0
                 Filter: l_partkey[7]=p_partkey[10]
-                -> PhysicRedistribute  (inccost=6013, cost=8, rows=78) (actual rows=8, loops=10)
+                -> PhysicRedistribute  (inccost=6013, cost=8, rows=8) (actual rows=8, loops=10)
                     Output: l_extendedprice[0],l_discount[1],{'PROMO%'}[2],{l_extendedprice*(1-l_discount)}[3],{(1-l_discount)}[4],{1}[5],{0}[6],l_partkey[7]
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=78) (actual rows=8, loops=10)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=8) (actual rows=8, loops=10)
                         Output: l_extendedprice[5],l_discount[6],'PROMO%',l_extendedprice[5]*(1-l_discount[6]),(1-l_discount[6]),1,0,l_partkey[1]
                         Filter: (l_shipdate[10]>='1995-09-01' and l_shipdate[10]<'10/1/1995 12:00:00 AM')
-                -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=20, loops=10)
+                -> PhysicScanTable part (inccost=200, cost=200, rows=20) (actual rows=20, loops=10)
                     Output: p_type[4],p_type[4] like 'PROMO%',p_partkey[0]
 15.2302
 

--- a/test/regress/expect/tpch0001_d/q16.txt
+++ b/test/regress/expect/tpch0001_d/q16.txt
@@ -28,25 +28,25 @@ order by
 	p_brand,
 	p_type,
 	p_size
-Total cost: 3553.38, memory=22274
-PhysicOrder  (inccost=3553.38, cost=754.38, rows=148, memory=6364) (actual rows=0)
+Total cost: 2501.38, memory=22274
+PhysicOrder  (inccost=2501.38, cost=754.38, rows=148, memory=6364) (actual rows=0)
     Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
     Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
-    -> PhysicHashAgg  (inccost=2799, cost=444, rows=148, memory=12728) (actual rows=0)
+    -> PhysicHashAgg  (inccost=1747, cost=311, rows=148, memory=12728) (actual rows=0)
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicGather Threads: 20 (inccost=2355, cost=296, rows=148) (actual rows=0)
+        -> PhysicGather Threads: 20 (inccost=1436, cost=163, rows=148) (actual rows=0)
             Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
-            -> PhysicHashJoin  (inccost=2059, cost=1022, rows=148, memory=3182) (actual rows=0, loops=10)
+            -> PhysicHashJoin  (inccost=1273, cost=236, rows=148, memory=3182) (actual rows=0, loops=10)
                 Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
                 Filter: p_partkey[3]=ps_partkey[5]
                 -> PhysicBroadcast  (inccost=237, cost=37, rows=37) (actual rows=34, loops=10)
                     Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
-                    -> PhysicScanTable part (inccost=200, cost=200, rows=37) (actual rows=3, loops=10)
+                    -> PhysicScanTable part (inccost=200, cost=200, rows=4) (actual rows=3, loops=10)
                         Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
                         Filter: ((p_brand[3]<>'Brand#45' and p_type[4] not like 'MEDIUM POLISHED%') and p_size[5] in (49,14,23, ... <Total: 8> ))
-                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=0, loops=10)
+                -> PhysicScanTable partsupp (inccost=800, cost=800, rows=80) (actual rows=0, loops=10)
                     Output: ps_suppkey[1],ps_partkey[0]
                     Filter: ps_suppkey[1] in @1
                     <InSubqueryExpr> cached 1

--- a/test/regress/expect/tpch0001_d/q16.txt
+++ b/test/regress/expect/tpch0001_d/q16.txt
@@ -28,20 +28,20 @@ order by
 	p_brand,
 	p_type,
 	p_size
-Total cost: 4774.38, memory=22274
-PhysicOrder  (inccost=4774.38, cost=754.38, rows=148, memory=6364) (actual rows=0)
+Total cost: 3553.38, memory=22274
+PhysicOrder  (inccost=3553.38, cost=754.38, rows=148, memory=6364) (actual rows=0)
     Output: p_brand[0],p_type[1],p_size[2],{count(ps_suppkey)}[3]
     Order by: {count(ps_suppkey)}[3], p_brand[0], p_type[1], p_size[2]
-    -> PhysicHashAgg  (inccost=4020, cost=444, rows=148, memory=12728) (actual rows=0)
+    -> PhysicHashAgg  (inccost=2799, cost=444, rows=148, memory=12728) (actual rows=0)
         Output: {p_brand}[0],{p_type}[1],{p_size}[2],{count(ps_suppkey)}[3]
         Aggregates: count(ps_suppkey[3])
         Group by: p_brand[0], p_type[1], p_size[2]
-        -> PhysicGather Threads: 20 (inccost=3576, cost=1480, rows=148) (actual rows=0)
+        -> PhysicGather Threads: 20 (inccost=2355, cost=296, rows=148) (actual rows=0)
             Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
-            -> PhysicHashJoin  (inccost=2096, cost=1022, rows=148, memory=3182) (actual rows=0, loops=10)
+            -> PhysicHashJoin  (inccost=2059, cost=1022, rows=148, memory=3182) (actual rows=0, loops=10)
                 Output: p_brand[0],p_type[1],p_size[2],ps_suppkey[4]
                 Filter: p_partkey[3]=ps_partkey[5]
-                -> PhysicBroadcast  (inccost=274, cost=74, rows=37) (actual rows=34, loops=10)
+                -> PhysicBroadcast  (inccost=237, cost=37, rows=37) (actual rows=34, loops=10)
                     Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
                     -> PhysicScanTable part (inccost=200, cost=200, rows=37) (actual rows=3, loops=10)
                         Output: p_brand[3],p_type[4],p_size[5],p_partkey[0]
@@ -50,7 +50,7 @@ PhysicOrder  (inccost=4774.38, cost=754.38, rows=148, memory=6364) (actual rows=
                     Output: ps_suppkey[1],ps_partkey[0]
                     Filter: ps_suppkey[1] in @1
                     <InSubqueryExpr> cached 1
-                        -> PhysicGather Threads: 10 (inccost=20, cost=10, rows=1) (actual rows=0)
+                        -> PhysicGather Threads: 10 (inccost=12, cost=2, rows=1) (actual rows=0)
                             Output: s_suppkey[0]
                             -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=0, loops=10)
                                 Output: s_suppkey[0]

--- a/test/regress/expect/tpch0001_d/q17.txt
+++ b/test/regress/expect/tpch0001_d/q17.txt
@@ -15,33 +15,33 @@ where
 		where
 			l_partkey = p_partkey
 	)
-Total cost: 27906, memory=5624
-PhysicHashAgg  (inccost=27906, cost=32, rows=1, memory=16) (actual rows=1)
+Total cost: 26065, memory=5624
+PhysicHashAgg  (inccost=26065, cost=32, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice)}[0]/7(as avg_yearly)
     Aggregates: sum(l_extendedprice[0])
-    -> PhysicFilter  (inccost=27874, cost=30, rows=30) (actual rows=0)
+    -> PhysicFilter  (inccost=26033, cost=30, rows=30) (actual rows=0)
         Output: l_extendedprice[0]
         Filter: l_quantity[1]<{avg(l_quantity)}[2]*0.2
-        -> PhysicHashJoin Left (inccost=27844, cost=290, rows=30, memory=1200) (actual rows=0)
+        -> PhysicHashJoin Left (inccost=26003, cost=290, rows=30, memory=1200) (actual rows=0)
             Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
             Filter: l_partkey[4]=p_partkey[2]
-            -> PhysicGather Threads: 20 (inccost=12544, cost=300, rows=30) (actual rows=0)
+            -> PhysicGather Threads: 20 (inccost=12303, cost=60, rows=30) (actual rows=0)
                 Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
-                -> PhysicHashJoin  (inccost=12244, cost=6037, rows=30, memory=8) (actual rows=0, loops=10)
+                -> PhysicHashJoin  (inccost=12243, cost=6037, rows=30, memory=8) (actual rows=0, loops=10)
                     Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
                     Filter: p_partkey[0]=l_partkey[3]
-                    -> PhysicBroadcast  (inccost=202, cost=2, rows=1) (actual rows=0, loops=10)
+                    -> PhysicBroadcast  (inccost=201, cost=1, rows=1) (actual rows=0, loops=10)
                         Output: p_partkey[0]
                         -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0, loops=10)
                             Output: p_partkey[0]
                             Filter: (p_container[6]='MED BOX' and p_brand[3]='Brand#23')
                     -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                         Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
-            -> PhysicHashAgg  (inccost=15010, cost=600, rows=200, memory=2000) (actual rows=0)
+            -> PhysicHashAgg  (inccost=13410, cost=600, rows=200, memory=2000) (actual rows=0)
                 Output: {sum({sum(l_quantity)})}[1]/{sum({count(l_quantity)})}[2],{l_partkey}[0]
                 Aggregates: sum({sum(l_quantity)}[1]), sum({count(l_quantity)}[2])
                 Group by: l_partkey[0]
-                -> PhysicGather Threads: 10 (inccost=14410, cost=2000, rows=200) (actual rows=0)
+                -> PhysicGather Threads: 10 (inccost=12810, cost=400, rows=200) (actual rows=0)
                     Output: {l_partkey}[0],{sum(l_quantity)}[1],{count(l_quantity)}[2]
                     -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200, memory=2400) (actual rows=189, loops=10)
                         Output: {l_partkey}[0],{sum(l_quantity)}[1],{count(l_quantity)}[2]

--- a/test/regress/expect/tpch0001_d/q17.txt
+++ b/test/regress/expect/tpch0001_d/q17.txt
@@ -15,19 +15,19 @@ where
 		where
 			l_partkey = p_partkey
 	)
-Total cost: 26065, memory=5624
-PhysicHashAgg  (inccost=26065, cost=32, rows=1, memory=16) (actual rows=1)
+Total cost: 14789, memory=3464
+PhysicHashAgg  (inccost=14789, cost=32, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice)}[0]/7(as avg_yearly)
     Aggregates: sum(l_extendedprice[0])
-    -> PhysicFilter  (inccost=26033, cost=30, rows=30) (actual rows=0)
+    -> PhysicFilter  (inccost=14757, cost=3, rows=30) (actual rows=0)
         Output: l_extendedprice[0]
         Filter: l_quantity[1]<{avg(l_quantity)}[2]*0.2
-        -> PhysicHashJoin Left (inccost=26003, cost=290, rows=30, memory=1200) (actual rows=0)
+        -> PhysicHashJoin Left (inccost=14754, cost=236, rows=3, memory=1200) (actual rows=0)
             Output: l_extendedprice[0],l_quantity[1],{avg(l_quantity)}[3]
             Filter: l_partkey[4]=p_partkey[2]
-            -> PhysicGather Threads: 20 (inccost=12303, cost=60, rows=30) (actual rows=0)
+            -> PhysicGather Threads: 20 (inccost=6872, cost=33, rows=30) (actual rows=0)
                 Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
-                -> PhysicHashJoin  (inccost=12243, cost=6037, rows=30, memory=8) (actual rows=0, loops=10)
+                -> PhysicHashJoin  (inccost=6839, cost=633, rows=30, memory=8) (actual rows=0, loops=10)
                     Output: l_extendedprice[1],l_quantity[2],p_partkey[0]
                     Filter: p_partkey[0]=l_partkey[3]
                     -> PhysicBroadcast  (inccost=201, cost=1, rows=1) (actual rows=0, loops=10)
@@ -35,19 +35,19 @@ PhysicHashAgg  (inccost=26065, cost=32, rows=1, memory=16) (actual rows=1)
                         -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=0, loops=10)
                             Output: p_partkey[0]
                             Filter: (p_container[6]='MED BOX' and p_brand[3]='Brand#23')
-                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                    -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=601) (actual rows=0)
                         Output: l_extendedprice[5],l_quantity[4],l_partkey[1]
-            -> PhysicHashAgg  (inccost=13410, cost=600, rows=200, memory=2000) (actual rows=0)
+            -> PhysicHashAgg  (inccost=7646, cost=420, rows=200, memory=2000) (actual rows=0)
                 Output: {sum({sum(l_quantity)})}[1]/{sum({count(l_quantity)})}[2],{l_partkey}[0]
                 Aggregates: sum({sum(l_quantity)}[1]), sum({count(l_quantity)}[2])
                 Group by: l_partkey[0]
-                -> PhysicGather Threads: 10 (inccost=12810, cost=400, rows=200) (actual rows=0)
+                -> PhysicGather Threads: 10 (inccost=7226, cost=220, rows=200) (actual rows=0)
                     Output: {l_partkey}[0],{sum(l_quantity)}[1],{count(l_quantity)}[2]
-                    -> PhysicHashAgg  (inccost=12410, cost=6405, rows=200, memory=2400) (actual rows=189, loops=10)
+                    -> PhysicHashAgg  (inccost=7006, cost=1001, rows=20, memory=240) (actual rows=189, loops=10)
                         Output: {l_partkey}[0],{sum(l_quantity)}[1],{count(l_quantity)}[2]
                         Aggregates: sum(l_quantity[1]), count(l_quantity[1])
                         Group by: l_partkey[0]
-                        -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
+                        -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=601) (actual rows=600, loops=10)
                             Output: l_partkey[1],l_quantity[4]
 
 

--- a/test/regress/expect/tpch0001_d/q18.txt
+++ b/test/regress/expect/tpch0001_d/q18.txt
@@ -31,46 +31,42 @@ order by
 	o_totalprice desc,
 	o_orderdate
 limit 100
-Total cost: 160324.25, memory=1556097
-PhysicLimit (100) (inccost=160324.25, cost=100, rows=100) (actual rows=0)
+Total cost: 132901.25, memory=1556097
+PhysicLimit (100) (inccost=132901.25, cost=100, rows=100) (actual rows=0)
     Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
-    -> PhysicOrder  (inccost=160224.25, cost=82916.25, rows=9007, memory=513399) (actual rows=0)
+    -> PhysicOrder  (inccost=132801.25, cost=82916.25, rows=9007, memory=513399) (actual rows=0)
         Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
         Order by: o_totalprice[4], o_orderdate[3]
-        -> PhysicHashAgg  (inccost=77308, cost=27021, rows=9007, memory=1026798) (actual rows=0)
+        -> PhysicHashAgg  (inccost=49885, cost=18915, rows=9007, memory=1026798) (actual rows=0)
             Output: {c_name}[0],{c_custkey}[1],{o_orderkey}[2],{o_orderdate}[3],{o_totalprice}[4],{sum(l_quantity)}[5]
             Aggregates: sum(l_quantity[5])
             Group by: c_name[0], c_custkey[1], o_orderkey[2], o_orderdate[3], o_totalprice[4]
-            -> PhysicHashJoin  (inccost=50287, cost=15312, rows=9007, memory=8700) (actual rows=0)
+            -> PhysicHashJoin  (inccost=30970, cost=9638, rows=901, memory=8700) (actual rows=0)
                 Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],l_quantity[5]
                 Filter: c_custkey[1]=o_custkey[6]
-                -> PhysicGather Threads: 10 (inccost=450, cost=300, rows=150) (actual rows=150)
+                -> PhysicGather Threads: 10 (inccost=315, cost=165, rows=150) (actual rows=150)
                     Output: c_name[1],c_custkey[0]
-                    -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
+                    -> PhysicScanTable customer (inccost=150, cost=150, rows=15) (actual rows=15, loops=10)
                         Output: c_name[1],c_custkey[0]
-                -> PhysicGather Threads: 10 (inccost=34525, cost=12010, rows=6005) (actual rows=0)
+                -> PhysicGather Threads: 10 (inccost=21017, cost=6606, rows=6005) (actual rows=0)
                     Output: o_orderkey[0],o_orderdate[1],o_totalprice[2],l_quantity[4],o_custkey[3]
-                    -> PhysicHashJoin  (inccost=22515, cost=15010, rows=6005, memory=7200) (actual rows=0, loops=10)
+                    -> PhysicHashJoin  (inccost=14411, cost=6906, rows=6005, memory=7200) (actual rows=0, loops=10)
                         Output: o_orderkey[0],o_orderdate[1],o_totalprice[2],l_quantity[4],o_custkey[3]
                         Filter: o_orderkey[0]=l_orderkey[5]
-                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0, loops=10)
+                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=150) (actual rows=0, loops=10)
                             Output: o_orderkey[0],o_orderdate[4],o_totalprice[3],o_custkey[1]
                             Filter: o_orderkey[0] in @1
                             <InSubqueryExpr> cached 1
-                                -> PhysicHashAgg  (inccost=22510, cost=4500, rows=1500, memory=12000) (actual rows=0)
+                                -> PhysicHashAgg  (inccost=16212, cost=3601, rows=1500, memory=12000) (actual rows=0)
                                     Output: {l_orderkey}[0]
-                                    Aggregates: sum({sum(l_quantity)}[1])
+                                    Aggregates: sum(l_quantity[1])
                                     Group by: l_orderkey[0]
-                                    Filter: {sum({sum(l_quantity)})}[1]>300
-                                    -> PhysicGather Threads: 10 (inccost=18010, cost=3000, rows=1500) (actual rows=1500)
-                                        Output: {l_orderkey}[0],{sum(l_quantity)}[1]
-                                        -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500, memory=36000) (actual rows=150, loops=10)
-                                            Output: {l_orderkey}[0],{sum(l_quantity)}[1]
-                                            Aggregates: sum(l_quantity[1])
-                                            Group by: l_orderkey[0]
-                                            -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
-                                                Output: l_orderkey[0],l_quantity[4]
-                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                    Filter: {sum(l_quantity)}[1]>300
+                                    -> PhysicGather Threads: 10 (inccost=12611, cost=6606, rows=6005) (actual rows=6005)
+                                        Output: l_orderkey[0],l_quantity[4]
+                                        -> PhysicScanTable lineitem as lineitem__1 (inccost=6005, cost=6005, rows=601) (actual rows=600, loops=10)
+                                            Output: l_orderkey[0],l_quantity[4]
+                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=601) (actual rows=0)
                             Output: l_quantity[4],l_orderkey[0]
 
 

--- a/test/regress/expect/tpch0001_d/q18.txt
+++ b/test/regress/expect/tpch0001_d/q18.txt
@@ -31,38 +31,38 @@ order by
 	o_totalprice desc,
 	o_orderdate
 limit 100
-Total cost: 209564.25, memory=1620897
-PhysicLimit (100) (inccost=209564.25, cost=100, rows=100) (actual rows=0)
+Total cost: 160324.25, memory=1556097
+PhysicLimit (100) (inccost=160324.25, cost=100, rows=100) (actual rows=0)
     Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
-    -> PhysicOrder  (inccost=209464.25, cost=82916.25, rows=9007, memory=513399) (actual rows=0)
+    -> PhysicOrder  (inccost=160224.25, cost=82916.25, rows=9007, memory=513399) (actual rows=0)
         Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],{sum(l_quantity)}[5]
         Order by: o_totalprice[4], o_orderdate[3]
-        -> PhysicHashAgg  (inccost=126548, cost=27021, rows=9007, memory=1026798) (actual rows=0)
+        -> PhysicHashAgg  (inccost=77308, cost=27021, rows=9007, memory=1026798) (actual rows=0)
             Output: {c_name}[0],{c_custkey}[1],{o_orderkey}[2],{o_orderdate}[3],{o_totalprice}[4],{sum(l_quantity)}[5]
             Aggregates: sum(l_quantity[5])
             Group by: c_name[0], c_custkey[1], o_orderkey[2], o_orderdate[3], o_totalprice[4]
-            -> PhysicHashJoin  (inccost=99527, cost=15312, rows=9007, memory=8700) (actual rows=0)
+            -> PhysicHashJoin  (inccost=50287, cost=15312, rows=9007, memory=8700) (actual rows=0)
                 Output: c_name[0],c_custkey[1],o_orderkey[2],o_orderdate[3],o_totalprice[4],l_quantity[5]
                 Filter: c_custkey[1]=o_custkey[6]
-                -> PhysicGather Threads: 10 (inccost=1650, cost=1500, rows=150) (actual rows=150)
+                -> PhysicGather Threads: 10 (inccost=450, cost=300, rows=150) (actual rows=150)
                     Output: c_name[1],c_custkey[0]
                     -> PhysicScanTable customer (inccost=150, cost=150, rows=150) (actual rows=15, loops=10)
                         Output: c_name[1],c_custkey[0]
-                -> PhysicGather Threads: 10 (inccost=82565, cost=60050, rows=6005) (actual rows=0)
+                -> PhysicGather Threads: 10 (inccost=34525, cost=12010, rows=6005) (actual rows=0)
                     Output: o_orderkey[0],o_orderdate[1],o_totalprice[2],l_quantity[4],o_custkey[3]
-                    -> PhysicHashJoin  (inccost=22515, cost=15010, rows=6005, memory=72000) (actual rows=0, loops=10)
+                    -> PhysicHashJoin  (inccost=22515, cost=15010, rows=6005, memory=7200) (actual rows=0, loops=10)
                         Output: o_orderkey[0],o_orderdate[1],o_totalprice[2],l_quantity[4],o_custkey[3]
                         Filter: o_orderkey[0]=l_orderkey[5]
                         -> PhysicScanTable orders (inccost=1500, cost=1500, rows=1500) (actual rows=0, loops=10)
                             Output: o_orderkey[0],o_orderdate[4],o_totalprice[3],o_custkey[1]
                             Filter: o_orderkey[0] in @1
                             <InSubqueryExpr> cached 1
-                                -> PhysicHashAgg  (inccost=34510, cost=4500, rows=1500, memory=12000) (actual rows=0)
+                                -> PhysicHashAgg  (inccost=22510, cost=4500, rows=1500, memory=12000) (actual rows=0)
                                     Output: {l_orderkey}[0]
                                     Aggregates: sum({sum(l_quantity)}[1])
                                     Group by: l_orderkey[0]
                                     Filter: {sum({sum(l_quantity)})}[1]>300
-                                    -> PhysicGather Threads: 10 (inccost=30010, cost=15000, rows=1500) (actual rows=1500)
+                                    -> PhysicGather Threads: 10 (inccost=18010, cost=3000, rows=1500) (actual rows=1500)
                                         Output: {l_orderkey}[0],{sum(l_quantity)}[1]
                                         -> PhysicHashAgg  (inccost=15010, cost=9005, rows=1500, memory=36000) (actual rows=150, loops=10)
                                             Output: {l_orderkey}[0],{sum(l_quantity)}[1]

--- a/test/regress/expect/tpch0001_d/q19.txt
+++ b/test/regress/expect/tpch0001_d/q19.txt
@@ -33,18 +33,18 @@ where
 		and l_shipmode in ('AIR', 'AIR REG')
 		and l_shipinstruct = 'DELIVER IN PERSON'
 	)
-Total cost: 2532407, memory=16
-PhysicHashAgg  (inccost=2532407, cost=1201002, rows=1, memory=16) (actual rows=1)
+Total cost: 2482767, memory=16
+PhysicHashAgg  (inccost=2482767, cost=1201002, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice*(1-l_discount))}[0]
     Aggregates: sum(l_extendedprice[1]*(1-l_discount[4]))
-    -> PhysicNLJoin  (inccost=1331405, cost=1263150, rows=1201000) (actual rows=0)
+    -> PhysicNLJoin  (inccost=1281765, cost=1263150, rows=1201000) (actual rows=0)
         Output: {l_extendedprice*(1-l_discount)}[0],l_extendedprice[1],{(1-l_discount)}[2],{1}[3],l_discount[4]
         Filter: (((((((((p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12') and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG')) and l_quantity[6]>=1) and l_quantity[6]<=11) and (p_size[12]>=1 and p_size[12]<=5)) and l_shipmode[7] in ('AIR','AIR REG')) and l_shipinstruct[8]='DELIVER IN PERSON') or (((((((p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23') and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK')) and l_quantity[6]>=10) and l_quantity[6]<=20) and (p_size[12]>=1 and p_size[12]<=10)) and l_shipmode[7] in ('AIR','AIR REG')) and l_shipinstruct[8]='DELIVER IN PERSON')) or (((((((p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34') and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG')) and l_quantity[6]>=20) and l_quantity[6]<=30) and (p_size[12]>=1 and p_size[12]<=15)) and l_shipmode[7] in ('AIR','AIR REG')) and l_shipinstruct[8]='DELIVER IN PERSON'))
-        -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=6005)
+        -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=6005)
             Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
             -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
                 Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
-        -> PhysicGather Threads: 10 (inccost=2200, cost=2000, rows=200) (actual rows=200, loops=6005)
+        -> PhysicGather Threads: 10 (inccost=600, cost=400, rows=200) (actual rows=200, loops=6005)
             Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
             -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=20, loops=10)
                 Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]

--- a/test/regress/expect/tpch0001_d/q19.txt
+++ b/test/regress/expect/tpch0001_d/q19.txt
@@ -33,20 +33,20 @@ where
 		and l_shipmode in ('AIR', 'AIR REG')
 		and l_shipinstruct = 'DELIVER IN PERSON'
 	)
-Total cost: 2482767, memory=16
-PhysicHashAgg  (inccost=2482767, cost=1201002, rows=1, memory=16) (actual rows=1)
+Total cost: 151463, memory=16
+PhysicHashAgg  (inccost=151463, cost=120102, rows=1, memory=16) (actual rows=1)
     Output: {sum(l_extendedprice*(1-l_discount))}[0]
     Aggregates: sum(l_extendedprice[1]*(1-l_discount[4]))
-    -> PhysicNLJoin  (inccost=1281765, cost=1263150, rows=1201000) (actual rows=0)
+    -> PhysicNLJoin  (inccost=31361, cost=18330, rows=120100) (actual rows=0)
         Output: {l_extendedprice*(1-l_discount)}[0],l_extendedprice[1],{(1-l_discount)}[2],{1}[3],l_discount[4]
         Filter: (((((((((p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#12') and p_container[11] in ('SM CASE','SM BOX','SM PACK','SM PKG')) and l_quantity[6]>=1) and l_quantity[6]<=11) and (p_size[12]>=1 and p_size[12]<=5)) and l_shipmode[7] in ('AIR','AIR REG')) and l_shipinstruct[8]='DELIVER IN PERSON') or (((((((p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#23') and p_container[11] in ('MED BAG','MED BOX','MED PKG','MED PACK')) and l_quantity[6]>=10) and l_quantity[6]<=20) and (p_size[12]>=1 and p_size[12]<=10)) and l_shipmode[7] in ('AIR','AIR REG')) and l_shipinstruct[8]='DELIVER IN PERSON')) or (((((((p_partkey[9]=l_partkey[5] and p_brand[10]='Brand#34') and p_container[11] in ('LG CASE','LG BOX','LG PACK','LG PKG')) and l_quantity[6]>=20) and l_quantity[6]<=30) and (p_size[12]>=1 and p_size[12]<=15)) and l_shipmode[7] in ('AIR','AIR REG')) and l_shipinstruct[8]='DELIVER IN PERSON'))
-        -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=6005)
+        -> PhysicGather Threads: 10 (inccost=12611, cost=6606, rows=6005) (actual rows=6005)
             Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
-            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
+            -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=601) (actual rows=600, loops=10)
                 Output: l_extendedprice[5]*(1-l_discount[6]),l_extendedprice[5],(1-l_discount[6]),1,l_discount[6],l_partkey[1],l_quantity[4],l_shipmode[14],l_shipinstruct[13]
-        -> PhysicGather Threads: 10 (inccost=600, cost=400, rows=200) (actual rows=200, loops=6005)
+        -> PhysicGather Threads: 10 (inccost=420, cost=220, rows=200) (actual rows=200, loops=6005)
             Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
-            -> PhysicScanTable part (inccost=200, cost=200, rows=200) (actual rows=20, loops=10)
+            -> PhysicScanTable part (inccost=200, cost=200, rows=20) (actual rows=20, loops=10)
                 Output: p_partkey[0],p_brand[3],p_container[6],p_size[5]
 
 

--- a/test/regress/expect/tpch0001_d/q20.txt
+++ b/test/regress/expect/tpch0001_d/q20.txt
@@ -35,11 +35,11 @@ where
 	and n_name = 'CANADA'
 order by
 	s_name
-Total cost: 58.1, memory=73
-PhysicOrder  (inccost=58.1, cost=0.1, rows=1, memory=65) (actual rows=0)
+Total cost: 50.1, memory=73
+PhysicOrder  (inccost=50.1, cost=0.1, rows=1, memory=65) (actual rows=0)
     Output: s_name[0],s_address[1]
     Order by: s_name[0]
-    -> PhysicGather Threads: 10 (inccost=58, cost=10, rows=1) (actual rows=0)
+    -> PhysicGather Threads: 10 (inccost=50, cost=2, rows=1) (actual rows=0)
         Output: s_name[1],s_address[2]
         -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
             Output: s_name[1],s_address[2]
@@ -51,30 +51,30 @@ PhysicOrder  (inccost=58.1, cost=0.1, rows=1, memory=65) (actual rows=0)
                 Output: s_name[1],s_address[2],s_nationkey[3]
                 Filter: s_suppkey[0] in @1
                 <InSubqueryExpr> cached 1
-                    -> PhysicFilter  (inccost=27275, cost=367, rows=367) (actual rows=47)
+                    -> PhysicFilter  (inccost=15467, cost=367, rows=367) (actual rows=47)
                         Output: ps_suppkey[0]
                         Filter: ps_availqty[1]>{sum(l_quantity)}[2]*0.5
-                        -> PhysicGather Threads: 20 (inccost=26908, cost=3670, rows=367) (actual rows=60)
+                        -> PhysicGather Threads: 20 (inccost=15100, cost=734, rows=367) (actual rows=60)
                             Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
-                            -> PhysicHashJoin Left (inccost=23238, cost=2886, rows=367, memory=19200) (actual rows=6, loops=10)
+                            -> PhysicHashJoin Left (inccost=14366, cost=2886, rows=367, memory=1920) (actual rows=6, loops=10)
                                 Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
                                 Filter: (l_partkey[4]=ps_partkey[2] and l_suppkey[5]=ps_suppkey[0])
-                                -> PhysicRedistribute  (inccost=2400, cost=1600, rows=800) (actual rows=6, loops=10)
+                                -> PhysicRedistribute  (inccost=880, cost=80, rows=800) (actual rows=6, loops=10)
                                     Output: ps_suppkey[0],ps_availqty[1],ps_partkey[2]
                                     -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=6, loops=10)
                                         Output: ps_suppkey[1],ps_availqty[2],ps_partkey[0]
                                         Filter: ps_partkey[0] in @2
                                         <InSubqueryExpr> cached 2
-                                            -> PhysicGather Threads: 10 (inccost=210, cost=10, rows=1) (actual rows=15)
+                                            -> PhysicGather Threads: 10 (inccost=202, cost=2, rows=1) (actual rows=15)
                                                 Output: p_partkey[0]
                                                 -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=1, loops=10)
                                                     Output: p_partkey[0]
                                                     Filter: p_name[1] like 'forest%'
-                                -> PhysicHashAgg  (inccost=17952, cost=2757, rows=919, memory=29408) (actual rows=499, loops=10)
+                                -> PhysicHashAgg  (inccost=10600, cost=2757, rows=919, memory=29408) (actual rows=499, loops=10)
                                     Output: {sum(l_quantity)}[2],{l_partkey}[0],{l_suppkey}[1]
                                     Aggregates: sum(l_quantity[2])
                                     Group by: l_partkey[0], l_suppkey[1]
-                                    -> PhysicGather Threads: 10 (inccost=15195, cost=9190, rows=919) (actual rows=922, loops=10)
+                                    -> PhysicGather Threads: 10 (inccost=7843, cost=1838, rows=919) (actual rows=922, loops=10)
                                         Output: l_partkey[1],l_suppkey[2],l_quantity[4]
                                         -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=919) (actual rows=92, loops=100)
                                             Output: l_partkey[1],l_suppkey[2],l_quantity[4]

--- a/test/regress/expect/tpch0001_d/q20.txt
+++ b/test/regress/expect/tpch0001_d/q20.txt
@@ -35,33 +35,33 @@ where
 	and n_name = 'CANADA'
 order by
 	s_name
-Total cost: 50.1, memory=73
-PhysicOrder  (inccost=50.1, cost=0.1, rows=1, memory=65) (actual rows=0)
+Total cost: 41.1, memory=73
+PhysicOrder  (inccost=41.1, cost=0.1, rows=1, memory=65) (actual rows=0)
     Output: s_name[0],s_address[1]
     Order by: s_name[0]
-    -> PhysicGather Threads: 10 (inccost=50, cost=2, rows=1) (actual rows=0)
+    -> PhysicGather Threads: 10 (inccost=41, cost=2, rows=1) (actual rows=0)
         Output: s_name[1],s_address[2]
-        -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
+        -> PhysicHashJoin  (inccost=39, cost=4, rows=1, memory=8) (actual rows=0, loops=10)
             Output: s_name[1],s_address[2]
             Filter: s_nationkey[3]=n_nationkey[0]
             -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1, loops=10)
                 Output: n_nationkey[0]
                 Filter: n_name[1]='CANADA'
-            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+            -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=1, loops=10)
                 Output: s_name[1],s_address[2],s_nationkey[3]
                 Filter: s_suppkey[0] in @1
                 <InSubqueryExpr> cached 1
-                    -> PhysicFilter  (inccost=15467, cost=367, rows=367) (actual rows=47)
+                    -> PhysicFilter  (inccost=11713, cost=37, rows=367) (actual rows=47)
                         Output: ps_suppkey[0]
                         Filter: ps_availqty[1]>{sum(l_quantity)}[2]*0.5
-                        -> PhysicGather Threads: 20 (inccost=15100, cost=734, rows=367) (actual rows=60)
+                        -> PhysicGather Threads: 20 (inccost=11676, cost=404, rows=367) (actual rows=60)
                             Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
-                            -> PhysicHashJoin Left (inccost=14366, cost=2886, rows=367, memory=1920) (actual rows=6, loops=10)
+                            -> PhysicHashJoin Left (inccost=11272, cost=1446, rows=37, memory=1920) (actual rows=6, loops=10)
                                 Output: ps_suppkey[0],ps_availqty[1],{sum(l_quantity)}[3]
                                 Filter: (l_partkey[4]=ps_partkey[2] and l_suppkey[5]=ps_suppkey[0])
-                                -> PhysicRedistribute  (inccost=880, cost=80, rows=800) (actual rows=6, loops=10)
+                                -> PhysicRedistribute  (inccost=880, cost=80, rows=80) (actual rows=6, loops=10)
                                     Output: ps_suppkey[0],ps_availqty[1],ps_partkey[2]
-                                    -> PhysicScanTable partsupp (inccost=800, cost=800, rows=800) (actual rows=6, loops=10)
+                                    -> PhysicScanTable partsupp (inccost=800, cost=800, rows=80) (actual rows=6, loops=10)
                                         Output: ps_suppkey[1],ps_availqty[2],ps_partkey[0]
                                         Filter: ps_partkey[0] in @2
                                         <InSubqueryExpr> cached 2
@@ -70,13 +70,13 @@ PhysicOrder  (inccost=50.1, cost=0.1, rows=1, memory=65) (actual rows=0)
                                                 -> PhysicScanTable part (inccost=200, cost=200, rows=1) (actual rows=1, loops=10)
                                                     Output: p_partkey[0]
                                                     Filter: p_name[1] like 'forest%'
-                                -> PhysicHashAgg  (inccost=10600, cost=2757, rows=919, memory=29408) (actual rows=499, loops=10)
+                                -> PhysicHashAgg  (inccost=8946, cost=1930, rows=919, memory=29408) (actual rows=499, loops=10)
                                     Output: {sum(l_quantity)}[2],{l_partkey}[0],{l_suppkey}[1]
                                     Aggregates: sum(l_quantity[2])
                                     Group by: l_partkey[0], l_suppkey[1]
-                                    -> PhysicGather Threads: 10 (inccost=7843, cost=1838, rows=919) (actual rows=922, loops=10)
+                                    -> PhysicGather Threads: 10 (inccost=7016, cost=1011, rows=919) (actual rows=922, loops=10)
                                         Output: l_partkey[1],l_suppkey[2],l_quantity[4]
-                                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=919) (actual rows=92, loops=100)
+                                        -> PhysicScanTable lineitem (inccost=6005, cost=6005, rows=92) (actual rows=92, loops=100)
                                             Output: l_partkey[1],l_suppkey[2],l_quantity[4]
                                             Filter: (l_shipdate[10]>='1994-01-01' and l_shipdate[10]<'1/1/1995 12:00:00 AM')
 

--- a/test/regress/expect/tpch0001_d/q21.txt
+++ b/test/regress/expect/tpch0001_d/q21.txt
@@ -38,34 +38,34 @@ order by
 	numwait desc,
 	s_name
 limit 100
-Total cost: 38168272.02, memory=6744
-PhysicLimit (100) (inccost=38168272.02, cost=100, rows=100) (actual rows=0)
+Total cost: 38069615.02, memory=1520
+PhysicLimit (100) (inccost=38069615.02, cost=100, rows=100) (actual rows=0)
     Output: s_name[0],{count(*)(0)}[1]
-    -> PhysicOrder  (inccost=38168172.02, cost=24.02, rows=10, memory=290) (actual rows=0)
+    -> PhysicOrder  (inccost=38069515.02, cost=24.02, rows=10, memory=290) (actual rows=0)
         Output: s_name[0],{count(*)(0)}[1]
         Order by: {count(*)(0)}[1], s_name[0]
-        -> PhysicHashAgg  (inccost=38168148, cost=6025, rows=10, memory=580) (actual rows=0)
+        -> PhysicHashAgg  (inccost=38069491, cost=6025, rows=10, memory=580) (actual rows=0)
             Output: {s_name}[0],{count(*)(0)}[1]
             Aggregates: count(*)(0)
             Group by: s_name[0]
-            -> PhysicFilter  (inccost=38162123, cost=6005, rows=6005) (actual rows=0)
+            -> PhysicFilter  (inccost=38063466, cost=6005, rows=6005) (actual rows=0)
                 Output: s_name[1]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=38156118, cost=36060025, rows=6005) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=38057461, cost=36060025, rows=6005) (actual rows=0)
                     Output: #marker,s_name[0]
                     Filter: (l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2])
-                    -> PhysicFilter  (inccost=2030038, cost=6005, rows=6005) (actual rows=0)
+                    -> PhysicFilter  (inccost=1979421, cost=6005, rows=6005) (actual rows=0)
                         Output: s_name[1],l_orderkey[2],l_suppkey[3]
                         Filter: {#marker}[0]
-                        -> PhysicMarkJoin Left (inccost=2024033, cost=1933610, rows=6005) (actual rows=0)
+                        -> PhysicMarkJoin Left (inccost=1973416, cost=1933610, rows=6005) (actual rows=0)
                             Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
                             Filter: (l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2])
-                            -> PhysicGather Threads: 20 (inccost=24368, cost=3220, rows=322) (actual rows=0)
+                            -> PhysicGather Threads: 20 (inccost=21791, cost=644, rows=322) (actual rows=0)
                                 Output: s_name[0],l_orderkey[2],l_suppkey[3]
-                                -> PhysicHashJoin  (inccost=21148, cost=3230, rows=322, memory=58) (actual rows=0, loops=10)
+                                -> PhysicHashJoin  (inccost=21147, cost=3230, rows=322, memory=58) (actual rows=0, loops=10)
                                     Output: s_name[0],l_orderkey[2],l_suppkey[3]
                                     Filter: s_suppkey[1]=l_suppkey[3]
-                                    -> PhysicBroadcast  (inccost=50, cost=2, rows=1) (actual rows=0, loops=10)
+                                    -> PhysicBroadcast  (inccost=49, cost=1, rows=1) (actual rows=0, loops=10)
                                         Output: s_name[1],s_suppkey[2]
                                         -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
                                             Output: s_name[1],s_suppkey[2]
@@ -75,7 +75,7 @@ PhysicLimit (100) (inccost=38168272.02, cost=100, rows=100) (actual rows=0)
                                                 Filter: n_name[1]='SAUDI ARABIA'
                                             -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
                                                 Output: s_name[1],s_suppkey[0],s_nationkey[3]
-                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906, memory=5808) (actual rows=0)
+                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906, memory=584) (actual rows=0)
                                         Output: l_orderkey[1],l_suppkey[2]
                                         Filter: o_orderkey[0]=l_orderkey[1]
                                         -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=0)
@@ -84,12 +84,12 @@ PhysicLimit (100) (inccost=38168272.02, cost=100, rows=100) (actual rows=0)
                                         -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
                                             Output: l_orderkey[0],l_suppkey[2]
                                             Filter: l_receiptdate[12]>l_commitdate[11]
-                            -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                            -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=0)
                                 Output: l_orderkey[0],l_suppkey[2]
                                 -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=375, loops=10)
                                     Output: l_orderkey[0],l_suppkey[2]
                                     Filter: l_receiptdate[12]>l_commitdate[11]
-                    -> PhysicGather Threads: 10 (inccost=66055, cost=60050, rows=6005) (actual rows=0)
+                    -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=0)
                         Output: l_orderkey[0],l_suppkey[2]
                         -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
                             Output: l_orderkey[0],l_suppkey[2]

--- a/test/regress/expect/tpch0001_d/q21.txt
+++ b/test/regress/expect/tpch0001_d/q21.txt
@@ -38,60 +38,60 @@ order by
 	numwait desc,
 	s_name
 limit 100
-Total cost: 38069615.02, memory=1520
-PhysicLimit (100) (inccost=38069615.02, cost=100, rows=100) (actual rows=0)
+Total cost: 3673579.02, memory=1520
+PhysicLimit (100) (inccost=3673579.02, cost=100, rows=100) (actual rows=0)
     Output: s_name[0],{count(*)(0)}[1]
-    -> PhysicOrder  (inccost=38069515.02, cost=24.02, rows=10, memory=290) (actual rows=0)
+    -> PhysicOrder  (inccost=3673479.02, cost=24.02, rows=10, memory=290) (actual rows=0)
         Output: s_name[0],{count(*)(0)}[1]
         Order by: {count(*)(0)}[1], s_name[0]
-        -> PhysicHashAgg  (inccost=38069491, cost=6025, rows=10, memory=580) (actual rows=0)
+        -> PhysicHashAgg  (inccost=3673455, cost=6025, rows=10, memory=580) (actual rows=0)
             Output: {s_name}[0],{count(*)(0)}[1]
             Aggregates: count(*)(0)
             Group by: s_name[0]
-            -> PhysicFilter  (inccost=38063466, cost=6005, rows=6005) (actual rows=0)
+            -> PhysicFilter  (inccost=3667430, cost=601, rows=6005) (actual rows=0)
                 Output: s_name[1]
                 Filter: {#marker}[0]
-                -> PhysicMarkJoin Left (inccost=38057461, cost=36060025, rows=6005) (actual rows=0)
+                -> PhysicMarkJoin Left (inccost=3666829, cost=3609005, rows=601) (actual rows=0)
                     Output: #marker,s_name[0]
                     Filter: (l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2])
-                    -> PhysicFilter  (inccost=1979421, cost=6005, rows=6005) (actual rows=0)
+                    -> PhysicFilter  (inccost=45213, cost=601, rows=6005) (actual rows=0)
                         Output: s_name[1],l_orderkey[2],l_suppkey[3]
                         Filter: {#marker}[0]
-                        -> PhysicMarkJoin Left (inccost=1973416, cost=1933610, rows=6005) (actual rows=0)
+                        -> PhysicMarkJoin Left (inccost=44612, cost=19833, rows=601) (actual rows=0)
                             Output: #marker,s_name[0],l_orderkey[1],l_suppkey[2]
                             Filter: (l_orderkey[3]=l_orderkey[1] and l_suppkey[4]<>l_suppkey[2])
-                            -> PhysicGather Threads: 20 (inccost=21791, cost=644, rows=322) (actual rows=0)
+                            -> PhysicGather Threads: 20 (inccost=12168, cost=355, rows=322) (actual rows=0)
                                 Output: s_name[0],l_orderkey[2],l_suppkey[3]
-                                -> PhysicHashJoin  (inccost=21147, cost=3230, rows=322, memory=58) (actual rows=0, loops=10)
+                                -> PhysicHashJoin  (inccost=11813, cost=615, rows=322, memory=58) (actual rows=0, loops=10)
                                     Output: s_name[0],l_orderkey[2],l_suppkey[3]
                                     Filter: s_suppkey[1]=l_suppkey[3]
-                                    -> PhysicBroadcast  (inccost=49, cost=1, rows=1) (actual rows=0, loops=10)
+                                    -> PhysicBroadcast  (inccost=40, cost=1, rows=1) (actual rows=0, loops=10)
                                         Output: s_name[1],s_suppkey[2]
-                                        -> PhysicHashJoin  (inccost=48, cost=13, rows=1, memory=8) (actual rows=0, loops=10)
+                                        -> PhysicHashJoin  (inccost=39, cost=4, rows=1, memory=8) (actual rows=0, loops=10)
                                             Output: s_name[1],s_suppkey[2]
                                             Filter: s_nationkey[3]=n_nationkey[0]
                                             -> PhysicScanTable nation (inccost=25, cost=25, rows=1) (actual rows=1, loops=10)
                                                 Output: n_nationkey[0]
                                                 Filter: n_name[1]='SAUDI ARABIA'
-                                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=10) (actual rows=1, loops=10)
+                                            -> PhysicScanTable supplier (inccost=10, cost=10, rows=1) (actual rows=1, loops=10)
                                                 Output: s_name[1],s_suppkey[0],s_nationkey[3]
-                                    -> PhysicHashJoin  (inccost=17868, cost=10363, rows=2906, memory=584) (actual rows=0)
+                                    -> PhysicHashJoin  (inccost=11158, cost=3653, rows=291, memory=584) (actual rows=0)
                                         Output: l_orderkey[1],l_suppkey[2]
                                         Filter: o_orderkey[0]=l_orderkey[1]
-                                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=726) (actual rows=0)
+                                        -> PhysicScanTable orders (inccost=1500, cost=1500, rows=73) (actual rows=0)
                                             Output: o_orderkey[0]
                                             Filter: o_orderstatus[2]='F'
-                                        -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=6005) (actual rows=0)
+                                        -> PhysicScanTable lineitem as l1 (inccost=6005, cost=6005, rows=601) (actual rows=0)
                                             Output: l_orderkey[0],l_suppkey[2]
                                             Filter: l_receiptdate[12]>l_commitdate[11]
-                            -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=0)
+                            -> PhysicGather Threads: 10 (inccost=12611, cost=6606, rows=6005) (actual rows=0)
                                 Output: l_orderkey[0],l_suppkey[2]
-                                -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=6005) (actual rows=375, loops=10)
+                                -> PhysicScanTable lineitem as l3 (inccost=6005, cost=6005, rows=601) (actual rows=375, loops=10)
                                     Output: l_orderkey[0],l_suppkey[2]
                                     Filter: l_receiptdate[12]>l_commitdate[11]
-                    -> PhysicGather Threads: 10 (inccost=18015, cost=12010, rows=6005) (actual rows=0)
+                    -> PhysicGather Threads: 10 (inccost=12611, cost=6606, rows=6005) (actual rows=0)
                         Output: l_orderkey[0],l_suppkey[2]
-                        -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=6005) (actual rows=600, loops=10)
+                        -> PhysicScanTable lineitem as l2 (inccost=6005, cost=6005, rows=601) (actual rows=600, loops=10)
                             Output: l_orderkey[0],l_suppkey[2]
 
 


### PR DESCRIPTION
The cardinality for distributed table is to be computed differently. Previously, the cardinality (card_ attributed in LogicNode) is used for computing the cost of PhysicNode. However, it can only represent serialized execution cost, and cost for distributed plan cannot be correctly represented.
In the new calculation, the card_ attribute for logic node remains the same, representing the total number of rows to be processed. A new machinecount_ attribute is introduced to logic node to identify if the node is running in parallel.

The default machinecount_ is 1, and there are three main changes involving this attribute:
1) For table scan of distributed table (distributed on a column or roundrobin), machinecount_ will be set to the number of distributions of the table. 
2) For join, the machinecount_ is the maximum of the child nodes' machinecount_. 
3) For gather, the machinecount_ will be set back to 1 to show that the output is singleton.

The Card() method for physic node now returns the average cardinality for each machine. (rounded up)
Since the cost estimation process uses the Card() method under PhysicNode, it will be using the modified cardinality, meaning the number of rows per machine. Meanwhile, logic card_ remains unchanged.


Other Bugs that are fixed in this PR:
1) False assignment of having_ during agg split: The having expression is falsely changed during application of agg split rule, which may lead to expr matching issue. It is fixed by reassigning the unchanged having_.
2) Using anydistribution strictly for distributed and not singleton: change the default distribution property to singleton to avoid ambiguity and error for join resolver enabled optimization.