### PR TITLE
REMOVE_FROM WORK: stage 4

### DIFF
--- a/qpmodel/Expr.cs
+++ b/qpmodel/Expr.cs
@@ -733,6 +733,13 @@ namespace qpmodel.expr
                         Debug.Assert(x.bounded_);
                         tableRefs_.AddRange(x.ResetAggregateTableRefs());
                     }
+                    else
+                    {
+                        // propagate tableref from count(*) to whatever it is part of
+                        // so that the expression containing count(*) will have correct
+                        // tableref and correct number of them.
+                        tableRefs_.AddRange(x.tableRefs_);
+                    }
                 });
                 if (tableRefs_.Count > 1)
                     tableRefs_ = tableRefs_.Distinct().ToList();

--- a/qpmodel/ExprFunc.cs
+++ b/qpmodel/ExprFunc.cs
@@ -512,10 +512,15 @@ namespace qpmodel.expr
             base.Bind(context);
             type_ = new IntType();
 
-            // Try adding all tableRefs to fix count(*) being orphaned and
-            // getting pushed to random side when join transformations happen.
-            //
-            tableRefs_ = context.AllTableRefs();
+            // Add the first table in the scope as tableref of count(*)
+            // because adding all of them would make the containg expression
+            // to appear to require more than one table when that is really
+            // not the case and may lead to attempts create a join or push
+            // count(*) to both sides of an existing join.
+            // This will let count(*) to be pushed to the correct node and side.
+            List<TableRef> trefs = context.AllTableRefs();
+            if (trefs.Count > 0)
+                tableRefs_.Add(trefs[0]);
         }
 
         public override Value Init(ExecContext context, Row input)

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -567,6 +567,29 @@ namespace qpmodel.logic
 
             return allsubs;
         }
+
+        // Try to push all or part of a filter with aggregates to a LogicAgg node
+        // which can provide the required inputs.
+        public bool TryPushingToLogicAgg(LogicAgg lag, Expr filter)
+        {
+            List<AggFunc> aggFns = filter.RetrieveAllType<AggFunc>();
+            int matchCount = 0;
+            for (int i = 0; i < aggFns.Count; ++i)
+            {
+                for (int j = 0; j < lag.rawAggrs_.Count; ++j)
+                {
+                    if (lag.rawAggrs_[j] == aggFns[i])
+                        ++matchCount;
+                }
+            }
+            if (matchCount >= aggFns.Count)
+            {
+                lag.having_.AddAndFilter(filter);
+                return true;
+            }
+            return false; // what now! We will say we can't do this.
+        }
+
         bool pushdownFilter(LogicNode plan, Expr filter, bool pushJoinFilter)
         {
             // don't push down special expressions
@@ -586,12 +609,37 @@ namespace qpmodel.logic
                 case 1:
                     return plan.VisitEachExists(n =>
                     {
+                        // when remove_from is true (or removed entirely) it is possible to have an
+                        // aggregate in the filter, which should not be pushed to table scan.
+                        // By defintion, if the node n is an aggregate node, and the filter has an
+                        // the aggregate which refers exactly to the same and sinlge tableref which is
+                        // the child of the aggregate in the filter, then the filter belongs to the
+                        // node n.
+                        if (filter.HasAggFunc() && n is LogicAgg lag)
+                            return TryPushingToLogicAgg(lag, filter);
                         if (n is LogicScanTable nodeGet &&
                             filter.EqualTableRef(nodeGet.tabref_))
                             return nodeGet.AddFilter(filter);
                         return false;
                     });
                 default:
+                    // even when there are more tables in the filter,
+                    // first try to find a LogicAgg which can provide
+                    // the required inputs and push the filter to that
+                    // node. This happens only when FromQuery is removed.
+                    bool pushed = false;
+                    if (filter.HasAggFunc())
+                    {
+                        pushed = plan.VisitEachExists(n =>
+                        {
+                            if (n is LogicAgg lag)
+                                return TryPushingToLogicAgg(lag, filter);
+                            else
+                                return false;
+                        });
+                    }
+                    if (pushed)
+                        return pushed;
                     if (pushJoinFilter)
                         return plan.PushJoinFilter(filter);
                     return false;


### PR DESCRIPTION
when remove_from is true (or removed entirely) it is possible to have an
aggregate in the filter, which should not be pushed to table scan.
Find the LogcAgg which has the same tableref as the aggregate and push
the filter to it.

Add the first table in the scope as tableref of count(*) instead of all
because adding all of them would make the containg expression to appear to
require more than one table when that is really not the case.
This will let count(*) to be pushed to the correct node and side.
Propagate this tableref to the expression containing count(*) so that
that expression can be pushed to the correct node.