### PR TITLE
fix AggCountStar conflicting memo signature

### DIFF
--- a/qpmodel/LogicNode.cs
+++ b/qpmodel/LogicNode.cs
@@ -371,7 +371,7 @@ namespace qpmodel.logic
 
         public virtual LogicSignature MemoLogicSign()
         {
-            if (logicSign_ is -1)
+            if (logicSign_ == -1)
                 logicSign_ = GetHashCode();
             return logicSign_;
         }
@@ -766,8 +766,8 @@ namespace qpmodel.logic
         public override LogicSignature MemoLogicSign()
         {
             if (logicSign_ == -1)
-                logicSign_ = child_().MemoLogicSign() ^ isLocal_.GetHashCode() ^ 
-                    having_.FilterHashCode() ^ rawAggrs_.ListHashCode() ^ groupby_.ListHashCode();
+                logicSign_ = (child_().MemoLogicSign() << 32) + ((isLocal_.GetHashCode() ^ 
+                    having_.FilterHashCode() ^ rawAggrs_.ListHashCode() ^ groupby_.ListHashCode()) >> 32);
             return logicSign_;
         }
         public override string ExplainMoreDetails(int depth, ExplainOption option)

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -2350,10 +2350,8 @@ namespace qpmodel.unittest
 
             // COUNT(*)
             sql = "select * from (select count(*) from a, b where a1 <> b1 and a2 <> b2) s1, (select count(*) from a, b where a1 <> b3 and a2 <> b4) s2, (select count(*) from a, b where a1 < b1 and a2 < b2) s3, (select count(*) from a, b where a1 <> b1 and a2 <> b2) s4";
-            option.optimize_.use_memo_ = false;  // FIXME
             TU.ExecuteSQL(sql, "6,8,3,6", out phyplan, option);
             Assert.IsTrue(phyplan.Contains("Output: {count(*)(0)}[0],{count(*)(0)}[1],{count(*)(0)}[2],{count(*)(0)}[3]"));
-            option.optimize_.use_memo_ = true;
 
             // Assert fails in master, fixed code doesn't assert but there is no output
             sql = "select (select a1 from a order by -a1 limit 1), count(a1) from a group by (select a1 from a order by -a1 limit 1)";


### PR DESCRIPTION
due to similar join queries. What happens here is that:

 agg(s2):
  child_().MemoLogicSign() -1533365257 long
  rawAggrs_.ListHashCode() 66148586 int
  -1533365257^66148586 -1486099683 int

 agg(s3)
  child_().MemoLogicSign() -1530855187 long
  rawAggrs_.ListHashCode() 61533168 int
  -1530855187^61533168 -1486099683 int

However, this is only a local fix which does not solve the fundmental issues that memo signature may conflict. A complete solution shall introduce a SemanticEqual()  function for each logic plan to do a bottom line check.