### PR TITLE
[bug] Incorrect NULL argument handling in functions #215

### DIFF
--- a/qpmodel/ExprFunc.cs
+++ b/qpmodel/ExprFunc.cs
@@ -222,7 +222,6 @@ namespace qpmodel.expr
         {
             base.Bind(context);
             type_ = args_()[0].type_;
-            Debug.Assert(type_ is CharType || type_ is VarCharType);
         }
 
         public override Value Exec(ExecContext context, Row input)
@@ -249,7 +248,6 @@ namespace qpmodel.expr
         {
             base.Bind(context);
             type_ = args_()[0].type_;
-            Debug.Assert(type_ is CharType || type_ is VarCharType);
         }
         public override Value Exec(ExecContext context, Row input)
         {
@@ -269,7 +267,6 @@ namespace qpmodel.expr
         {
             base.Bind(context);
             type_ = args_()[0].type_;
-            Debug.Assert(type_ is CharType || type_ is VarCharType);
         }
 
         public override Value Exec(ExecContext context, Row input)

--- a/qpmodel/ExprFunc.cs
+++ b/qpmodel/ExprFunc.cs
@@ -222,6 +222,7 @@ namespace qpmodel.expr
         {
             base.Bind(context);
             type_ = args_()[0].type_;
+            Debug.Assert(type_ is CharType || type_ is VarCharType || this.AnyArgNull());
         }
 
         public override Value Exec(ExecContext context, Row input)
@@ -248,6 +249,7 @@ namespace qpmodel.expr
         {
             base.Bind(context);
             type_ = args_()[0].type_;
+            Debug.Assert(type_ is CharType || type_ is VarCharType || this.AnyArgNull());
         }
         public override Value Exec(ExecContext context, Row input)
         {
@@ -267,6 +269,7 @@ namespace qpmodel.expr
         {
             base.Bind(context);
             type_ = args_()[0].type_;
+            Debug.Assert(type_ is CharType || type_ is VarCharType || this.AnyArgNull());
         }
 
         public override Value Exec(ExecContext context, Row input)

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2014,6 +2014,26 @@ namespace qpmodel.unittest
             sql = "select hash(1), hash('abc'), hash(26.33)";
             TU.ExecuteSQL(sql);
         }
+
+        [TestMethod]
+        public void TestFuncExprWithNull()
+        {
+            string scale = "0001";
+            Tpch.CreateTables();
+            Tpch.LoadTables(scale);
+            Tpch.AnalyzeTables();
+
+            string sql = null;
+
+            sql = "select substring(null, 1, 4) from lineitem where l_orderkey=1;";
+            TU.ExecuteSQL(sql, ";;;;;");
+
+            sql = "select repeat(null, 3) from lineitem where l_orderkey=1;";
+            TU.ExecuteSQL(sql, ";;;;;");
+
+            sql = "select upper(null) from lineitem where l_orderkey=1;";
+            TU.ExecuteSQL(sql, ";;;;;");
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
The function expression is converted to a constant expression by normalizer when the parameter is null.
Do not need to check whether the parameter is the string type or not.