### PR TITLE
[bug] REPEAT of SUBSTRING of CONCAT fails #214

### DIFF
--- a/qpmodel/SQLParser.cs
+++ b/qpmodel/SQLParser.cs
@@ -157,7 +157,7 @@ namespace qpmodel.sqlparser
         public override object VisitArithplusexpr([NotNull] SQLiteParser.ArithplusexprContext context)
             => new BinExpr((Expr)Visit(context.arith_expr(0)), (Expr)Visit(context.arith_expr(1)), context.op.Text);
         public override object VisitStrconexpr([NotNull] SQLiteParser.StrconexprContext context)
-            => new BinExpr((Expr)Visit(context.expr(0)), (Expr)Visit(context.expr(1)), "||");
+            => new BinExpr((Expr)Visit(context.arith_expr(0)), (Expr)Visit(context.arith_expr(1)), "||");
 
         public override object VisitBetweenExpr([NotNull] SQLiteParser.BetweenExprContext context)
         {

--- a/qpmodel/SQLite.g4
+++ b/qpmodel/SQLite.g4
@@ -193,33 +193,27 @@ pred_expr
  * predicate, for example: WHERE case when ... then true ... end
  */
 arith_expr
- : literal_value											#xxLiteralExpr
- | unary_operator arith_expr								#unaryexpr
- | BIND_PARAMETER											#bindexpr
- | ( ( database_name '.' )? table_name '.' )? column_name	#ColExpr
- | signed_number                                            #NumericLiteral
-
-
- | arith_expr op=( '*' | '/' | '%' ) arith_expr				#arithtimesexpr
- | arith_expr op=( PLUS | MINUS ) arith_expr				#arithplusexpr
- | arith_expr op=( '<<' | '>>' | '&' | '|' ) arith_expr		#arithbitexpr
-
- | '(' select_stmt ')'                                      #ScalarSubqueryExpr
- | function_name '(' ( K_DISTINCT? arith_expr ( ',' arith_expr )* | '*' )? ')'	#FuncExpr
-
- | K_CAST '(' arith_expr K_AS type_name ')'					#CastExpr
+ : literal_value											                                                          #xxLiteralExpr
+ | unary_operator arith_expr								                                                    #unaryexpr
+ | BIND_PARAMETER											                                                          #bindexpr
+ | ( ( database_name '.' )? table_name '.' )? column_name	                                      #ColExpr
+ | signed_number                                                                                #NumericLiteral
+ | arith_expr op=( '*' | '/' | '%' ) arith_expr				                                          #arithtimesexpr
+ | arith_expr op=( PLUS | MINUS ) arith_expr				                                            #arithplusexpr
+ | arith_expr op=( '<<' | '>>' | '&' | '|' ) arith_expr		                                      #arithbitexpr
+ | '(' select_stmt ')'                                                                          #ScalarSubqueryExpr
+ | function_name '(' ( K_DISTINCT? arith_expr ( ',' arith_expr )* | '*' )? ')'	                #FuncExpr
+ | K_CAST '(' arith_expr K_AS type_name ')'					                                            #CastExpr
  | K_CASE arith_expr? ( K_WHEN logical_expr K_THEN arith_expr )+ ( K_ELSE arith_expr )? K_END		#CaseExpr
- | '(' arith_expr ')'										#arithbrackexpr
-;
+ | arith_expr '||' arith_expr											                                              #strconexpr
+ | '(' arith_expr ')'										                                                        #arithbrackexpr
+ ;
 
 expr
  :
- logical_expr #logicalexpr
- | arith_expr #arithexpr
-
- | expr '||' expr											#strconexpr
- | '(' expr ')'												#otherbrackexpr
-
+ logical_expr               #logicalexpr
+ | arith_expr               #arithexpr
+ | '(' expr ')'							#otherbrackexpr
  ;
 
 foreign_key_clause

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2014,6 +2014,18 @@ namespace qpmodel.unittest
             sql = "select hash(1), hash('abc'), hash(26.33)";
             TU.ExecuteSQL(sql);
         }
+
+        [TestMethod]
+        public void TestNestStrConWithFuncExpr()
+        {
+            string sql = null;
+
+            sql = "select repeat((substring('Pacific South', 9, 13) || ' Pack' || 'ard'), 3) from a;";
+            TU.ExecuteSQL(sql, "South PackardSouth PackardSouth Packard;South PackardSouth PackardSouth Packard;South PackardSouth PackardSouth Packard");
+
+            sql = "select substring(upper('mat') || upper('he') || upper('mat') || upper('ics'), 3, 8) from a;";
+            TU.ExecuteSQL(sql, "THEMAT;THEMAT;THEMAT");
+        }
     }
 
     [TestClass]


### PR DESCRIPTION
move @strconexpr from @expr to @arith_expr. When @strconexpr is a parameter of @FuncExpr, @strconexpr can be recognized by the parser.