### PR TITLE
fix to keep the original stack trace

### DIFF
--- a/qpmodel/Utils.cs
+++ b/qpmodel/Utils.cs
@@ -302,7 +302,7 @@ namespace qpmodel.utils
                     Console.WriteLine($"Error was: {e.Message}");
                     Console.WriteLine("+++ StackTrace +++");
                     Console.Error.WriteLine(e.StackTrace);
-                    throw e;
+                    throw;
                 };
             }
         }

--- a/qpmodel/stmt.cs
+++ b/qpmodel/stmt.cs
@@ -173,7 +173,7 @@ namespace qpmodel.logic
                 {
                     // throw on unexpected errors
                     Console.Error.WriteLine(e.StackTrace);
-                    throw e;
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
by using the throw statement without specifying the exception. Otherwise the stack trace is restarted at the current method and the list of method calls between the original method that threw the exception and the current method is lost.